### PR TITLE
Fix incorrect patient example reference

### DIFF
--- a/examples/UKCore-AllergyIntolerance-Amoxicillin-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Amoxicillin-Example.xml
@@ -22,7 +22,7 @@
     </coding>
   </code>
   <patient>
-    <reference value="Patient/UKCore-RichardSmith-Patient-Example" />
+    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
   </patient>
   <encounter>
     <reference value="Encounter/UKCore-Encounter-InpatientEncounter-Example" />

--- a/examples/UKCore-AllergyIntolerance-Extension-Evidence-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Extension-Evidence-Example.xml
@@ -28,7 +28,7 @@
 		</coding>
 	</code>
 	<patient>
-		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
 	</patient>
 	<encounter>
 		<reference value="Encounter/UKCore-Encounter-InpatientEncounter-Example"/>

--- a/examples/UKCore-AllergyIntolerance-Sn-DrugAllergy-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-DrugAllergy-Example.xml
@@ -25,6 +25,6 @@
 	</code>
 	<!-- **************Snippet end************** -->
 	<patient>
-		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
 	</patient>
 </AllergyIntolerance>

--- a/examples/UKCore-AllergyIntolerance-Sn-DrugAllergyToEggProtein-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-DrugAllergyToEggProtein-Example.xml
@@ -25,6 +25,6 @@
 	</code>
 	<!-- **************Snippet end************** -->
 	<patient>
-		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
 	</patient>
 </AllergyIntolerance>

--- a/examples/UKCore-AllergyIntolerance-Sn-NegHandlNoKnownAllergies-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-NegHandlNoKnownAllergies-Example.xml
@@ -24,6 +24,6 @@
 	</code>
 	<!-- **************Snippet end************** -->
 	<patient>
-		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
 	</patient>
 </AllergyIntolerance>

--- a/examples/UKCore-AllergyIntolerance-Sn-NonDrugAllergy-Example.xml
+++ b/examples/UKCore-AllergyIntolerance-Sn-NonDrugAllergy-Example.xml
@@ -25,6 +25,6 @@
 	</code>
 	<!-- **************Snippet end************** -->
 	<patient>
-		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
 	</patient>
 </AllergyIntolerance>

--- a/examples/UKCore-VitalSigns-Observation-OxygenSaturation-Example.xml
+++ b/examples/UKCore-VitalSigns-Observation-OxygenSaturation-Example.xml
@@ -25,7 +25,7 @@
 		</coding>
 	</code>
 	<subject>
-		<reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
 	</subject>
 	<effectiveDateTime value="2018-10-04T14:17:59+01:00"/>
 	<performer>


### PR DESCRIPTION
Fix 1.0.0 patient references

from <reference value="Patient/UKCore-RichardSmith-Patient-Example"/>
to <reference value="Patient/UKCore-Patient-RichardSmith-Example"/>