### PR TITLE
CHINumber patient example

### DIFF
--- a/examples/UKCore-Patient-CHINumber-Example.xml
+++ b/examples/UKCore-Patient-CHINumber-Example.xml
@@ -1,0 +1,31 @@
+<Patient xmlns="http://hl7.org/fhir">
+	<id value="UKCore-Patient-CHINumber-Example"/>
+	<identifier>
+		<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus">
+			<valueCodeableConcept>
+				<coding>
+					<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
+					<code value="NI"/>
+					<display value="NoInformation"/>
+				</coding>
+			</valueCodeableConcept>
+		</extension>
+		<system value="https://fhir.nhs.uk/Id/chi-number"/>
+		<value value="0402568877"/>
+	</identifier>
+	<name>
+		<use value="official"/>
+		<given value="David"/>
+		<family value="McDonald"/>
+	</name>
+	<gender value="male"/>
+	<communication>
+		<language>
+			<coding>
+				<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-HumanLanguage"/>
+				<code value="en"/>
+				<display value="English"/>
+			</coding>
+		</language>
+	</communication>
+</Patient>

--- a/examples/UKCore-Patient-CHINumber-Example.xml
+++ b/examples/UKCore-Patient-CHINumber-Example.xml
@@ -1,15 +1,6 @@
 <Patient xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Patient-CHINumber-Example"/>
 	<identifier>
-		<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus">
-			<valueCodeableConcept>
-				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
-					<code value="NI"/>
-					<display value="NoInformation"/>
-				</coding>
-			</valueCodeableConcept>
-		</extension>
 		<system value="https://fhir.nhs.uk/Id/chi-number"/>
 		<value value="0402568877"/>
 	</identifier>

--- a/examples/UKCore-Patient-CHINumber-Example.xml
+++ b/examples/UKCore-Patient-CHINumber-Example.xml
@@ -1,7 +1,7 @@
 <Patient xmlns="http://hl7.org/fhir">
 	<id value="UKCore-Patient-CHINumber-Example"/>
 	<identifier>
-		<system value="https://fhir.nhs.uk/Id/chi-number"/>
+		<system value="urn:oid:2.16.840.1.113883.2.1.3.2.4.16.53"/>
 		<value value="0402568877"/>
 	</identifier>
 	<name>


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/IOPS-1089

We removed the inline CHI Number snippet from MedStatement.subject in 1.0.0, and didn't turn it into a full snippet. This adds a chi number example back into the project