### PR TITLE
Fixed system url for ukcore codesystem pointing at nhs.uk

### DIFF
--- a/valuesets/ValueSet-UKCore-ConditionEpisodicity.xml
+++ b/valuesets/ValueSet-UKCore-ConditionEpisodicity.xml
@@ -1,32 +1,32 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-ConditionEpisodicity"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ConditionEpisodicity"/>
-	<version value="2.1.0"/>
+	<version value="2.2.0"/>
 	<name value="UKCoreConditionEpisodicity"/>
 	<title value="UK Core Condition Episodicity"/>
-	<status value="active" />
-	<date value="2022-01-07" />
-	<publisher value="HL7 UK" />
+	<status value="active"/>
+	<date value="2022-12-16"/>
+	<publisher value="HL7 UK"/>
 	<contact>
-		<name value="HL7 UK" />
+		<name value="HL7 UK"/>
 		<telecom>
-			<system value="email" />
-			<value value="secretariat@hl7.org.uk" />
-			<use value="work" />
-			<rank value="1" />
+			<system value="email"/>
+			<value value="secretariat@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
 		</telecom>
 	</contact>
 	<contact>
-		<name value="NHS Digital" />
+		<name value="NHS Digital"/>
 		<telecom>
-			<system value="email" />
-			<value value="interoperabilityteam@nhs.net" />
-			<use value="work" />
-			<rank value="2" />
+			<system value="email"/>
+			<value value="interoperabilityteam@nhs.net"/>
+			<use value="work"/>
+			<rank value="2"/>
 		</telecom>
 	</contact>
 	<description value="A set of codes that define the episodicity of a condition."/>
-	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<compose>
 		<include>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity"/>
@@ -34,38 +34,26 @@
 	</compose>
 	<expansion>
 		<identifier value="7a8d1bd2-f0f6-4fb6-879b-a1195833a329"/>
-		<timestamp value="2022-01-07T11:32:50+00:00"/>
+		<timestamp value="2022-12-22T15:29:10+00:00"/>
 		<total value="4"/>
 		<offset value="0"/>
-		<parameter>
-			<name value="version"/>
-			<valueUri value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ConditionEpisodicity|2.1.0"/>
-		</parameter>
-		<parameter>
-			<name value="count"/>
-			<valueInteger value="2147483647"/>
-		</parameter>
-		<parameter>
-			<name value="offset"/>
-			<valueInteger value="0"/>
-		</parameter>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ConditionEpisodicity"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity"/>
 			<code value="end"/>
 			<display value="End"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ConditionEpisodicity"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity"/>
 			<code value="first"/>
 			<display value="First"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ConditionEpisodicity"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity"/>
 			<code value="new"/>
 			<display value="New"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ConditionEpisodicity"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity"/>
 			<code value="review"/>
 			<display value="Review"/>
 		</contains>

--- a/valuesets/ValueSet-UKCore-ListWarningCode.xml
+++ b/valuesets/ValueSet-UKCore-ListWarningCode.xml
@@ -1,32 +1,32 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-ListWarningCode"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ListWarningCode"/>
-	<version value="2.1.0"/>
+	<version value="2.2.0"/>
 	<name value="UKCoreListWarningCode"/>
 	<title value="UK Core List Warning Code"/>
-	<status value="active" />
-	<date value="2022-01-07" />
-	<publisher value="HL7 UK" />
+	<status value="active"/>
+	<date value="2022-12-16"/>
+	<publisher value="HL7 UK"/>
 	<contact>
-		<name value="HL7 UK" />
+		<name value="HL7 UK"/>
 		<telecom>
-			<system value="email" />
-			<value value="secretariat@hl7.org.uk" />
-			<use value="work" />
-			<rank value="1" />
+			<system value="email"/>
+			<value value="secretariat@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
 		</telecom>
 	</contact>
 	<contact>
-		<name value="NHS Digital" />
+		<name value="NHS Digital"/>
 		<telecom>
-			<system value="email" />
-			<value value="interoperabilityteam@nhs.net" />
-			<use value="work" />
-			<rank value="2" />
+			<system value="email"/>
+			<value value="interoperabilityteam@nhs.net"/>
+			<use value="work"/>
+			<rank value="2"/>
 		</telecom>
 	</contact>
 	<description value="A set of codes that define the reason a list may be incomplete."/>
-	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<compose>
 		<include>
 			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ListWarningCode"/>
@@ -34,33 +34,21 @@
 	</compose>
 	<expansion>
 		<identifier value="8879d362-e498-43dd-8e29-d59ac1d05bf3"/>
-		<timestamp value="2022-01-07T13:40:18+00:00"/>
+		<timestamp value="2022-12-22T15:31:11+00:00"/>
 		<total value="3"/>
 		<offset value="0"/>
-		<parameter>
-			<name value="version"/>
-			<valueUri value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ListWarningCode|2.1.0"/>
-		</parameter>
-		<parameter>
-			<name value="count"/>
-			<valueInteger value="2147483647"/>
-		</parameter>
-		<parameter>
-			<name value="offset"/>
-			<valueInteger value="0"/>
-		</parameter>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ListWarningCode"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ListWarningCode"/>
 			<code value="confidential-items"/>
 			<display value="Confidential Items"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ListWarningCode"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ListWarningCode"/>
 			<code value="data-awaiting-filing"/>
 			<display value="Data Awaiting Filing"/>
 		</contains>
 		<contains>
-			<system value="https://fhir.nhs.uk/R4/CodeSystem/UKCore-ListWarningCode"/>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ListWarningCode"/>
 			<code value="data-in-transit"/>
 			<display value="Data in Transit"/>
 		</contains>


### PR DESCRIPTION
Checks on 1.0.0 highlighted 2 valusets with ukcore codesystems, where the expansion contained references to fhir.nhs.uk

Both valusets updated with fresh expansions