### PR TITLE
set messageevent binding to example

### DIFF
--- a/structuredefinitions/UKCore-MessageHeader.xml
+++ b/structuredefinitions/UKCore-MessageHeader.xml
@@ -74,7 +74,7 @@
     <element id="MessageHeader.event[x]">
       <path value="MessageHeader.event[x]" />
       <binding>
-        <strength value="preferred" />
+        <strength value="example" />
         <description value="Message event" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-MessageEvent" />
       </binding>


### PR DESCRIPTION
as per standup call discussion, set binding to MessageEvent valueset which uses NHSD codesystems to 'example' 