### PR TITLE
added backport ref

### DIFF
--- a/structuredefinitions/Extension-UKCore-BodySiteReference.xml
+++ b/structuredefinitions/Extension-UKCore-BodySiteReference.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference" />
+  <version value="1.0.0" />
+  <name value="Extension-UKCore-BodySiteReference" />
+  <status value="active" />
+  <date value="2023-04-28" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="An extension to replicate the changes within R5 allowing the data type of Specimen.collection.bodySite to act as a CodeableReference (bodyStructure)." />
+  <purpose value="Allowing the referencing to bodyStructure" />
+  <copyright value="Copyright &amp;#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &amp;quot;License&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&amp;#174; FHIR&amp;#174; standard Copyright &amp;#169; 2011+ HL7 The HL7&amp;#174; FHIR&amp;#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="Specimen.collection.bodySite" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="An extension to allow the referencing to BodyStructure" />
+      <definition value="An extension to replicate the changes within R5 altering the data type of Specimen.collection.bodySite from CodeableConcept to CodeableReference (bodyStructure)." />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodyStructure" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-BodySiteReference.xml
+++ b/structuredefinitions/Extension-UKCore-BodySiteReference.xml
@@ -15,7 +15,7 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="An extension to replicate the changes within R5 allowing the data type of Specimen.collection.bodySite to act as a CodeableReference (bodyStructure)." />
+  <description value="An extension to replicate the changes within R5 allowing the data type of Specimen.collection.bodySite to act as a CodeableReference (BodyStructure)." />
   <purpose value="Allowing the referencing to bodyStructure" />
   <copyright value="Copyright &amp;#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &amp;quot;License&amp;quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&amp;#174; FHIR&amp;#174; standard Copyright &amp;#169; 2011+ HL7 The HL7&amp;#174; FHIR&amp;#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />

--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -19,7 +19,7 @@
   </contact>
   <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Specimen](https://hl7.org/fhir/R4/Specimen.html)." />
   <purpose value="This profile allows exchange of information about a sample to be used for analysis." />
-  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -125,6 +125,28 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
+    <element id="Specimen.collection.bodySite.extension">
+      <path value="Specimen.collection.bodySite.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="0" />
+    </element>
+    <element id="Specimen.collection.bodySite.extension:myExtension">
+      <path value="Specimen.collection.bodySite.extension" />
+      <sliceName value="myExtension" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference" />
+      </type>
+      <isModifier value="false" />
+    </element>
     <element id="Specimen.collection.bodySite.coding">
       <path value="Specimen.collection.bodySite.coding" />
       <slicing>
@@ -155,9 +177,6 @@
       <min value="1" />
     </element>
     <element id="Specimen.collection.bodySite.coding:snomedCT.display">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
       <path value="Specimen.collection.bodySite.coding.display" />
       <min value="1" />
     </element>

--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -132,6 +132,28 @@
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite" />
       </binding>
     </element>
+    <element id="Specimen.collection.bodySite.extension">
+      <path value="Specimen.collection.bodySite.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="0" />
+    </element>
+    <element id="Specimen.collection.bodySite.extension:bodySiteReference">
+      <path value="Specimen.collection.bodySite.extension" />
+      <sliceName value="bodySiteReference" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference" />
+      </type>
+      <isModifier value="false" />
+    </element>
     <element id="Specimen.processing.additive.identifier.assigner">
       <path value="Specimen.processing.additive.identifier.assigner" />
       <type>

--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -177,6 +177,9 @@
       <min value="1" />
     </element>
     <element id="Specimen.collection.bodySite.coding:snomedCT.display">
+      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
+        <valueBoolean value="true" />
+      </extension>
       <path value="Specimen.collection.bodySite.coding.display" />
       <min value="1" />
     </element>

--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -136,9 +136,9 @@
       </slicing>
       <min value="0" />
     </element>
-    <element id="Specimen.collection.bodySite.extension:BodySiteReference">
+    <element id="Specimen.collection.bodySite.extension:bodySiteReference">
       <path value="Specimen.collection.bodySite.extension" />
-      <sliceName value="BodySiteReference" />
+      <sliceName value="bodySiteReference" />
       <min value="0" />
       <max value="1" />
       <type>

--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -136,9 +136,9 @@
       </slicing>
       <min value="0" />
     </element>
-    <element id="Specimen.collection.bodySite.extension:myExtension">
+    <element id="Specimen.collection.bodySite.extension:BodySiteReference">
       <path value="Specimen.collection.bodySite.extension" />
-      <sliceName value="myExtension" />
+      <sliceName value="BodySiteReference" />
       <min value="0" />
       <max value="1" />
       <type>


### PR DESCRIPTION
>The FHIR R5 snapshot of the [Specimen](https://hl7.org/fhir/5.0.0-snapshot3/Specimen.html) resource, has a change to >Specimen.collection.bodySite, altering the data type of the element from CodeableConcept to CodeableReference >(BodyStructure).

>Genomics have a use case for referencing the BodyStructure. 	

>Backport the R5 functionality as a new extension: Extension-UKCore-BodySiteReference