### PR TITLE
The ConceptMap UKCore-ConditionEpisodicity and ValueSet-UKCore-Condit…

### DIFF
--- a/conceptmaps/ConceptMap-UKCore-ConditionEpisodicity.xml
+++ b/conceptmaps/ConceptMap-UKCore-ConditionEpisodicity.xml
@@ -4,8 +4,8 @@
 	<version value="2.0.0"/>
 	<name value="ConceptMapUKCoreConditionEpisodicity"/>
 	<title value="ConceptMap - UK Core Condition Episodicity"/>
-	<status value="draft" />
-	<date value="2021-09-10" />
+	<status value="retired" />
+	<date value="2022-12-16" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-ConditionEpisode.xml
+++ b/valuesets/ValueSet-UKCore-ConditionEpisode.xml
@@ -4,8 +4,8 @@
 	<version value="2.1.0"/>
 	<name value="UKCoreConditionEpisode"/>
 	<title value="UK Core Condition Episode"/>
-	<status value="active" />
-	<date value="2022-01-07" />
+	<status value="retired" />
+	<date value="2022-12-16" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />


### PR DESCRIPTION
The ConceptMap UKCore-ConditionEpisodicity and ValueSet-UKCore-ConditionEpisode have been retired, as it has been confirmed these are not used by GP Connect.  So there is no requirement for these to be in UK Core from GP Connect.