### PR TITLE
Rest cta6 profiles to draft

### DIFF
--- a/structuredefinitions/UKCore-Consent.xml
+++ b/structuredefinitions/UKCore-Consent.xml
@@ -5,7 +5,7 @@
   <version value="2.3.0" />
   <name value="UKCoreConsent" />
   <title value="UK Core Consent" />
-  <status value="active" />
+  <status value="draft" />
   <date value="2023-02-14" />
   <publisher value="HL7 UK" />
   <contact>

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -5,7 +5,7 @@
   <version value="2.2.0" />
   <name value="UKCoreDiagnosticReport" />
   <title value="UK Core DiagnosticReport" />
-  <status value="active" />
+  <status value="draft" />
   <date value="2023-02-14" />
   <publisher value="HL7 UK" />
   <contact>


### PR DESCRIPTION
I jumped the gun on setting the CTA6 profiles I'd updated to active, resetting them to draft

No date/version change needed as already uplifted for cta6