### PR TITLE
Fix min value on value[x], and missing assigner references

### DIFF
--- a/structuredefinitions/Extension-UKCore-ActualProblem.xml
+++ b/structuredefinitions/Extension-UKCore-ActualProblem.xml
@@ -49,6 +49,7 @@
       <path value="Extension.value[x]" />
       <short value="A reference to a resource that is the actual problem." />
       <definition value="A reference to a resource that is the actual problem." />
+      <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance" />

--- a/structuredefinitions/Extension-UKCore-AssociatedEncounter.xml
+++ b/structuredefinitions/Extension-UKCore-AssociatedEncounter.xml
@@ -44,13 +44,21 @@
     </element>
     <element id="Extension.url">
       <path value="Extension.url" />
-      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ExtensionUKCoreAssociatedEncounter" />
+      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AssociatedEncounter" />
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
+      <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter" />
+      </type>
+    </element>
+    <element id="Extension.value[x].identifier.assigner">
+      <path value="Extension.value[x].identifier.assigner" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
   </differential>

--- a/structuredefinitions/Extension-UKCore-BookingOrganization.xml
+++ b/structuredefinitions/Extension-UKCore-BookingOrganization.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-BookingOrganization" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BookingOrganization" />
-  <version value="1.1.0" />
+  <version value="1.2.0" />
   <name value="ExtensionUKCoreBookingOrganization" />
   <title value="Extension UK Core Booking Organization" />
   <status value="active" />
-  <date value="2022-05-20" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -50,6 +50,7 @@
       <path value="Extension.value[x]" />
       <short value="The organisation booking the appointment" />
       <definition value="The organisation booking the appointment." />
+      <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />

--- a/structuredefinitions/Extension-UKCore-DeliveryChannel.xml
+++ b/structuredefinitions/Extension-UKCore-DeliveryChannel.xml
@@ -53,6 +53,7 @@
 			<path value="Extension.value[x]"/>
 			<short value="A code that identifies the delivery channel of an appointment"/>
 			<definition value="A code that identifies the delivery channel of an appointment."/>
+			<min value="1" />
 			<type>
 				<code value="code"/>
 			</type>

--- a/structuredefinitions/Extension-UKCore-EncounterTransport.xml
+++ b/structuredefinitions/Extension-UKCore-EncounterTransport.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-EncounterTransport" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EncounterTransport" />
-  <version value="2.0.0" />
+  <version value="2.1.0" />
   <name value="ExtensionUKCoreEncounterTransport" />
   <title value="Extension UK Core Encounter Transport" />
   <status value="retired" />
-  <date value="2022-01-07" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -69,6 +69,7 @@
       <path value="Extension.extension.value[x]" />
       <short value="The type of transport used" />
       <definition value="The type of transport used." />
+      <min value="1" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -89,6 +90,7 @@
       <path value="Extension.extension.value[x]" />
       <short value="Period of time during which the transport was used" />
       <definition value="Period of time during which the transport was used." />
+      <min value="1" />
       <type>
         <code value="Period" />
       </type>
@@ -109,6 +111,7 @@
       <path value="Extension.extension.value[x]" />
       <short value="The reason the transport was needed" />
       <definition value="The reason the transport was needed." />
+      <min value="1" />
       <type>
         <code value="string" />
       </type>

--- a/structuredefinitions/Extension-UKCore-LegalStatus.xml
+++ b/structuredefinitions/Extension-UKCore-LegalStatus.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-LegalStatus" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-LegalStatus" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="ExtensionUKCoreLegalStatus" />
   <title value="Extension UK Core Legal Status" />
   <status value="active" />
-  <date value="2022-01-07" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -63,6 +63,7 @@
       <path value="Extension.extension.value[x]" />
       <short value="The context in which a mental health legal status is being used." />
       <definition value="The context in which a mental health legal status is being used." />
+      <min value="1" />
       <type>
         <code value="CodeableConcept" />
       </type>
@@ -87,6 +88,7 @@
     <element id="Extension.extension:legalStatusClassification.value[x]">
       <path value="Extension.extension.value[x]" />
       <short value="Codes that define the classification of a patient's legal status" />
+      <min value="1" />
       <type>
         <code value="CodeableConcept" />
       </type>

--- a/structuredefinitions/Extension-UKCore-ProblemSignificance.xml
+++ b/structuredefinitions/Extension-UKCore-ProblemSignificance.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-ProblemSignificance" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ProblemSignificance" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="ExtensionUKCoreProblemSignificance" />
   <title value="Extension UK Core Problem Significance" />
   <status value="active" />
-  <date value="2022-01-07" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -48,6 +48,7 @@
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
       <short value="Describes the significance of a Condition that is a Problem Header." />
+      <min value="1" />
       <type>
         <code value="code" />
       </type>

--- a/structuredefinitions/Extension-UKCore-Recorder.xml
+++ b/structuredefinitions/Extension-UKCore-Recorder.xml
@@ -47,11 +47,19 @@
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />
+      <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson" />
+      </type>
+    </element>
+    <element id="Extension.value[x].identifier.assigner">
+      <path value="Extension.value[x].identifier.assigner" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
   </differential>

--- a/structuredefinitions/Extension-UKCore-RelatedClinicalContent.xml
+++ b/structuredefinitions/Extension-UKCore-RelatedClinicalContent.xml
@@ -49,6 +49,7 @@
 			<path value="Extension.value[x]"/>
 			<short value="A reference to any resource that provides related clinical content to the Condition."/>
 			<definition value="A reference to any resource that provides related clinical content to the Condition."/>
+			<min value="1" />
 			<type>
 				<code value="Reference"/>
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource"/>

--- a/structuredefinitions/Extension-UKCore-RelatedProblemHeader.xml
+++ b/structuredefinitions/Extension-UKCore-RelatedProblemHeader.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-RelatedProblemHeader" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RelatedProblemHeader" />
-  <version value="1.1.0" />
+  <version value="1.2.0" />
   <name value="ExtensionUKCoreRelatedProblemHeader" />
   <title value="Extension UK Core Related Problem Header" />
   <status value="active" />
-  <date value="2022-03-01" />
+  <date value="2022-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -69,6 +69,7 @@
       <path value="Extension.extension.value[x]" />
       <short value="Condition relationship type." />
       <definition value="Condition relationship type." />
+      <min value="1" />
       <type>
         <code value="code" />
       </type>
@@ -92,6 +93,7 @@
       <path value="Extension.extension.value[x]" />
       <short value="Target problem header condition." />
       <definition value="Target problem header condition." />
+      <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition" />


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/IOPS-1134 and https://nhsd-jira.digital.nhs.uk/browse/IOPS-1135

Coming out of Ryans DesignApproach meeting, we had a few extensions without min value =1 on value[x]

In fixing those, I noticed a couple of extensions had not got identifer.assigner referencing ukcore-org
And duff url for an extension (draft, url doesn't match name)