### PR TITLE
Fix for specimen SNOMED valuesets to bring in line with design approach

### DIFF
--- a/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
@@ -16,7 +16,9 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-	<description value="A code from the SNOMED Clinical Terminology UK coding system to record a specimen body site."/>
+	<description value="A set of codes to record a specimen body site. Selected from the following SNOMED CT UK coding system:
+&#13; - descendantOf 442083009 | Anatomical or acquired body structure
+&#13; - descendantOf 49755003 | Morphologically abnormal structure"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>
@@ -24,7 +26,7 @@
 			<filter>
 				<property value="constraint"/>
 				<op value="="/>
-				<value value="(&lt; 442083009 |Anatomical or acquired body structure| OR &lt; 49755003 |Morphologically abnormal structure|)"/>
+				<value value="(descendantOf 442083009 OR descendantOf 49755003)"/>
 			</filter>
 		</include>
 	</compose>

--- a/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-SpecimenBodySite"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite"/>
-	<version value="2.0.0"/>
+	<version value="2.1.0"/>
 	<name value="UKCoreSpecimenBodySite"/>
 	<title value="UK Core Specimen Body Site"/>
 	<status value="draft" />
-	<date value="2021-09-10" />
+	<date value="2023-02-14" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
@@ -17,7 +17,7 @@
 		</telecom>
 	</contact>
 	<description value="A set of codes to record a specimen body site. Selected from the following SNOMED CT UK coding system:
-&#13; - descendantOf 442083009 | Anatomical or acquired body structure
+&#13; - descendantOf 442083009 | Anatomical or acquired body structure, or
 &#13; - descendantOf 49755003 | Morphologically abnormal structure"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>

--- a/valuesets/ValueSet-UKCore-SpecimenType.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenType.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-SpecimenType"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenType"/>
-	<version value="2.1.0"/>
+	<version value="2.2.0"/>
 	<name value="UKCoreSpecimenType"/>
 	<title value="UK Core Specimen Type"/>
 	<status value="draft" />
-	<date value="2022-08-26" />
+	<date value="2023-02-14" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-SpecimenType.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenType.xml
@@ -16,7 +16,10 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-	<description value="A code from the SNOMED Clinical Terminology UK coding system to record a specimen type."/>
+	<description value="A set of codes to record a specimen type. Selected from the following SNOMED CT UK coding system:
+&#13; - descendantOf 105590001 | Substance
+&#13; - descendantOf 49755003 | Morphologically abnormal structure
+&#13; - descendantOf 260787004 | Physical object"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>
@@ -24,7 +27,7 @@
 			<filter>
 				<property value="constraint"/>
 				<op value="="/>
-				<value value="(&lt;105590001 |Substance (in which case method and site SHOULD also be populated)|OR &lt;49755003 |Morphologically abnormal structure|OR &lt; 260787004 |Physical object|)"/>
+				<value value="(descendantOf 105590001 OR descendantOf 49755003 OR descendantOf 260787004)"/>
 			</filter>
 		</include>
 	</compose>

--- a/valuesets/ValueSet-UKCore-SpecimenType.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenType.xml
@@ -17,8 +17,8 @@
 		</telecom>
 	</contact>
 	<description value="A set of codes to record a specimen type. Selected from the following SNOMED CT UK coding system:
-&#13; - descendantOf 105590001 | Substance
-&#13; - descendantOf 49755003 | Morphologically abnormal structure
+&#13; - descendantOf 105590001 | Substance, or
+&#13; - descendantOf 49755003 | Morphologically abnormal structure, or
 &#13; - descendantOf 260787004 | Physical object"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>


### PR DESCRIPTION
Minor tweaks to description and filtering on the 2 Specimen related valuesets for sprint 6, in line with design approach ig.

Updated date and version to be in line with other pre sprint 6 changes