### PR TITLE
Added source and date of latest expansion

### DIFF
--- a/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.xml
+++ b/codesystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.xml
@@ -1,11 +1,11 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
 	<id value="UKCore-NHSNumberVerificationStatusEngland"/>
 	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland"/>
-	<version value="1.0.0" />
+	<version value="1.1.0" />
 	<name value="UKCoreNHSNumberVerificationStatusEngland"/>
 	<title value="UK Core NHS Number Verification Status England"/>
 	<status value="active" />
-	<date value="2022-08-26" />
+	<date value="2022-12-16" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />
@@ -25,7 +25,7 @@
 			<rank value="2" />
 		</telecom>
 	</contact>
-	<description value="A CodeSystem for England that identifies the trace status of an NHS Number with respect to a national source of NHS Numbers."/>
+	<description value="A CodeSystem for England that identifies the trace status of an NHS Number with respect to a national source of NHS Numbers. These codes and their descriptions represent concepts used in England and are copied from the content of the NHS Data Dictionary NHS number status indicator code web page at https://www.datadictionary.nhs.uk/data_elements/nhs_number_status_indicator_code.html on 22/12/2022."/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<caseSensitive value="true"/>
 	<content value="complete"/>
@@ -61,5 +61,4 @@
 		<code value="08"/>
 		<display value="Trace postponed (baby under six weeks old)"/>
 	</concept>
-	
 </CodeSystem>


### PR DESCRIPTION
As per jira ticket, Data Model Dictionary related codesystems were checked for differences, NHSNumberVerificationStatusEngland was found not to have a source of data or expansion date listed