### PR TITLE
Fixes for 1.0.0/martial status filtering

### DIFF
--- a/codesystems/CodeSystem-UKCore-PersonMaritalStatusEngland.xml
+++ b/codesystems/CodeSystem-UKCore-PersonMaritalStatusEngland.xml
@@ -1,64 +1,64 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
-  <id value="UKCore-PersonMaritalStatusEngland" />
-  <url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland" />
-  <version value="1.1.0" />
-  <name value="UKCorePersonMaritalStatusEngland" />
-  <title value="UK Core Person Marital Status England" />
-  <status value="active" />
-  <date value="2022-12-16" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="secretariat@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <contact>
-    <name value="NHS Digital" />
-    <telecom>
-      <system value="email" />
-      <value value="interoperabilityteam@nhs.net" />
-      <use value="work" />
-      <rank value="2" />
-    </telecom>
-  </contact>
-  <description value="A set of codes that define the marital status of a person, as specified by the person. These codes and their descriptions represent concepts used in England and are copied from the content of the NHS Data Dictionary Person Marital Status web page at https://www.datadictionary.nhs.uk/data_elements/person_marital_status.html on 16/12/2022." />
-  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <caseSensitive value="true" />
-  <content value="complete" />
-  <concept>
-    <code value="S" />
-    <display value="Single" />
-  </concept>
-  <concept>
-    <code value="M" />
-    <display value="Married/Civil Partner" />
-  </concept>
-  <concept>
-    <code value="D" />
-    <display value="Divorced/Person whose Civil Partnership has been dissolved" />
-  </concept>
-  <concept>
-    <code value="W" />
-    <display value="Widowed/Surviving Civil Partner" />
-  </concept> 
-  <concept>
-    <code value="P" />
-    <display value="Separated" />
-  </concept>
-  <concept>
-    <code value="N" />
-    <display value="Not disclosed" />
-  </concept>
-  <concept>
-    <code value="8" />
-    <display value="Not applicable" />
-  </concept>
-  <concept>
-    <code value="9" />
-    <display value="Not known" />
-  </concept>
+	<id value="UKCore-PersonMaritalStatusEngland"/>
+	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
+	<version value="1.1.0"/>
+	<name value="UKCorePersonMaritalStatusEngland"/>
+	<title value="UK Core Person Marital Status England"/>
+	<status value="active"/>
+	<date value="2022-12-16"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="secretariat@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<contact>
+		<name value="NHS Digital"/>
+		<telecom>
+			<system value="email"/>
+			<value value="interoperabilityteam@nhs.net"/>
+			<use value="work"/>
+			<rank value="2"/>
+		</telecom>
+	</contact>
+	<description value="A set of codes that define the marital status of a person, as specified by the person. These codes and their descriptions represent concepts used in England and are copied from the content of the NHS Data Dictionary Person Marital Status web page at https://www.datadictionary.nhs.uk/data_elements/person_marital_status.html on 16/12/2022."/>
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<caseSensitive value="true"/>
+	<content value="complete"/>
+	<concept>
+		<code value="S"/>
+		<display value="Single"/>
+	</concept>
+	<concept>
+		<code value="M"/>
+		<display value="Married/Civil Partner"/>
+	</concept>
+	<concept>
+		<code value="D"/>
+		<display value="Divorced/Person whose Civil Partnership has been dissolved"/>
+	</concept>
+	<concept>
+		<code value="W"/>
+		<display value="Widowed/Surviving Civil Partner"/>
+	</concept>
+	<concept>
+		<code value="P"/>
+		<display value="Separated"/>
+	</concept>
+	<concept>
+		<code value="N"/>
+		<display value="Not disclosed"/>
+	</concept>
+	<concept>
+		<code value="8"/>
+		<display value="Not applicable"/>
+	</concept>
+	<concept>
+		<code value="9"/>
+		<display value="Not known"/>
+	</concept>
 </CodeSystem>

--- a/codesystems/CodeSystem-UKCore-PersonMaritalStatusEngland.xml
+++ b/codesystems/CodeSystem-UKCore-PersonMaritalStatusEngland.xml
@@ -1,11 +1,11 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
   <id value="UKCore-PersonMaritalStatusEngland" />
   <url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="UKCorePersonMaritalStatusEngland" />
   <title value="UK Core Person Marital Status England" />
   <status value="active" />
-  <date value="2022-08-26" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -25,7 +25,7 @@
       <rank value="2" />
     </telecom>
   </contact>
-  <description value="A set of codes that define the marital status of a person, as specified by the person. These codes and their descriptions represent concepts used in England and are copied from the content of the NHS Data Dictionary Person Marital Status web page at https://www.datadictionary.nhs.uk/attributes/person_marital_status.html on 14/10/2022." />
+  <description value="A set of codes that define the marital status of a person, as specified by the person. These codes and their descriptions represent concepts used in England and are copied from the content of the NHS Data Dictionary Person Marital Status web page at https://www.datadictionary.nhs.uk/data_elements/person_marital_status.html on 16/12/2022." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <caseSensitive value="true" />
   <content value="complete" />
@@ -52,5 +52,13 @@
   <concept>
     <code value="N" />
     <display value="Not disclosed" />
+  </concept>
+  <concept>
+    <code value="8" />
+    <display value="Not applicable" />
+  </concept>
+  <concept>
+    <code value="9" />
+    <display value="Not known" />
   </concept>
 </CodeSystem>

--- a/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
+++ b/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
@@ -189,7 +189,6 @@
 			<display value="Civil Partner"/>
 		</contains>
 		<contains>
-		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
 			<version value="1.0.0"/>
 			<code value="32"/>

--- a/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
+++ b/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
@@ -5,7 +5,7 @@
 	<name value="UKCorePersonMaritalStatusCode"/>
 	<title value="UK Core Person Marital Status Code"/>
 	<status value="active"/>
-	<date value="2022-12-16"/>
+	<date value="2022-08-26"/>
 	<publisher value="HL7 UK"/>
 	<contact>
 		<name value="HL7 UK"/>
@@ -57,6 +57,10 @@
 				<display value="Not disclosed"/>
 			</concept>
 			<concept>
+				<code value="P"/>
+				<display value="Separated"/>
+			</concept>
+			<concept>
 				<code value="8"/>
 				<display value="Not applicable"/>
 			</concept>
@@ -76,6 +80,10 @@
 				<display value="Surviving Civil Partner"/>
 			</concept>
 			<concept>
+				<code value="51"/>
+				<display value="Separated"/>
+			</concept>
+			<concept>
 				<code value="91"/>
 				<display value="Not disclosed or unknown"/>
 			</concept>
@@ -84,7 +92,7 @@
 	<expansion>
 		<identifier value="3368b10a-72be-4c8c-9d57-133c63bbd41a"/>
 		<timestamp value="2022-11-17T13:12:59+00:00"/>
-		<total value="20"/>
+		<total value="22"/>
 		<offset value="0"/>
 		<contains>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
@@ -179,6 +187,12 @@
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
 			<version value="1.1.0"/>
+			<code value="P"/>
+			<display value="Separated"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
+			<version value="1.1.0"/>
 			<code value="8"/>
 			<display value="Not applicable"/>
 		</contains>
@@ -199,6 +213,12 @@
 			<version value="1.0.0"/>
 			<code value="42"/>
 			<display value="Surviving Civil Partner"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
+			<version value="1.0.0"/>
+			<code value="51"/>
+			<display value="Separated"/>
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>

--- a/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
+++ b/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-PersonMaritalStatusCode"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonMaritalStatusCode"/>
-	<version value="2.2.0"/>
+	<version value="2.3.0"/>
 	<name value="UKCorePersonMaritalStatusCode"/>
 	<title value="UK Core Person Marital Status Code"/>
 	<status value="active"/>
-	<date value="2022-08-26"/>
+	<date value="2022-12-16"/>
 	<publisher value="HL7 UK"/>
 	<contact>
 		<name value="HL7 UK"/>
@@ -40,45 +40,45 @@
 		</include>
 		<include>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-            <concept>
-                <code value="M" />
-                <display value="Married/Civil Partner" />
-            </concept>
-            <concept>
-                <code value="D" />
-                <display value="Divorced/Person whose Civil Partnership has been dissolved" />
-            </concept>
-            <concept>
-                <code value="W" />
-                <display value="Widowed/Surviving Civil Partner" />
-            </concept>
-            <concept>
-                <code value="N" />
-                <display value="Not disclosed" />
-            </concept>
-            <concept>
-                <code value="8" />
-                <display value="Not applicable" />
-            </concept>
+			<concept>
+				<code value="M"/>
+				<display value="Married/Civil Partner"/>
+			</concept>
+			<concept>
+				<code value="D"/>
+				<display value="Divorced/Person whose Civil Partnership has been dissolved"/>
+			</concept>
+			<concept>
+				<code value="W"/>
+				<display value="Widowed/Surviving Civil Partner"/>
+			</concept>
+			<concept>
+				<code value="N"/>
+				<display value="Not disclosed"/>
+			</concept>
+			<concept>
+				<code value="8"/>
+				<display value="Not applicable"/>
+			</concept>
 		</include>
 		<include>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-            <concept>
-                <code value="22" />
-                <display value="Civil Partner" />
-            </concept>
-            <concept>
-                <code value="32" />
-                <display value="Person whose Civil Partnership has been dissolved" />
-            </concept>
-            <concept>
-                <code value="42" />
-                <display value="Surviving Civil Partner" />
-            </concept>
-            <concept>
-                <code value="91" />
-                <display value="Not disclosed or unknown" />
-            </concept>
+			<concept>
+				<code value="22"/>
+				<display value="Civil Partner"/>
+			</concept>
+			<concept>
+				<code value="32"/>
+				<display value="Person whose Civil Partnership has been dissolved"/>
+			</concept>
+			<concept>
+				<code value="42"/>
+				<display value="Surviving Civil Partner"/>
+			</concept>
+			<concept>
+				<code value="91"/>
+				<display value="Not disclosed or unknown"/>
+			</concept>
 		</include>
 	</compose>
 	<expansion>

--- a/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
+++ b/valuesets/ValueSet-UKCore-PersonMaritalStatusCode.xml
@@ -40,24 +40,52 @@
 		</include>
 		<include>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
+            <concept>
+                <code value="M" />
+                <display value="Married/Civil Partner" />
+            </concept>
+            <concept>
+                <code value="D" />
+                <display value="Divorced/Person whose Civil Partnership has been dissolved" />
+            </concept>
+            <concept>
+                <code value="W" />
+                <display value="Widowed/Surviving Civil Partner" />
+            </concept>
+            <concept>
+                <code value="N" />
+                <display value="Not disclosed" />
+            </concept>
+            <concept>
+                <code value="8" />
+                <display value="Not applicable" />
+            </concept>
 		</include>
 		<include>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
+            <concept>
+                <code value="22" />
+                <display value="Civil Partner" />
+            </concept>
+            <concept>
+                <code value="32" />
+                <display value="Person whose Civil Partnership has been dissolved" />
+            </concept>
+            <concept>
+                <code value="42" />
+                <display value="Surviving Civil Partner" />
+            </concept>
+            <concept>
+                <code value="91" />
+                <display value="Not disclosed or unknown" />
+            </concept>
 		</include>
 	</compose>
 	<expansion>
 		<identifier value="3368b10a-72be-4c8c-9d57-133c63bbd41a"/>
 		<timestamp value="2022-11-17T13:12:59+00:00"/>
-		<total value="27"/>
+		<total value="20"/>
 		<offset value="0"/>
-		<parameter>
-			<name value="offset"/>
-			<valueInteger value="0"/>
-		</parameter>
-		<parameter>
-			<name value="count"/>
-			<valueInteger value="1000"/>
-		</parameter>
 		<contains>
 			<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
 			<version value="2018-08-12"/>
@@ -126,57 +154,33 @@
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-			<version value="1.0.0"/>
-			<code value="S"/>
-			<display value="Single"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-			<version value="1.0.0"/>
+			<version value="1.1.0"/>
 			<code value="M"/>
 			<display value="Married/Civil Partner"/>
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-			<version value="1.0.0"/>
+			<version value="1.1.0"/>
 			<code value="D"/>
 			<display value="Divorced/Person whose Civil Partnership has been dissolved"/>
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-			<version value="1.0.0"/>
+			<version value="1.1.0"/>
 			<code value="W"/>
 			<display value="Widowed/Surviving Civil Partner"/>
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-			<version value="1.0.0"/>
-			<code value="P"/>
-			<display value="Separated"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
-			<version value="1.0.0"/>
+			<version value="1.1.0"/>
 			<code value="N"/>
 			<display value="Not disclosed"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-			<version value="1.0.0"/>
-			<code value="11"/>
-			<display value="Single"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-			<version value="1.0.0"/>
-			<code value="12"/>
-			<display value="Cohabiting"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-			<version value="1.0.0"/>
-			<code value="21"/>
-			<display value="Married"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland"/>
+			<version value="1.1.0"/>
+			<code value="8"/>
+			<display value="Not applicable"/>
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
@@ -185,11 +189,6 @@
 			<display value="Civil Partner"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-			<version value="1.0.0"/>
-			<code value="31"/>
-			<display value="Divorced"/>
-		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
 			<version value="1.0.0"/>
@@ -199,20 +198,8 @@
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
 			<version value="1.0.0"/>
-			<code value="41"/>
-			<display value="Widowed"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-			<version value="1.0.0"/>
 			<code value="42"/>
 			<display value="Surviving Civil Partner"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>
-			<version value="1.0.0"/>
-			<code value="51"/>
-			<display value="Separated"/>
 		</contains>
 		<contains>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales"/>


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/IOPS-950

As requested by NA, I have filtered the PersonMaritalStatus valueset with the requested codes.
I have also removed the total/offset in the expansion as per DK suggestion

CodeSystem required a change because it was missing 8 | Not applicable, because we'd used the attribute list not data element list