### PR TITLE
Fix/uk core immunization explanation reason

### DIFF
--- a/valuesets/ValueSet-UKCore-ImmunizationExplanationReason.xml
+++ b/valuesets/ValueSet-UKCore-ImmunizationExplanationReason.xml
@@ -43,7 +43,7 @@
       </rank>
     </telecom>
   </contact>
-  <description value="A set of codes that define a clinical indication or reason for administering a vaccine.">
+  <description value="A set of codes that define a clinical indication or reason for administering a vaccine. Selected from the SNOMED CT UK coding system.">
   </description>
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.">
   </copyright>

--- a/valuesets/ValueSet-UKCore-ImmunizationExplanationReason.xml
+++ b/valuesets/ValueSet-UKCore-ImmunizationExplanationReason.xml
@@ -43,7 +43,7 @@
       </rank>
     </telecom>
   </contact>
-  <description value="A set of codes that define a clinical indication or reason for administering a vaccine. Selected from the 'Healthcare matters' simple reference set of the SNOMED CT UK coding system.">
+  <description value="A set of codes that define a clinical indication or reason for administering a vaccine.">
   </description>
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.">
   </copyright>


### PR DESCRIPTION
Removed the sentence That includes "Healthcare matter" as the valueset is no longer from there. 
Date/version no have been kept as 2020-08-26 was the changes made for 1.0.0.

https://nhsd-jira.digital.nhs.uk/browse/IOPS-970