### PR TITLE
Point eventHistory to UKCore Provenance

### DIFF
--- a/structuredefinitions/UKCore-MedicationRequest.xml
+++ b/structuredefinitions/UKCore-MedicationRequest.xml
@@ -350,6 +350,13 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
+    <element id="MedicationRequest.eventHistory">
+      <path value="MedicationRequest.eventHistory" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Provenance" />
+      </type>
+    </element>
     <element id="MedicationRequest.eventHistory.identifier.assigner">
       <path value="MedicationRequest.eventHistory.identifier.assigner" />
       <type>


### PR DESCRIPTION
As per discussion during call on 8/11, IG guidance listed eventHistory as UKCore Provenance, but structure definition didn't