### PR TITLE
Fix/ballot 1.0.0 issue 188

### DIFF
--- a/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatus.xml
+++ b/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatus.xml
@@ -4,8 +4,8 @@
 	<version value="2.1.0" />
 	<name value="UKCoreNHSNumberVerificationStatus"/>
 	<title value="UK Core NHS Number Verification Status"/>
-	<status value="active" />
-	<date value="2021-09-10" />
+	<status value="retired" />
+	<date value="2022-08-26" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />

--- a/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.xml
+++ b/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.xml
@@ -1,0 +1,76 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+	<id value="UKCore-NHSNumberVerificationStatus"/>
+	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+	<version value="1.1.0" />
+	<name value="UKCoreNHSNumberVerificationStatusEngland"/>
+	<title value="UK Core NHS Number Verification Status England"/>
+	<status value="active" />
+	<date value="2022-08-26" />
+	<publisher value="HL7 UK" />
+	<contact>
+		<name value="HL7 UK" />
+		<telecom>
+			<system value="email" />
+			<value value="secretariat@hl7.org.uk" />
+			<use value="work" />
+			<rank value="1" />
+		</telecom>
+	</contact>
+	<contact>
+		<name value="NHS Digital" />
+		<telecom>
+			<system value="email" />
+			<value value="interoperabilityteam@nhs.net" />
+			<use value="work" />
+			<rank value="2" />
+		</telecom>
+	</contact>
+	<description value="A CodeSystem that identifies the trace status of an NHS Number with respect to a national source of NHS Numbers."/>
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+	<caseSensitive value="true"/>
+	<content value="complete"/>
+	<filter>
+		<code value="ApplicableCountry"/>
+		<description value="Filter to identify an applicable country for a concept"/>
+		<operator value="="/>
+		<value value="ApplicableCountry"/>
+	</filter>
+	<property>
+		<code value="ApplicableCountry"/>
+		<description value="A set of codes that define the verification status of a patient's NHS number. These codes and their descriptions represent concepts used in England and are copied from the content of the NHS Data Dictionary web page at https://www.datadictionary.nhs.uk/data_elements/nhs_number_status_indicator_code.html"/>
+		<type value="string"/>
+	</property>
+	<concept>
+		<code value="01"/>
+		<display value="Number present and verified"/>
+	</concept>
+	<concept>
+		<code value="02"/>
+		<display value="Number present but not traced"/>
+	</concept>
+	<concept>
+		<code value="03"/>
+		<display value="Trace required"/>
+	</concept>
+	<concept>
+		<code value="04"/>
+		<display value="Trace attempted - No match or multiple match found"/>
+	</concept>
+	<concept>
+		<code value="05"/>
+		<display value="Trace needs to be resolved - (NHS number or patient detail conflict)"/>
+	</concept>
+	<concept>
+		<code value="06"/>
+		<display value="Trace in progress"/>
+	</concept>
+	<concept>
+		<code value="07"/>
+		<display value="Number not present and trace not required"/>
+	</concept>
+	<concept>
+		<code value="08"/>
+		<display value="Trace postponed (baby under six weeks old)"/>
+	</concept>
+	
+</CodeSystem>

--- a/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.xml
+++ b/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.xml
@@ -1,7 +1,7 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="UKCore-NHSNumberVerificationStatus"/>
+	<id value="UKCore-NHSNumberVerificationStatusEngland"/>
 	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
-	<version value="1.1.0" />
+	<version value="1.0.0" />
 	<name value="UKCoreNHSNumberVerificationStatusEngland"/>
 	<title value="UK Core NHS Number Verification Status England"/>
 	<status value="active" />

--- a/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusWales.xml
+++ b/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusWales.xml
@@ -1,0 +1,79 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+	<id value="UKCore-NHSNumberVerificationStatus"/>
+	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+	<version value="1.1.0" />
+	<name value="UKCoreNHSNumberVerificationStatusWales"/>
+	<title value="UK Core NHS Number Verification Status Wales"/>
+	<status value="active" />
+	<date value="2022-08-26" />
+	<publisher value="HL7 UK" />
+	<contact>
+		<name value="HL7 UK" />
+		<telecom>
+			<system value="email" />
+			<value value="secretariat@hl7.org.uk" />
+			<use value="work" />
+			<rank value="1" />
+		</telecom>
+	</contact>
+	<contact>
+		<name value="NHS Digital" />
+		<telecom>
+			<system value="email" />
+			<value value="interoperabilityteam@nhs.net" />
+			<use value="work" />
+			<rank value="2" />
+		</telecom>
+	</contact>
+	<description value="A CodeSystem that identifies the trace status of an NHS Number with respect to a national source of NHS Numbers."/>
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+	<caseSensitive value="true"/>
+	<content value="complete"/>
+	<filter>
+		<code value="ApplicableCountry"/>
+		<description value="Filter to identify an applicable country for a concept"/>
+		<operator value="="/>
+		<value value="ApplicableCountry"/>
+	</filter>
+	<property>
+		<code value="ApplicableCountry"/>
+		<description value="A set of codes that define the verification status of a patient's NHS number. These codes and their descriptions represent concepts used in Wales and are copied from the content of the NHS Wales Data Dictionary web page at http://www.datadictionary.wales.nhs.uk/index.html#!WordDocuments/nhsnumberstatusindicator.htm"/>
+		<type value="string"/>
+	</property>
+	<concept>
+		<code value="nn"/>
+		<display value="Number present and traced using Welsh NHS AR"/>
+	</concept>
+	<concept>
+		<code value="01"/>
+		<display value="Number present &amp; traced"/>
+	</concept>
+	<concept>
+		<code value="02"/>
+		<display value="Number present but not traced"/>
+	</concept>
+	<concept>
+		<code value="03"/>
+		<display value="Trace required"/>
+	</concept>
+	<concept>
+		<code value="04"/>
+		<display value="Trace attempted – no match or multiple match found"/>
+	</concept>
+	<concept>
+		<code value="05"/>
+		<display value="Trace needs to be resolved (NHS number or patient detail conflict)"/>
+	</concept>
+	<concept>
+		<code value="06"/>
+		<display value="Trace in progress"/>
+	</concept>
+	<concept>
+		<code value="07"/>
+		<display value="Number not present and trace not required"/>
+	</concept>
+	<concept>
+		<code value="08"/>
+		<display value="Trace postponed (baby under six weeks old)"/>
+	</concept>
+</CodeSystem>

--- a/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusWales.xml
+++ b/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusWales.xml
@@ -1,7 +1,7 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-	<id value="UKCore-NHSNumberVerificationStatus"/>
+	<id value="UKCore-NHSNumberVerificationStatusWales"/>
 	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
-	<version value="1.1.0" />
+	<version value="1.0.0" />
 	<name value="UKCoreNHSNumberVerificationStatusWales"/>
 	<title value="UK Core NHS Number Verification Status Wales"/>
 	<status value="active" />

--- a/valuesets/ValueSet-UKCore-NHSNumberVerificationStatus.xml
+++ b/valuesets/ValueSet-UKCore-NHSNumberVerificationStatus.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-NHSNumberVerificationStatus"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-NHSNumberVerificationStatus"/>
-	<version value="2.1.0" />
+	<version value="2.2.0" />
 	<name value="UKCoreNHSNumberVerificationStatus"/>
 	<title value="UK Core NHS Number Verification Status"/>
 	<status value="active" />
-	<date value="2021-09-10" />
+	<date value="2022-08-26" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />
@@ -25,12 +25,15 @@
 			<rank value="2" />
 		</telecom>
 	</contact>
-	<description value=" &#13; A set of codes that indicate the trace status of an NHS Number with respect to a national source of NHS Numbers. &#13;&#13;
- &#13; Where there is no information about the trace status available, a specific code from the nullFlavor Code System can be used instead to indicate this. &#13;&#13;"/>
+	<description value="A set of codes that indicate the trace status of an NHS Number with respect to a national source of NHS Numbers. &#13;&#13;
+ &#13; Where there is no information about the trace status available, a specific code from the nullFlavor Code System can be used instead to indicate this."/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+		</include>
+		<include>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
 		</include>
 		<include>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
@@ -41,85 +44,125 @@
 		</include>
 	</compose>
 	<expansion>
-		<identifier value="daa45a58-75cf-42a6-ac98-8cbee912c065"/>
-		<timestamp value="2021-09-09T15:39:30+00:00"/>
-		<total value="10"/>
-		<offset value="0"/>
-		<parameter>
-			<name value="version"/>
-			<valueUri value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus|2.1.0"/>
-		</parameter>
-		<parameter>
-			<name value="version"/>
-			<valueUri value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor|2018-08-12"/>
-		</parameter>
-		<parameter>
-			<name value="count"/>
-			<valueInteger value="2147483647"/>
-		</parameter>
-		<parameter>
-			<name value="offset"/>
-			<valueInteger value="0"/>
-		</parameter>
-		<contains>
-			<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
-			<version value="2018-08-12"/>
-			<code value="NI"/>
-			<display value="NoInformation"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="number-not-present-and-trace-not-required"/>
-			<display value="Number not present and trace not required"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="number-present-and-traced-using-welsh-nhs-ar"/>
-			<display value="Number present and traced using Welsh NHS AR"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="number-present-and-verified"/>
-			<display value="Number present and verified"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="number-present-but-not-traced"/>
-			<display value="Number present but not traced"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="trace-attempted"/>
-			<display value="Trace attempted - No match or multiple match found"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="trace-in-progress"/>
-			<display value="Trace in progress"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="trace-needs-to-be-resolved"/>
-			<display value="Trace needs to be resolved - (NHS number or patient detail conflict)"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="trace-postponed"/>
-			<display value="Trace postponed (baby under six weeks old)"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus"/>
-			<version value="2.1.0"/>
-			<code value="trace-required"/>
-			<display value="Trace required"/>
-		</contains>
-	</expansion>
+        <identifier value="0b1f8226-afc8-49e6-a7f7-e945cdb24521"/>
+        <timestamp value="2022-10-19T14:08:35+00:00"/>
+        <total value="18"/>
+        <offset value="0"/>
+        <parameter>
+            <name value="offset"/>
+            <valueInteger value="0"/>
+        </parameter>
+        <parameter>
+            <name value="count"/>
+            <valueInteger value="1000"/>
+        </parameter>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="01"/>
+            <display value="Number present and verified"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="02"/>
+            <display value="Number present but not traced"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="03"/>
+            <display value="Trace required"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="04"/>
+            <display value="Trace attempted - No match or multiple match found"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="05"/>
+            <display value="Trace needs to be resolved - (NHS number or patient detail conflict)"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="06"/>
+            <display value="Trace in progress"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="07"/>
+            <display value="Number not present and trace not required"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+            <version value="1.1.0"/>
+            <code value="08"/>
+            <display value="Trace postponed (baby under six weeks old)"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="nn"/>
+            <display value="Number present and traced using Welsh NHS AR"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="01"/>
+            <display value="Number present &amp; traced"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="02"/>
+            <display value="Number present but not traced"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="03"/>
+            <display value="Trace required"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="04"/>
+            <display value="Trace attempted – no match or multiple match found"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="05"/>
+            <display value="Trace needs to be resolved (NHS number or patient detail conflict)"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="06"/>
+            <display value="Trace in progress"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="07"/>
+            <display value="Number not present and trace not required"/>
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales"/>
+            <version value="1.1.0"/>
+            <code value="08"/>
+            <display value="Trace postponed (baby under six weeks old)"/>
+        </contains>
+        <contains>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
+            <version value="2018-08-12"/>
+            <code value="NI"/>
+            <display value="NoInformation"/>
+        </contains>
+    </expansion>
 </ValueSet>


### PR DESCRIPTION
Split the codesystem into separate England and Wales files and changed the valueset to reflect this. Old codesystem with them both combined needs removing. 

Can we just delete it off git or do we need to keep it and set it to retired in Simplifier?