### PR TITLE
Updated version, status, date, description and references to uk core profiles

### DIFF
--- a/structuredefinitions/UKCore-Consent.xml
+++ b/structuredefinitions/UKCore-Consent.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Consent" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Consent" />
-  <version value="2.2.0" />
+  <version value="2.3.0" />
   <name value="UKCoreConsent" />
   <title value="UK Core Consent" />
-  <status value="draft" />
-  <date value="2022-12-16" />
+  <status value="active" />
+  <date value="2023-02-14" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -18,7 +18,11 @@
     </telecom>
   </contact>
   <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Consent](https://hl7.org/fhir/R4/Consent.html)." />
-  <purpose value="The purpose of this profile is to be used to express a Consent regarding Healthcare. There are four anticipated uses for the Consent Resource, all of which are written or verbal agreements by a healthcare consumer [grantor] or a personal representative, made to an authorised entity [grantee] concerning authorised or restricted actions with any limitations on purpose of use, and handling instructions to which the authorised entity SHALL comply:&#xD;&#xA; · Privacy Consent Directive: Agreement to collect, access, use or disclose (share) information.&#xD;&#xA; · Medical Treatment Consent Directive: Consent to undergo a specific treatment (or record of refusal to consent).&#xD;&#xA; · Research Consent Directive: Consent to participate in research protocol and information sharing required.&#xD;&#xA; · Advance Care Directives: Consent to instructions for potentially needed medical treatment (e.g. DNR)." />
+  <purpose value="The purpose of this profile is to be used to express a Consent regarding Healthcare. There are four anticipated uses for the Consent Resource, all of which are written or verbal agreements by a healthcare consumer [grantor] or a personal representative, made to an authorised entity [grantee] concerning authorised or restricted actions with any limitations on purpose of use, and handling instructions to which the authorised entity SHALL comply:
+&#xD;&#xA;- **Privacy Consent Directive**: Agreement to collect, access, use or disclose (share) information.
+&#xD;&#xA;- **Medical Treatment Consent Directive**: Consent to undergo a specific treatment (or record of refusal to consent).
+&#xD;&#xA;- **Research Consent Directive**: Consent to participate in research protocol and information sharing required.
+&#xD;&#xA;- **Advance Care Directives**: Consent to instructions for potentially needed medical treatment (e.g. DNR)." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>
@@ -86,9 +90,9 @@
       </type>
       <type>
         <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DocumentReference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Contract" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Consent" />
       </type>
     </element>
@@ -104,9 +108,9 @@
       <path value="Consent.provision.actor.reference" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CareTeam" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CareTeam" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />


### PR DESCRIPTION
On producing IG page, noticed the description didn't list / format correctly, and there were missing references to uk core profiles