### PR TITLE
remove/retire UKCore PractitionerRoleCode

### DIFF
--- a/structuredefinitions/UKCore-PractitionerRole.xml
+++ b/structuredefinitions/UKCore-PractitionerRole.xml
@@ -104,13 +104,6 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
-    <element id="PractitionerRole.code">
-      <path value="PractitionerRole.code" />
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PractitionerRoleCode" />
-      </binding>
-    </element>
 	<element id="PractitionerRole.specialty">
       <path value="PractitionerRole.specialty" />
       <binding>

--- a/valuesets/ValueSet-UKCore-PractitionerRoleCode.xml
+++ b/valuesets/ValueSet-UKCore-PractitionerRoleCode.xml
@@ -5,8 +5,8 @@
 	<version value="1.0.0" />
 	<name value="UKCorePractitionerRoleCode"/>
 	<title value="UK Core Practitioner Role Code"/>
-	<status value="active" />
-	<date value="2021-09-10" />
+	<status value="retired" />
+	<date value="2022-08-26" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />


### PR DESCRIPTION
removed PractitionerRole.code and retired the UKCore PractitionerRoleCode valueset, as it was the same as the base fhir spec valueset