### PR TITLE
Snomed CT filter is missing OR

### DIFF
--- a/valuesets/ValueSet-UKCore-ACVPU.xml
+++ b/valuesets/ValueSet-UKCore-ACVPU.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="UKCore-ACVPU"/>
    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ACVPU"/>
-   <version value="2.0.0"/>
+   <version value="2.1.0"/>
    <name value="UKCoreACVPU"/>
    <title value="UK Core ACVPU"/>
    <status value="draft" />
-   <date value="2021-09-10" />
+   <date value="2023-02-14" />
    <publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />
@@ -24,7 +24,7 @@
          <filter>
             <property value="constraint"/>
             <op value="="/>
-            <value value="(248234008 |Mentally alert| OR 300202002 |Responds to voice| OR 450847001 |Responds to pain| OR 422768004 |Unresponsive| 130987000 |Acute confusion|)"/>
+            <value value="(248234008 |Mentally alert| OR 300202002 |Responds to voice| OR 450847001 |Responds to pain| OR 422768004 |Unresponsive| OR 130987000 |Acute confusion|)"/>
          </filter>
       </include>
    </compose>

--- a/valuesets/ValueSet-UKCore-ACVPU.xml
+++ b/valuesets/ValueSet-UKCore-ACVPU.xml
@@ -16,9 +16,7 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system.
-
-&#13;SNOMED CT filtered to the following concepts:
+	<description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
 &#13; - 248234008 | Mentally alert
 &#13; - 300202002 | Responds to voice
 &#13; - 450847001 | Responds to pain

--- a/valuesets/ValueSet-UKCore-ACVPU.xml
+++ b/valuesets/ValueSet-UKCore-ACVPU.xml
@@ -1,31 +1,69 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-   <id value="UKCore-ACVPU"/>
-   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ACVPU"/>
-   <version value="2.1.0"/>
-   <name value="UKCoreACVPU"/>
-   <title value="UK Core ACVPU"/>
-   <status value="draft" />
-   <date value="2023-02-14" />
-   <publisher value="HL7 UK" />
+	<id value="UKCore-ACVPU"/>
+	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ACVPU"/>
+	<version value="2.1.0"/>
+	<name value="UKCoreACVPU"/>
+	<title value="UK Core ACVPU"/>
+	<status value="draft"/>
+	<date value="2023-02-14"/>
+	<publisher value="HL7 UK"/>
 	<contact>
-		<name value="HL7 UK" />
+		<name value="HL7 UK"/>
 		<telecom>
-			<system value="email" />
-			<value value="ukcore@hl7.org.uk" />
-			<use value="work" />
-			<rank value="1" />
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
 		</telecom>
 	</contact>
-   <description value="A code from the SNOMED Clinical Terminology UK coding system which describes whether a patient is mentally alert, unresponsive, responds to voice, responds to pain or is acutely confused."/>
-  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-   <compose>
-      <include>
-         <system value="http://snomed.info/sct"/>
-         <filter>
-            <property value="constraint"/>
-            <op value="="/>
-            <value value="(248234008 |Mentally alert| OR 300202002 |Responds to voice| OR 450847001 |Responds to pain| OR 422768004 |Unresponsive| OR 130987000 |Acute confusion|)"/>
-         </filter>
-      </include>
-   </compose>
+	<description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system.
+
+&#13;SNOMED CT filtered to the following concepts:
+&#13; - 248234008 | Mentally alert
+&#13; - 300202002 | Responds to voice
+&#13; - 450847001 | Responds to pain
+&#13; - 422768004 | Unresponsive
+&#13; - 130987000 | Acute confusion"/>
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<compose>
+		<include>
+			<system value="http://snomed.info/sct"/>
+			<filter>
+				<property value="constraint"/>
+				<op value="="/>
+				<value value="(248234008 OR 300202002 OR 450847001 OR 422768004 OR 130987000)"/>
+			</filter>
+		</include>
+	</compose>
+	<expansion>
+		<identifier value="6c36caea-57d1-42a7-8621-ae1addc67581"/>
+		<timestamp value="2023-01-20T10:50:41+00:00"/>
+		<total value="5"/>
+		<offset value="0"/>
+		<contains>
+			<system value="http://snomed.info/sct"/>
+			<code value="130987000"/>
+			<display value="Acute confusion"/>
+		</contains>
+		<contains>
+			<system value="http://snomed.info/sct"/>
+			<code value="248234008"/>
+			<display value="Mentally alert"/>
+		</contains>
+		<contains>
+			<system value="http://snomed.info/sct"/>
+			<code value="450847001"/>
+			<display value="Responds to pain"/>
+		</contains>
+		<contains>
+			<system value="http://snomed.info/sct"/>
+			<code value="300202002"/>
+			<display value="Responds to voice"/>
+		</contains>
+		<contains>
+			<system value="http://snomed.info/sct"/>
+			<code value="422768004"/>
+			<display value="Unresponsive"/>
+		</contains>
+	</expansion>
 </ValueSet>


### PR DESCRIPTION
LOW PRIORITY

https://nhsd-jira.digital.nhs.uk/browse/IOPS-1074

Issue raised on simplifier - valueset is draft, unused, and could probably be retired as its contents exist in another, but the filter IS wrong

Updated description to be inline with valueset design approach, but testing a new way of displaying the filter (list of: - concept | term)
Removed |term| on the include filter concepts, as per guidance (systems may not be able to understand the pipe)
Added expansion of the filter
Pretty print