### PR TITLE
Fix/ballot 1.0.0 issue 64

### DIFF
--- a/examples/UKCore-MedicationRequest-Extension-RepeatInformation-Example.xml
+++ b/examples/UKCore-MedicationRequest-Extension-RepeatInformation-Example.xml
@@ -9,6 +9,9 @@
 		<extension url="numberOfPrescriptionsIssued">
 			<valueUnsignedInt value="1"/>
 		</extension>
+		<extension url="authorisationExpiryDate">
+			<valueDateTime value="2022-09-10T19:00:00.000Z"/>
+		</extension>
 	</extension>
 	<!-- **************extension end************** -->
 	<status value="completed"/>
@@ -64,13 +67,6 @@
 			</coding>
 		</method>
 	</dosageInstruction>
-	<dispenseRequest>
-		<validityPeriod>
-			<start value="2022-09-10"/>
-			<end value="2023-03-10"/>
-		</validityPeriod>
-		<numberOfRepeatsAllowed value="4"/> 
-	</dispenseRequest>
 	<substitution>
 		<allowedBoolean value="true"/>
 	</substitution>

--- a/examples/UKCore-MedicationRequest-Extension-RepeatInformation-Example.xml
+++ b/examples/UKCore-MedicationRequest-Extension-RepeatInformation-Example.xml
@@ -9,9 +9,6 @@
 		<extension url="numberOfPrescriptionsIssued">
 			<valueUnsignedInt value="1"/>
 		</extension>
-		<extension url="authorisationExpiryDate">
-			<valueDateTime value="2022-09-10T19:00:00.000Z"/>
-		</extension>
 	</extension>
 	<!-- **************extension end************** -->
 	<status value="completed"/>
@@ -67,6 +64,13 @@
 			</coding>
 		</method>
 	</dosageInstruction>
+	<dispenseRequest>
+		<validityPeriod>
+			<start value="2022-09-10"/>
+			<end value="2023-03-10"/>
+		</validityPeriod>
+		<numberOfRepeatsAllowed value="4"/> 
+	</dispenseRequest>
 	<substitution>
 		<allowedBoolean value="true"/>
 	</substitution>

--- a/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
+++ b/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-MedicationRepeatInformation" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation" />
@@ -26,9 +25,9 @@
       <rank value="2" />
     </telecom>
   </contact>
-  <description value="The specific number of times a repeat prescription has been issued." />
-  <purpose value="This extension extends the MedicationRequest resource to support the exchange of the number of times a repeat medication has been issued, which are currently not supported by the FHIR standard." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <description value="The specific repeat information of a medication item." />
+  <purpose value="This extension extends the MedicationRequest resource to support the exchange of repeat medication data items, which are currently not supported by the FHIR standard." />
+  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -47,7 +46,7 @@
   <differential>
     <element id="Extension">
       <path value="Extension" />
-      <short value="Medication repeat issued information" />
+      <short value="Medication repeat information" />
       <definition value="Medication repeat information." />
       <max value="1" />
     </element>
@@ -60,14 +59,12 @@
         </discriminator>
         <rules value="open" />
       </slicing>
-      <min value="0" />
     </element>
     <element id="Extension.extension:numberOfPrescriptionsIssued">
       <path value="Extension.extension" />
       <sliceName value="numberOfPrescriptionsIssued" />
-      <short value="Number of prescriptions issued" />
+      <short value="The specific number of times a repeat prescription has been issued" />
       <definition value="An integer recording the number of times a repeat prescription has been issued. This integer does not include the original order dispense." />
-      <min value="0" />
       <max value="1" />
     </element>
     <element id="Extension.extension:numberOfPrescriptionsIssued.url">
@@ -76,26 +73,18 @@
     </element>
     <element id="Extension.extension:numberOfPrescriptionsIssued.value[x]">
       <path value="Extension.extension.value[x]" />
-      <short value="Number of prescriptions issued" />
-      <definition value="Number of prescriptions issued." />
+      <short value="The specific number of times a repeat prescription has been issued" />
+      <definition value="An integer recording the number of times a repeat prescription has been issued. This integer does not include the original order dispense." />
       <min value="1" />
       <type>
         <code value="unsignedInt" />
       </type>
     </element>
-    <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation" />
-    </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]" />
-      <max value="0" />
-    </element>
     <element id="Extension.extension:authorisationExpiryDate">
       <path value="Extension.extension" />
       <sliceName value="authorisationExpiryDate" />
       <short value="Repeat prescription review date" />
-      <definition value="Repeat prescription review date." />
+      <definition value="The date a prescriber must review a repeat prescription with the patient. This is distinct from dispenseRequest.validityPeriod.end, which marks when a dispensing cycle ends e.g. in Electronic Repeat Dispensing" />
       <max value="1" />
     </element>
     <element id="Extension.extension:authorisationExpiryDate.url">

--- a/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
+++ b/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
@@ -26,7 +26,7 @@
       <rank value="2" />
     </telecom>
   </contact>
-  <description value="The specific repeat information of a medication item." />
+  <description value="The specific number of times a repeat prescription has been issued." />
   <purpose value="This extension extends the MedicationRequest resource to support the exchange of the number of times a repeat medication has been issued, which are currently not supported by the FHIR standard." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
@@ -47,7 +47,7 @@
   <differential>
     <element id="Extension">
       <path value="Extension" />
-      <short value="Medication repeat information" />
+      <short value="Medication repeat issued information" />
       <definition value="Medication repeat information." />
       <max value="1" />
     </element>
@@ -66,7 +66,7 @@
       <path value="Extension.extension" />
       <sliceName value="numberOfPrescriptionsIssued" />
       <short value="Number of prescriptions issued" />
-      <definition value="Number of prescriptions issued." />
+      <definition value="An integer recording the number of times a repeat prescription has been issued. This integer does not include the original order dispense." />
       <min value="0" />
       <max value="1" />
     </element>

--- a/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
+++ b/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
@@ -91,5 +91,33 @@
       <path value="Extension.value[x]" />
       <max value="0" />
     </element>
+    <element id="Extension.extension:authorisationExpiryDate">
+      <path value="Extension.extension" />
+      <sliceName value="authorisationExpiryDate" />
+      <short value="Repeat prescription review date" />
+      <definition value="Repeat prescription review date." />
+      <max value="1" />
+    </element>
+    <element id="Extension.extension:authorisationExpiryDate.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="authorisationExpiryDate" />
+    </element>
+    <element id="Extension.extension:authorisationExpiryDate.value[x]">
+      <path value="Extension.extension.value[x]" />
+      <short value="Repeat prescription review date" />
+      <definition value="Repeat prescription review date." />
+      <min value="1" />
+      <type>
+        <code value="dateTime" />
+      </type>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <max value="0" />
+    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
Problem: MedicationRequest contains the numberOfRepeatsAllowed field and the validityPeriod field. Reccomended that these fields are used instead of the extension, or clarification is required on what information this extension captures that is not applicable to those two fields.

I've decided the best approach is to remove the authorisationExpiryDate from the extension as this is a duplicate of the validityPeriod within the profile. numberOfPrescriptionsIssued is different to the numberOfRepeatsAllowed so is staying. One example updated to reflect new change. IG to be updated to explain this better.

Do we need to change the extension name to be mre descriptive, e.g MedicationRepeatInformation to MedicationNumberRepeatsIssued ?