### PR TITLE
changed patient-religion max value to *

### DIFF
--- a/structuredefinitions/UKCore-Patient.xml
+++ b/structuredefinitions/UKCore-Patient.xml
@@ -156,7 +156,6 @@
       <path value="Patient.extension" />
       <sliceName value="patientReligion" />
       <min value="0" />
-      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/patient-religion" />


### PR DESCRIPTION
To align the extension 'patient-religion' within 'patient profile' with the HL7 FHIR spec, the cardinality has changed from 0..1 to 0..* .