### PR TITLE
changed UK extension to coding, fixed example

### DIFF
--- a/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
+++ b/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
@@ -3,12 +3,10 @@
 	<code>
 		<coding>
 			<extension url="http://hl7.org/fhir/StructureDefinition/coding-sctdescid">
-				<valueid>
-					<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay">
-						<valueString value="Bronchial asthma"/>
-					</extension>
-					<value value="301480018"/>
-				</valueid> 
+				<valueId value="301480018"/>
+			</extension>
+			<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay">
+				<valueString value="Bronchial asthma"/>
 			</extension>
 			<system value="http://snomed.info/sct"/>
 			<code value="195967001"/>

--- a/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
+++ b/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
@@ -5,6 +5,9 @@
 			<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay">
 				<valueString value="Bronchial asthma"/>
 			</extension>
+			<extension url="http://hl7.org/fhir/StructureDefinition/coding-sctdescid">
+				<valueId value="301480018"/>
+			</extension>
 			<system value="http://snomed.info/sct"/>
 			<code value="195967001"/>
 			<display value="Asthma"/>

--- a/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
+++ b/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
@@ -2,9 +2,6 @@
 	<id value="UKCore-Condition-Extension-CodingSCTDescId-Example"/>
 	<code>
 		<coding>
-			<extension url="http://hl7.org/fhir/StructureDefinition/coding-sctdescid">
-				<valueId value="301480018"/>
-			</extension>
 			<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay">
 				<valueString value="Bronchial asthma"/>
 			</extension>

--- a/structuredefinitions/Extension-UKCore-CodingSCTDescDisplay.xml
+++ b/structuredefinitions/Extension-UKCore-CodingSCTDescDisplay.xml
@@ -39,7 +39,7 @@
 	<abstract value="false"/>
 	<context>
 		<type value="element"/>
-		<expression value="coding"/>
+		<expression value="Coding"/>
 	</context>
 	<type value="Extension"/>
 	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>

--- a/structuredefinitions/Extension-UKCore-CodingSCTDescDisplay.xml
+++ b/structuredefinitions/Extension-UKCore-CodingSCTDescDisplay.xml
@@ -39,7 +39,7 @@
 	<abstract value="false"/>
 	<context>
 		<type value="element"/>
-		<expression value="coding-sctdescid.value"/>
+		<expression value="coding"/>
 	</context>
 	<type value="Extension"/>
 	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>


### PR DESCRIPTION
Changed UKCore extension to be a child of coding as you cannot extend another extension that has value[x]. Fixed example to suit.