### PR TITLE
Fix uk core medication code binding strength

### DIFF
--- a/structuredefinitions/UKCore-Immunization.xml
+++ b/structuredefinitions/UKCore-Immunization.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Immunization" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization" />
-  <version value="2.3.0" />
+  <version value="2.2.0" />
   <name value="UKCoreImmunization" />
   <title value="UK Core Immunization" />
   <status value="active" />
-  <date value="2022-12-16" />
+  <date value="2022-08-26" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Immunization.xml
+++ b/structuredefinitions/UKCore-Immunization.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Immunization" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization" />
-  <version value="2.2.0" />
+  <version value="2.3.0" />
   <name value="UKCoreImmunization" />
   <title value="UK Core Immunization" />
   <status value="active" />
-  <date value="2022-08-26" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Medication.xml
+++ b/structuredefinitions/UKCore-Medication.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Medication" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication" />
-  <version value="2.1.0" />
+  <version value="2.2.0" />
   <name value="UKCoreMedication" />
   <title value="UK Core Medication" />
   <status value="active" />
-  <date value="2021-09-10" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -87,7 +87,7 @@
       <path value="Medication.code" />
       <min value="1" />
       <binding>
-        <strength value="extensible" />
+        <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationCode" />
       </binding>
     </element>

--- a/structuredefinitions/UKCore-MedicationAdministration.xml
+++ b/structuredefinitions/UKCore-MedicationAdministration.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-MedicationAdministration" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationAdministration" />
-  <version value="2.1.0" />
+  <version value="2.2.0" />
   <name value="UKCoreMedicationAdministration" />
   <title value="UK Core MedicationAdministration" />
   <status value="active" />
-  <date value="2021-09-10" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -93,7 +93,7 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication" />
       </type>
       <binding>
-        <strength value="extensible" />
+        <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationCode" />
       </binding>
     </element>

--- a/structuredefinitions/UKCore-MedicationDispense.xml
+++ b/structuredefinitions/UKCore-MedicationDispense.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-MedicationDispense" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationDispense" />
-  <version value="2.1.0" />
+  <version value="2.2.0" />
   <name value="UKCoreMedicationDispense" />
   <title value="UK Core MedicationDispense" />
   <status value="active" />
-  <date value="2021-09-10" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -92,7 +92,7 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication" />
       </type>
       <binding>
-        <strength value="extensible" />
+        <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationCode" />
       </binding>
     </element>

--- a/structuredefinitions/UKCore-MedicationRequest.xml
+++ b/structuredefinitions/UKCore-MedicationRequest.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-MedicationRequest" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest" />
-  <version value="2.2.0" />
+  <version value="2.3.0" />
   <name value="UKCoreMedicationRequest" />
   <title value="UK Core MedicationRequest" />
   <status value="active" />
-  <date value="2022-08-26" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -117,7 +117,7 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication" />
       </type>
       <binding>
-        <strength value="extensible" />
+        <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationCode" />
       </binding>
     </element>

--- a/structuredefinitions/UKCore-MedicationStatement.xml
+++ b/structuredefinitions/UKCore-MedicationStatement.xml
@@ -157,7 +157,7 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication" />
       </type>
       <binding>
-        <strength value="extensible" />
+        <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationCode" />
       </binding>
     </element>

--- a/structuredefinitions/UKCore-MedicationStatement.xml
+++ b/structuredefinitions/UKCore-MedicationStatement.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-MedicationStatement" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement" />
-  <version value="2.2.0" />
+  <version value="2.3.0" />
   <name value="UKCoreMedicationStatement" />
   <title value="UK Core MedicationStatement" />
   <status value="active" />
-  <date value="2022-08-26" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />


### PR DESCRIPTION
Change UKCore-MedicationCode binding strength from extensible to preferred on all 5 profiles that its bound to (with date and version uplift), as per DA discussion