### PR TITLE
fix/Ballot-1.0.0_Issue-215

### DIFF
--- a/examples/UKCore-AllergyIntolerance-Amoxicillin-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Amoxicillin-Example.xml
@@ -17,8 +17,6 @@
       <display value="Confirmed" />
     </coding>
   </verificationStatus>
-  <type value="allergy" />
-  <category value="medication" />
   <code>
     <coding>
       <system value="http://snomed.info/sct" />

--- a/examples/UKCore-AllergyIntolerance-EnteredInError-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-EnteredInError-Example.xml
@@ -18,8 +18,6 @@
             <display value="Entered in Error" />
         </coding>
     </verificationStatus>
-    <type value="allergy" />
-    <category value="medication" />
     <code>
         <coding>
             <system value="http://snomed.info/sct" />

--- a/examples/UKCore-AllergyIntolerance-Extension-AllergyIntolEnd-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Extension-AllergyIntolEnd-Example.xml
@@ -28,8 +28,6 @@
 			<display value="Confirmed"/>
 		</coding>
 	</verificationStatus>
-	<type value="intolerance"/>
-	<category value="medication"/>
 	<code>
 		<coding>
 			<system value="http://snomed.info/sct"/>

--- a/examples/UKCore-AllergyIntolerance-Extension-Evidence-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Extension-Evidence-Example.xml
@@ -23,15 +23,13 @@
 			<display value="Confirmed"/>
 		</coding>
 	</verificationStatus>
-	<type value="allergy"/>
-	<category value="medication"/>
 	<code>
-    <coding>
-      <system value="http://snomed.info/sct"/>
-      <code value="372687004"/>
-      <display value="Amoxicillin"/>
-    </coding>
-  </code>
+		<coding>
+			<system value="http://snomed.info/sct"/>
+			<code value="372687004"/>
+			<display value="Amoxicillin"/>
+		</coding>
+	</code>
 	<patient>
 		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
 	</patient>

--- a/examples/UKCore-Bundle-AllergyList-Example.xml
+++ b/examples/UKCore-Bundle-AllergyList-Example.xml
@@ -52,8 +52,6 @@
 						<display value="Confirmed"/>
 					</coding>
 				</verificationStatus>
-				<type value="allergy"/>
-				<category value="medication"/>
 				<code>
 					<coding>
 						<system value="http://snomed.info/sct"/>


### PR DESCRIPTION
The guidance for the AllergyIntolerance "type" and "category" elements is for provider systems to omit and consumer systems to ignore. Omit these two elements which are present in all three examples.

@SheenaSharma  @KazeemHamzat 