### PR TITLE
removed meta profile tags from examples

### DIFF
--- a/examples/UKCore-AllergyIntolerance-Amoxicillin-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Amoxicillin-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
   <id value="UKCore-AllergyIntolerance-Amoxicillin-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance" />
-  </meta>
   <clinicalStatus>
     <coding>
       <system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical" />

--- a/examples/UKCore-AllergyIntolerance-EnteredInError-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-EnteredInError-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
     <id value="UKCore-AllergyIntolerance-EnteredInError-Example" />
-    <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance" />
-    </meta>
     <verificationStatus>
         <coding>
             <system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-verification" />

--- a/examples/UKCore-AllergyIntolerance-Extension-AllergyIntolEnd-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Extension-AllergyIntolEnd-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Extension-AllergyIntolEnd-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<clinicalStatus>
 		<!-- **************extension start************** -->
 		<!--This supports the date when the allergy or intolerance was no longer valid, and/or, the reason why the allergy or intolerance is no longer valid..-->

--- a/examples/UKCore-AllergyIntolerance-Extension-Evidence-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Extension-Evidence-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Extension-Evidence-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Evidence">
 		<valueReference>
 			<reference value="DiagnosticReport/UKCore-DiagnosticReport-DiagnosticStudiesReport-Example"/>

--- a/examples/UKCore-AllergyIntolerance-Sn-DrugAllergy-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-DrugAllergy-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Sn-DrugAllergy-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<clinicalStatus>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"/>

--- a/examples/UKCore-AllergyIntolerance-Sn-DrugAllergyToEggProtein-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-DrugAllergyToEggProtein-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Sn-DrugAllergyToEggProtein-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<clinicalStatus>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"/>

--- a/examples/UKCore-AllergyIntolerance-Sn-NegHandlNoKnownAllergies-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-NegHandlNoKnownAllergies-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Sn-NegHandlNoKnownAllergies-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<clinicalStatus>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"/>

--- a/examples/UKCore-AllergyIntolerance-Sn-NonDrugAllergy-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-NonDrugAllergy-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Sn-NonDrugAllergy-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<clinicalStatus>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"/>

--- a/examples/UKCore-AllergyIntolerance-Sn-TransferDegradDrugAllergy-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-TransferDegradDrugAllergy-Example.xml
@@ -1,8 +1,5 @@
 <AllergyIntolerance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AllergyIntolerance-Sn-TransferDegradDrugAllergy-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance"/>
-	</meta>
 	<clinicalStatus>
 		<coding>
 			<system value="http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical"/>

--- a/examples/UKCore-Appointment-OrthopaedicSurgery-Example.xml
+++ b/examples/UKCore-Appointment-OrthopaedicSurgery-Example.xml
@@ -1,8 +1,5 @@
 <Appointment xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Appointment-OrthopaedicSurgery-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Appointment"/>
-	</meta>
 	<!--This supports the recording of the organisation booking the appointment.-->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BookingOrganization">
 		<valueReference>

--- a/examples/UKCore-AuditEvent-Query-Example.xml
+++ b/examples/UKCore-AuditEvent-Query-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AuditEvent xmlns="http://hl7.org/fhir">
 	<id value="UKCore-AuditEvent-Query-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AuditEvent"/>
-	</meta>
 	<type>
 		<system value="http://dicom.nema.org/resources/ontology/DCM"/>
 		<code value="110112"/>

--- a/examples/UKCore-Bundle-Sn-NoAllergyData-Example.xml
+++ b/examples/UKCore-Bundle-Sn-NoAllergyData-Example.xml
@@ -1,8 +1,5 @@
 <Bundle xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Bundle-Sn-NoAllergyData-Example"/>
-	<meta>
-		<lastUpdated value="2021-07-21T12:00:00+00:00"/>
-	</meta>
 	<type value="searchset"/>
 	<total value="0"/>
 	<link>

--- a/examples/UKCore-CarePlan-WellnessPlan-Example.xml
+++ b/examples/UKCore-CarePlan-WellnessPlan-Example.xml
@@ -1,8 +1,5 @@
 <CarePlan xmlns="http://hl7.org/fhir">
  <id value="UKCore-CarePlan-WellnessPlan-Example"/>
- <meta>
-  <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CarePlan"/>
- </meta>
  <identifier>
   <value value="7d9955bc-afe0-11ea-b3de-0242ac130004"/>
  </identifier>

--- a/examples/UKCore-CareTeam-WeightManagementTeamExample.xml
+++ b/examples/UKCore-CareTeam-WeightManagementTeamExample.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CareTeam xmlns="http://hl7.org/fhir">
 	<id value="UKCore-CareTeam-WeightManagementTeam-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CareTeam"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="0e7cc7b2-94b7-42c2-875b-56c921e4bcc2"/>

--- a/examples/UKCore-Communication-FirstMMRVaccination-Example.xml
+++ b/examples/UKCore-Communication-FirstMMRVaccination-Example.xml
@@ -1,8 +1,5 @@
 <Communication xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Communication-FirstMMRVaccination-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Communication"/>
-	</meta>
 	<text>
 		<status value="generated"/>
 		<div xmlns="http://www.w3.org/1999/xhtml">First MMR vacinnation administered to Melanie.</div>

--- a/examples/UKCore-Composition-Discharge-Example.xml
+++ b/examples/UKCore-Composition-Discharge-Example.xml
@@ -1,8 +1,5 @@
 <Composition>
     <id value="UKCore-Composition-Discharge-Example"/>
-    <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Composition"/>
-    </meta>
     <!-- Extension to carry details of the Correspondence Care Setting Type. -->
     <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CareSettingType">
         <valueCodeableConcept>

--- a/examples/UKCore-Condition-BleedingFromEar-Example.xml
+++ b/examples/UKCore-Condition-BleedingFromEar-Example.xml
@@ -1,8 +1,5 @@
 <Condition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Condition-BleedingFromEar-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition" />
-  </meta>
   <clinicalStatus>
     <coding>
       <system value="http://terminology.hl7.org/CodeSystem/condition-clinical" />

--- a/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
+++ b/examples/UKCore-Condition-Extension-CodingSCTDescId-Example.xml
@@ -1,8 +1,5 @@
 <Condition xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Condition-Extension-CodingSCTDescId-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition"/>
-	</meta>
 	<code>
 		<coding>
 			<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay">

--- a/examples/UKCore-Condition-Sn-Extension-CodingSCT-Heart-Example.xml
+++ b/examples/UKCore-Condition-Sn-Extension-CodingSCT-Heart-Example.xml
@@ -1,8 +1,5 @@
 <Condition xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Condition-Sn-Extension-CodingSCT-Heart-Example"/>
-	 <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition" />
-  </meta>
 	<!-- **************Snippet start************** -->
 	<code>
 		<coding>

--- a/examples/UKCore-Condition-Sn-Extension-CodingSCT-MoleOfSkin-Example.xml
+++ b/examples/UKCore-Condition-Sn-Extension-CodingSCT-MoleOfSkin-Example.xml
@@ -1,8 +1,5 @@
 <Condition xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Condition-Sn-Extension-CodingSCT-MoleOfSkin-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition"/>
-	</meta>
 	<!-- **************Snippet start************** -->
 	<code>
 		<coding>

--- a/examples/UKCore-Condition-Sn-Extension-CodingSCT-Myocardial-Example.xml
+++ b/examples/UKCore-Condition-Sn-Extension-CodingSCT-Myocardial-Example.xml
@@ -1,8 +1,5 @@
 <Condition xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Condition-Sn-Extension-CodingSCT-Myocardial-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition"/>
-	</meta>
 	<!-- **************Snippet start************** -->
 	<code>
 		<coding>

--- a/examples/UKCore-Consent-ForInformationAccess-Example.xml
+++ b/examples/UKCore-Consent-ForInformationAccess-Example.xml
@@ -1,8 +1,5 @@
 <Consent xmlns="http://hl7.org/fhir">
   <id value="UKCore-Consent-ForInformationAccess-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Consent" />
-  </meta>
   <status value="active" />
   <scope>
     <coding>

--- a/examples/UKCore-Device-ColostomyBag-Example.xml
+++ b/examples/UKCore-Device-ColostomyBag-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Device xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Device-ColostomyBag-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device"/>
-	</meta>
 	<identifier>
 		<system value="https://www.leedsth.nhs.uk/identifier/devices"/>
 		<value value="DEV1999990567"/>

--- a/examples/UKCore-DiagnosticReport-DiagnosticStudiesReport-Example.xml
+++ b/examples/UKCore-DiagnosticReport-DiagnosticStudiesReport-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DiagnosticReport xmlns="http://hl7.org/fhir">
 	<id value="UKCore-DiagnosticReport-DiagnosticStudiesReport-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="727071dc-eb01-4224-8ee8-cc0a029787ac"/>

--- a/examples/UKCore-DocumentReference-CarePlanReportPDF-Example.xml
+++ b/examples/UKCore-DocumentReference-CarePlanReportPDF-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DocumentReference xmlns="http://hl7.org/fhir">
-<id value="UKCore-DocumentReference-CarePlanReportPDF-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference"/>
-	</meta>
+	<id value="UKCore-DocumentReference-CarePlanReportPDF-Example"/>
 	<status value="current"/>
 	<type>
 		<coding>

--- a/examples/UKCore-Encounter-Extension-AdmissionMethod-Example.xml
+++ b/examples/UKCore-Encounter-Extension-AdmissionMethod-Example.xml
@@ -1,8 +1,5 @@
 <Encounter xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Encounter-Extension-AdmissionMethod-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter"/>
-	</meta>
 	<!-- **************extension start************** -->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdmissionMethod">
 		<valueCodeableConcept>

--- a/examples/UKCore-Encounter-Extension-DischargeMethod-Example.xml
+++ b/examples/UKCore-Encounter-Extension-DischargeMethod-Example.xml
@@ -1,8 +1,5 @@
 <Encounter xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Encounter-Extension-DischargeMethod-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter"/>
-	</meta>
 	<!-- **************extension start************** -->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DischargeMethod">
 		<valueCodeableConcept>

--- a/examples/UKCore-Encounter-Extension-EmergencyCareDischargeStatus-Example.xml
+++ b/examples/UKCore-Encounter-Extension-EmergencyCareDischargeStatus-Example.xml
@@ -1,8 +1,5 @@
 <Encounter xmlns="http://hl7.org/fhir">
     <id value="UKCore-Encounter-Extension-EmergencyCareDischargeStatus-Example" />
-    <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter" />
-    </meta>
     <!--  **************extension start**************  -->
     <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EmergencyCareDischargeStatus">
         <valueCodeableConcept>

--- a/examples/UKCore-Encounter-Extension-LegalStatus-Example.xml
+++ b/examples/UKCore-Encounter-Extension-LegalStatus-Example.xml
@@ -1,8 +1,5 @@
 <Encounter xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Encounter-Extension-LegalStatus-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter"/>
-	</meta>
 	<!-- **************extension start************** -->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-LegalStatus">
 		<extension url="legalStatusContext">

--- a/examples/UKCore-Encounter-Extension-OutcomeofAttendance-Example.xml
+++ b/examples/UKCore-Encounter-Extension-OutcomeofAttendance-Example.xml
@@ -1,8 +1,5 @@
 <Encounter xmlns="http://hl7.org/fhir">
     <id value="UKCore-Encounter-Extension-OutcomeofAttendance-Example" />
-    <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter" />
-    </meta>
     <!--  **************extension start**************  -->
     <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OutcomeofAttendance">
         <valueCodeableConcept>

--- a/examples/UKCore-Encounter-InpatientEncounter-Example.xml
+++ b/examples/UKCore-Encounter-InpatientEncounter-Example.xml
@@ -1,8 +1,5 @@
 <Encounter xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Encounter-InpatientEncounter-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter"/>
-	</meta>
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdmissionMethod">
 		<valueCodeableConcept>
 			<coding>

--- a/examples/UKCore-EpisodeOfCare-SmokingCessationTherapy-Example.xml
+++ b/examples/UKCore-EpisodeOfCare-SmokingCessationTherapy-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <EpisodeOfCare xmlns="http://hl7.org/fhir">
-<id value="UKCore-EpisodeOfCare-SmokingCessationTherapy-Example"/>
-<meta>
-	<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-EpisodeOfCare"/>
-</meta>
+	<id value="UKCore-EpisodeOfCare-SmokingCessationTherapy-Example"/>
 	<status value="finished"/>
 	<type>
 		<coding>

--- a/examples/UKCore-Flag-FoodAllergy-Example.xml
+++ b/examples/UKCore-Flag-FoodAllergy-Example.xml
@@ -1,8 +1,5 @@
 <Flag xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Flag-FoodAllergy-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Flag"/>
-	</meta>
 	<text>
 		<status value="generated"/>
 		<div xmlns="http://www.w3.org/1999/xhtml">Food Allergy Warning</div>

--- a/examples/UKCore-HealthcareService-OrthopaedicService-Example.xml
+++ b/examples/UKCore-HealthcareService-OrthopaedicService-Example.xml
@@ -1,8 +1,5 @@
 <HealthcareService xmlns="http://hl7.org/fhir">
 	<id value="UKCore-HealthcareService-OrthopaedicService-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-HealthcareService"/>
-	</meta>
 	<identifier>
 		<system value="https://fhir.nhs.uk/Id/ods-site-code"/>
 		<value value="RR813"/>

--- a/examples/UKCore-Immunization-InfluenzaVaccine-Example.xml
+++ b/examples/UKCore-Immunization-InfluenzaVaccine-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-InfluenzaVaccine-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-AstraZenecaVaccine-Example.xml
+++ b/examples/UKCore-Immunization-Sn-AstraZenecaVaccine-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-AstraZenecaVaccine-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<!-- **************snippet start************** -->
 	<vaccineCode>

--- a/examples/UKCore-Immunization-Sn-IntramuscularRoute-Example.xml
+++ b/examples/UKCore-Immunization-Sn-IntramuscularRoute-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-IntramuscularRoute-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-LeftUpperArmStructure-Example.xml
+++ b/examples/UKCore-Immunization-Sn-LeftUpperArmStructure-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-LeftUpperArmStructure-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-LotNumber-Example.xml
+++ b/examples/UKCore-Immunization-Sn-LotNumber-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-LotNumber-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-Manufacturer-Example.xml
+++ b/examples/UKCore-Immunization-Sn-Manufacturer-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-Manufacturer-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-PatientConformVaccination-Example.xml
+++ b/examples/UKCore-Immunization-Sn-PatientConformVaccination-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-PatientConformVaccination-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-Performer-Example.xml
+++ b/examples/UKCore-Immunization-Sn-Performer-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-Performer-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-ProtocolApplied-Example.xml
+++ b/examples/UKCore-Immunization-Sn-ProtocolApplied-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-ProtocolApplied-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-Immunization-Sn-UnitsOfMeasure-Example.xml
+++ b/examples/UKCore-Immunization-Sn-UnitsOfMeasure-Example.xml
@@ -1,8 +1,5 @@
 <Immunization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Immunization-Sn-UnitsOfMeasure-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
-	</meta>
 	<status value="completed"/>
 	<vaccineCode>
 		<coding>

--- a/examples/UKCore-List-EmptyList-Example.xml
+++ b/examples/UKCore-List-EmptyList-Example.xml
@@ -1,8 +1,5 @@
 <List xmlns="http://hl7.org/fhir" >
   <id value="UKCore-List-EmptyList-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-List" />
-  </meta>
   <status value="current" />
   <mode value="working" />
   <code>

--- a/examples/UKCore-List-Extension-ListWarningCode-Example.xml
+++ b/examples/UKCore-List-Extension-ListWarningCode-Example.xml
@@ -1,8 +1,5 @@
 <List xmlns="http://hl7.org/fhir">
     <id value="UKCore-List-Extension-ListWarningCode-Example" />
-    <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-List" />
-    </meta>
     <!--  **************extension start**************  -->
     <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ListWarningCode">
         <valueCode value="data-in-transit"/>

--- a/examples/UKCore-List-Sn-NoAllergyData-Example.xml
+++ b/examples/UKCore-List-Sn-NoAllergyData-Example.xml
@@ -1,8 +1,5 @@
 <List xmlns="http://hl7.org/fhir">
 	<id value="UKCore-List-Sn-NoAllergyData-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-List"/>
-	</meta>
 	<status value="current"/>
 	<mode value="snapshot"/>
 	<code>

--- a/examples/UKCore-Location-CardiologySJUH-Example.xml
+++ b/examples/UKCore-Location-CardiologySJUH-Example.xml
@@ -1,8 +1,5 @@
 <Location xmlns="http://hl7.org/fhir">
   <id value="UKCore-Location-CardiologySJUH-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location" />
-  </meta>
   <identifier>
     <system value="https://fhir.nhs.uk/Id/ods-site-code" />
     <value value="RR8D7" />

--- a/examples/UKCore-Location-GeneralPracticeNurseClinic-Example.xml
+++ b/examples/UKCore-Location-GeneralPracticeNurseClinic-Example.xml
@@ -1,8 +1,5 @@
 <Location xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Location-GeneralPracticeNurseClinic-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location"/>
-	</meta>
 	<identifier>
 		<system value="https://fhir.nhs.uk/Id/ods-site-code"/>
 		<value value="GP8D7"/>

--- a/examples/UKCore-Location-HospitalSJUH-Example.xml
+++ b/examples/UKCore-Location-HospitalSJUH-Example.xml
@@ -1,8 +1,5 @@
 <Location xmlns="http://hl7.org/fhir">
   <id value="UKCore-Location-HospitalSJUH-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location" />
-  </meta>
   <identifier>
     <system value="https://fhir.nhs.uk/Id/ods-site-code" />
     <value value="RR813" />

--- a/examples/UKCore-Medication-COVID-Vaccine-Example.xml
+++ b/examples/UKCore-Medication-COVID-Vaccine-Example.xml
@@ -1,8 +1,5 @@
 <Medication xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Medication-COVID-Vaccine-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication"/>
-	</meta>
 	<code>
 		<coding>
 			<system value="https://dmd.nhs.uk"/>

--- a/examples/UKCore-Medication-Sn-Extension-Amoxicillin-Example.xml
+++ b/examples/UKCore-Medication-Sn-Extension-Amoxicillin-Example.xml
@@ -1,8 +1,5 @@
 <Medication xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Medication-Sn-Extension-Amoxicillin-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication"/>
-	</meta>
 	<!-- **************Snippet start************** -->
 	<code>
 		<coding>

--- a/examples/UKCore-Medication-Sn-TransferDegradMedEntry-Example.xml
+++ b/examples/UKCore-Medication-Sn-TransferDegradMedEntry-Example.xml
@@ -1,8 +1,5 @@
 <Medication xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Medication-Sn-TransferDegradMedEntry-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication"/>
-	</meta>
 	<!-- **************Snippet start************** -->
 	<code>
 		<coding>

--- a/examples/UKCore-Medication-TimololVTM-Example.xml
+++ b/examples/UKCore-Medication-TimololVTM-Example.xml
@@ -1,8 +1,5 @@
 <Medication xmlns="http://hl7.org/fhir">
     <id value="UKCore-Medication-TimololVTM-Example" />
-    <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication" />
-    </meta>
     <code>
         <coding>
             <system value="https://dmd.nhs.uk" />

--- a/examples/UKCore-Medication-TimoptolEyeDrops-Example.xml
+++ b/examples/UKCore-Medication-TimoptolEyeDrops-Example.xml
@@ -1,8 +1,5 @@
 <Medication xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Medication-TimoptolEyeDrops-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication"/>
-	</meta>
 	<code>
 		<coding>
 			<system value="https://dmd.nhs.uk"/>

--- a/examples/UKCore-MedicationAdministration-TimoptolEyeDrops-Example.xml
+++ b/examples/UKCore-MedicationAdministration-TimoptolEyeDrops-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationAdministration xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MedicationAdministration-TimoptolEyeDrops-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationAdministration"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="e8779393-9b7c-4654-a8df-0ba4cc9b28ce"/>

--- a/examples/UKCore-MedicationDispense-EyeDrops-Example.xml
+++ b/examples/UKCore-MedicationDispense-EyeDrops-Example.xml
@@ -1,8 +1,5 @@
 <MedicationDispense xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MedicationDispense-EyeDrops-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationDispense"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="5c92c1dc-06a9-4729-b8c9-222cf769f8dc"/>

--- a/examples/UKCore-MedicationRequest-Extension-RepeatInformation-Example.xml
+++ b/examples/UKCore-MedicationRequest-Extension-RepeatInformation-Example.xml
@@ -1,8 +1,5 @@
 <MedicationRequest xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MedicationRequest-Extension-RepeatInformation-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest"/>
-	</meta>
 	<!-- **************extension start************** -->
 	<!--MedicationRepeatInformation extension details-->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation">

--- a/examples/UKCore-MedicationRequest-EyeDrops-Example.xml
+++ b/examples/UKCore-MedicationRequest-EyeDrops-Example.xml
@@ -1,8 +1,5 @@
 <MedicationRequest xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MedicationRequest-EyeDrops-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest"/>
-	</meta>
 	<status value="completed"/>
 	<intent value="order"/>
 	<category>

--- a/examples/UKCore-MedicationStatement-Amoxicillin-Example.xml
+++ b/examples/UKCore-MedicationStatement-Amoxicillin-Example.xml
@@ -1,8 +1,5 @@
 <MedicationStatement xmlns="http://hl7.org/fhir">
-<id value="UKCore-MedicationStatement-Amoxicillin-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement"/>
-	</meta>
+	<id value="UKCore-MedicationStatement-Amoxicillin-Example"/>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="ac0ffbdf-3289-41d5-84d9-068a1f5937db"/>

--- a/examples/UKCore-MedicationStatement-Extension-MedicationChangeSummary-Example.xml
+++ b/examples/UKCore-MedicationStatement-Extension-MedicationChangeSummary-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationStatement xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MedicationStatement-Extension-ChangeSummary-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement"/>
-	</meta>
 	<!--Change details extension-->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationChangeSummary">
 		<extension url="status">

--- a/examples/UKCore-MedicationStatement-Extension-MedicationPrescribingOrganizationType-Example.xml
+++ b/examples/UKCore-MedicationStatement-Extension-MedicationPrescribingOrganizationType-Example.xml
@@ -1,8 +1,5 @@
 <MedicationStatement xmlns="http://hl7.org/fhir">
-<id value="UKCore-MedicationStatement-Extension-PrescribingOrg-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement"/>
-	</meta>
+	<id value="UKCore-MedicationStatement-Extension-PrescribingOrg-Example"/>
 	<!-- **************extension start************** -->
 	<!--Medication Prescribing Organization extension details-->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationPrescribingOrganizationType">

--- a/examples/UKCore-MedicationStatement-Extension-MedicationStatementLastIssueDate-Example.xml
+++ b/examples/UKCore-MedicationStatement-Extension-MedicationStatementLastIssueDate-Example.xml
@@ -1,8 +1,5 @@
 <MedicationStatement xmlns="http://hl7.org/fhir">
-<id value="UKCore-MedicationStatement-Extension-LastIssueDate-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement"/>
-	</meta>
+	<id value="UKCore-MedicationStatement-Extension-LastIssueDate-Example"/>
 	<!-- **************extension start************** -->
 	<!--MedicationStatement Last Issue Date extension details-->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationStatementLastIssueDate">

--- a/examples/UKCore-MedicationStatement-Extension-PharmacistVerifiedIndicator-Example.xml
+++ b/examples/UKCore-MedicationStatement-Extension-PharmacistVerifiedIndicator-Example.xml
@@ -1,8 +1,5 @@
 <MedicationStatement xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MedicationStatement-Extension-PharmacistVerified-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement"/>
-	</meta>
 	<!-- **************extension start************** -->
 	<!--Pharmacist Verified Indicator extension details-->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PharmacistVerifiedIndicator">

--- a/examples/UKCore-MessageHeader-Discharge-Example.xml
+++ b/examples/UKCore-MessageHeader-Discharge-Example.xml
@@ -1,8 +1,5 @@
 <MessageHeader xmlns="http://hl7.org/fhir">
 	<id value="UKCore-MessageHeader-Discharge-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MessageHeader"/>
-	</meta>
 	<eventCoding>
 		<system value="http://snomed.info/sct"/>
 		<code value="306689006"/>

--- a/examples/UKCore-Observation-AwarenessOfDiagnosis-Example.xml
+++ b/examples/UKCore-Observation-AwarenessOfDiagnosis-Example.xml
@@ -1,8 +1,5 @@
 <Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-AwarenessOfDiagnosis-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-  </meta>
   <status value="final" />
   <code>
     <coding>

--- a/examples/UKCore-Observation-Sn-Extension-CodingSCT-IllicitDrugs-Example.xml
+++ b/examples/UKCore-Observation-Sn-Extension-CodingSCT-IllicitDrugs-Example.xml
@@ -1,8 +1,5 @@
-<Observation xmlns="http://hl7.org/fhir">
+ <Observation xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Observation-Sn-Extension-CodingSCT-IllicitDrugs-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
-	</meta>
 	<status value="final"/>
 	<!-- **************Snippet start************** -->
 	<code>

--- a/examples/UKCore-Observation-Sn-Extension-CodingSCT-Potassium-Example.xml
+++ b/examples/UKCore-Observation-Sn-Extension-CodingSCT-Potassium-Example.xml
@@ -1,8 +1,5 @@
 <Observation xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Observation-Sn-Extension-CodingSCT-Potassium-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
-	</meta>
 	<status value="final"/>
 	<!-- **************Snippet start************** -->
 	<code>

--- a/examples/UKCore-Observation-Sn-Extension-CodingSCT-Weight-Example.xml
+++ b/examples/UKCore-Observation-Sn-Extension-CodingSCT-Weight-Example.xml
@@ -1,8 +1,5 @@
 <Observation xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Observation-Sn-Extension-CodingSCT-Weight-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
-	</meta>
 	<status value="final"/>
 	<!-- **************Snippet start************** -->
 	<code>

--- a/examples/UKCore-Observation-WhiteCellCount-Example.xml
+++ b/examples/UKCore-Observation-WhiteCellCount-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Observation>
 	<id value="UKCore-Observation-WhiteCellCount-Example" />
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122" />
 		<value value="2af46949-4938-4c57-bad4-c4363e1965d5" />

--- a/examples/UKCore-OperationOutcome-DateError-Example.xml
+++ b/examples/UKCore-OperationOutcome-DateError-Example.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OperationOutcome xmlns="http://hl7.org/fhir">
-  <id value="UKCore-OperationOutcome-DateError-Example"/>
-   <meta>
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-OperationOutcome" />
-    </meta>
-  <issue>  
-   <severity value="fatal"/> 
-    <code value="structure"/>
-    <details> 
-<coding>
-<system value="http://terminology.hl7.org/CodeSystem/operation-outcome"/>
-<code value="MSG_DATE_FORMAT"/>
-<display value="The Date value %s is not in the correct format (Xml Date Format required)"/>
-</coding>
-   </details> 
-       <diagnostics value="Interop.FHIRProcessors.Patient.processbirthDate line 2450"/>
-       <expression value="Patient.birthDate"/> 
- </issue>
+	<id value="UKCore-OperationOutcome-DateError-Example"/>
+	<issue>
+		<severity value="fatal"/>
+		<code value="structure"/>
+		<details>
+			<coding>
+				<system value="http://terminology.hl7.org/CodeSystem/operation-outcome"/>
+				<code value="MSG_DATE_FORMAT"/>
+				<display value="The Date value %s is not in the correct format (Xml Date Format required)"/>
+			</coding>
+		</details>
+		<diagnostics value="Interop.FHIRProcessors.Patient.processbirthDate line 2450"/>
+		<expression value="Patient.birthDate"/>
+	</issue>
 </OperationOutcome>

--- a/examples/UKCore-Organization-LeedsTeachingHospital-Example.xml
+++ b/examples/UKCore-Organization-LeedsTeachingHospital-Example.xml
@@ -1,8 +1,5 @@
 <Organization xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Organization-LeedsTeachingHospital-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
-	</meta>
 	<identifier>
 		<use value="official"/>
 		<system value="https://fhir.nhs.uk/Id/ods-organization-code"/>

--- a/examples/UKCore-Organization-WhiteRoseMedicalCentre-Example.xml
+++ b/examples/UKCore-Organization-WhiteRoseMedicalCentre-Example.xml
@@ -1,8 +1,5 @@
 <Organization xmlns="http://hl7.org/fhir">
   <id value="UKCore-Organization-WhiteRoseMedicalCentre-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-  </meta>
   <identifier>
     <use value="official" />
     <system value="https://fhir.nhs.uk/Id/ods-organization-code" />

--- a/examples/UKCore-Patient-BabyPatient-Example.xml
+++ b/examples/UKCore-Patient-BabyPatient-Example.xml
@@ -1,8 +1,5 @@
 <Patient xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Patient-BabyPatient-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
-	</meta>
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory">
 		<valueCodeableConcept>
 			<coding>

--- a/examples/UKCore-Patient-Extension-NHSNumberVerificationStatus-Example.xml
+++ b/examples/UKCore-Patient-Extension-NHSNumberVerificationStatus-Example.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Patient xmlns="http://hl7.org/fhir">
-<id value="UKCore-Patient-Extension-NHSNumberVerificationStatus-Example" />
-<identifier>
-	<!-- **************extension start************** -->
-	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus">
-		<valueCodeableConcept>
-			<coding>
-				<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
-				<code value="01"/>
-				<display value="Number present and verified"/>
-			</coding>
-		</valueCodeableConcept>
-	</extension>
-	<!-- **************extension end************** -->
-</identifier>
-
+	<id value="UKCore-Patient-Extension-NHSNumberVerificationStatus-Example"/>
+	<identifier>
+		<!-- **************extension start************** -->
+		<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus">
+			<valueCodeableConcept>
+				<coding>
+					<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
+					<code value="01"/>
+					<display value="Number present and verified"/>
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+		<!-- **************extension end************** -->
+	</identifier>
 </Patient>

--- a/examples/UKCore-Patient-RichardSmith-Example.xml
+++ b/examples/UKCore-Patient-RichardSmith-Example.xml
@@ -1,8 +1,5 @@
 <Patient xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Patient-RichardSmith-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
-	</meta>
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory">
 		<valueCodeableConcept>
 			<coding>

--- a/examples/UKCore-Practitioner-ConsultantSandraGose-Example.xml
+++ b/examples/UKCore-Practitioner-ConsultantSandraGose-Example.xml
@@ -1,8 +1,5 @@
 <Practitioner xmlns="http://hl7.org/fhir">
   <id value="UKCore-Practitioner-ConsultantSandraGose-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-  </meta>
   <identifier>
     <system value="https://fhir.nhs.uk/Id/sds-user-id" />
     <value value="C12345678" />

--- a/examples/UKCore-Practitioner-DoctorPaulRastall-Example.xml
+++ b/examples/UKCore-Practitioner-DoctorPaulRastall-Example.xml
@@ -1,8 +1,5 @@
 <Practitioner xmlns="http://hl7.org/fhir">
   <id value="UKCore-Practitioner-DoctorPaulRastall-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-  </meta>
   <identifier>
     <system value="https://fhir.nhs.uk/Id/sds-user-id" />
     <value value="G12345678" />

--- a/examples/UKCore-Practitioner-Pharmacist-JimmyChuck-Example.xml
+++ b/examples/UKCore-Practitioner-Pharmacist-JimmyChuck-Example.xml
@@ -1,8 +1,5 @@
 <Practitioner xmlns="http://hl7.org/fhir">
   <id value="UKCore-Practitioner-PharmacistJimmyChuck-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-  </meta>
   <identifier>
     <system value="https://fhir.nhs.uk/Id/sds-user-id" />
     <value value="P12345678" />

--- a/examples/UKCore-Practitioner-Sn-Photo-Example.xml
+++ b/examples/UKCore-Practitioner-Sn-Photo-Example.xml
@@ -1,8 +1,5 @@
 <Practitioner xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Practitioner-Sn-Photo-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
-	</meta>
 	<!-- **************snippet start************** -->
 	<photo>
 		<contentType value="image/png"/>

--- a/examples/UKCore-Practitioner-Sn-Qualification-Example.xml
+++ b/examples/UKCore-Practitioner-Sn-Qualification-Example.xml
@@ -1,8 +1,5 @@
 <Practitioner xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Practitioner-Sn-Qualification-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
-	</meta>
 	<!-- **************snippet start************** -->
 	<qualification>
 		<identifier>

--- a/examples/UKCore-PractitionerRole-GeneralPractitioner-Example.xml
+++ b/examples/UKCore-PractitionerRole-GeneralPractitioner-Example.xml
@@ -1,8 +1,5 @@
 <PractitionerRole xmlns="http://hl7.org/fhir">
   <id value="UKCore-PractitionerRole-GeneralPractitioner-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole" />
-  </meta>
   <identifier>
     <system value="https://fhir.nhs.uk/Id/sds-role-profile-id" />
     <value value="100334993514" />

--- a/examples/UKCore-PractitionerRole-Sn-Organization-Code-Example.xml
+++ b/examples/UKCore-PractitionerRole-Sn-Organization-Code-Example.xml
@@ -1,8 +1,5 @@
 <PractitionerRole xmlns="http://hl7.org/fhir">
 	<id value="UKCore-PractitionerRole-Sn-Organization-Code-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"/>
-	</meta>
 		<!-- **************snippet start************** -->
 	<identifier>
 	    <system value="https://fhir.nhs.uk/Id/sds-role-profile-id"/>

--- a/examples/UKCore-Procedure-ExaminationOfSkin-Example.xml
+++ b/examples/UKCore-Procedure-ExaminationOfSkin-Example.xml
@@ -1,8 +1,5 @@
 <Procedure xmlns="http://hl7.org/fhir">
   <id value="UKCore-Procedure-ExaminationOfSkin-Example" />
-  <meta>
-    <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Procedure" />
-  </meta>
   <status value="completed" />
   <code>
     <coding>

--- a/examples/UKCore-Procedure-Extension-AnaestheticIssues-Example.xml
+++ b/examples/UKCore-Procedure-Extension-AnaestheticIssues-Example.xml
@@ -1,8 +1,5 @@
 <Procedure xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Procedure-Extension-AnaestheticIssues-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Procedure"/>
-	</meta>
 	<!-- **************extension start************** -->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AnaestheticIssues">
 		<valueCodeableConcept>

--- a/examples/UKCore-Provenance-RARecordConsent-Example.xml
+++ b/examples/UKCore-Provenance-RARecordConsent-Example.xml
@@ -1,8 +1,5 @@
 <Provenance xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Provenance-RARecordConsent-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Provenance"/>
-	</meta>
 	<target>
 		<reference value="Consent/UKCore-Consent-ForInformationAccess-Example"/>
 	</target>

--- a/examples/UKCore-Questionnaire-InpatientSurvey-Example.xml
+++ b/examples/UKCore-Questionnaire-InpatientSurvey-Example.xml
@@ -1,8 +1,5 @@
 <Questionnaire xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Questionnaire-InpatientSurvey-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Questionnaire"/>
-	</meta>
 	<url value="https://example.com/base/Questionnaire/UKCore-Questionnaire-InpatientSurvey-Example"/>
 	<identifier>
 		<value value="dbba41f5-2905-4a5f-baba-e5987cbd9cca"/>

--- a/examples/UKCore-QuestionnaireResponse-BabyPatientSurvey-Example.xml
+++ b/examples/UKCore-QuestionnaireResponse-BabyPatientSurvey-Example.xml
@@ -1,8 +1,5 @@
 <QuestionnaireResponse xmlns="http://hl7.org/fhir">
 	<id value="UKCore-QuestionnaireResponse-BabyPatientSurvey-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse"/>
-	</meta>
 	<identifier>
 		<value value="51f09892-d552-4265-8734-db6c7adbf4a4"/>
 		<assigner>

--- a/examples/UKCore-QuestionnaireResponse-InpatientSurvey-Example.xml
+++ b/examples/UKCore-QuestionnaireResponse-InpatientSurvey-Example.xml
@@ -1,8 +1,5 @@
 <QuestionnaireResponse xmlns="http://hl7.org/fhir">
 	<id value="UKCore-QuestionnaireResponse-InpatientSurvey-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse"/>
-	</meta>
 	<identifier>
 		<value value="6d47d8c4-2f05-4dbb-93f8-6863e6d2975b"/>
 		<assigner>

--- a/examples/UKCore-RelatedPerson-JoySmith-Example.xml
+++ b/examples/UKCore-RelatedPerson-JoySmith-Example.xml
@@ -1,8 +1,5 @@
 <RelatedPerson xmlns="http://hl7.org/fhir">
 	<id value="UKCore-RelatedPerson-JoySmith-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson"/>
-	</meta>
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference">
 		<extension url="PreferredContactMethod">
 			<valueCodeableConcept>

--- a/examples/UKCore-Schedule-Immunization-Example.xml
+++ b/examples/UKCore-Schedule-Immunization-Example.xml
@@ -1,9 +1,5 @@
 <Schedule xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Schedule-Immunization-Example"/>
-	<meta>
-		<lastUpdated value="2021-10-13T11:20:00+07:00"/>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Schedule"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="4c8b068a-d610-427f-a508-6b7f90d47bf2"/>

--- a/examples/UKCore-ServiceRequest-ColonoscopyRequest-Example.xml
+++ b/examples/UKCore-ServiceRequest-ColonoscopyRequest-Example.xml
@@ -1,9 +1,5 @@
 <ServiceRequest xmlns="http://hl7.org/fhir">
 	<id value="UKCore-ServiceRequest-ColonoscopyRequest-Example"/>
-	<meta>
-		<lastUpdated value="2021-11-26T15:15:15+00:00"/>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest"/>
-	</meta>
 	<!--The source of the service request.-->
 	<!-- ***************extension start*************** -->
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SourceOfServiceRequest">

--- a/examples/UKCore-Specimen-BloodSpecimen-Example.xml
+++ b/examples/UKCore-Specimen-BloodSpecimen-Example.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Specimen xmlns="http://hl7.org/fhir">
  <id value="UKCore-Specimen-BloodSpecimen-Example"/>
- <meta>
-  <profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen"/>
- </meta>
  <status value="available"/>
  <type>
   <coding>

--- a/examples/UKCore-Task-Colonoscopy-Example.xml
+++ b/examples/UKCore-Task-Colonoscopy-Example.xml
@@ -1,8 +1,5 @@
 <Task xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Task-Colonoscopy-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Task"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="b269d1d7-1acf-47bb-8b3c-e38b583d9a07"/>

--- a/examples/UKCore-VitalSigns-Observation-OxygenSaturation-Example.xml
+++ b/examples/UKCore-VitalSigns-Observation-OxygenSaturation-Example.xml
@@ -1,8 +1,5 @@
 <Observation xmlns="http://hl7.org/fhir">
 	<id value="UKCore-VitalSigns-Observation-OxygenSaturation-Example"/>
-	<meta>
-		<profile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
-	</meta>
 	<identifier>
 		<system value="https://tools.ietf.org/html/rfc4122"/>
 		<value value="f0297f56-48a4-43da-8e54-58146ef36b51"/>


### PR DESCRIPTION
Removed <meta><profile> tags from the examples. Majority were found in the 0.5.0 profiles, but some were in the 1.0.0 examples

This will allow the github validator to run successfully