### PR TITLE
removed collection.bodySite slice. Moved ValueSet

### DIFF
--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -19,7 +19,7 @@
   </contact>
   <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Specimen](https://hl7.org/fhir/R4/Specimen.html)." />
   <purpose value="This profile allows exchange of information about a sample to be used for analysis." />
-  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -125,41 +125,12 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
-    <element id="Specimen.collection.bodySite.coding">
-      <path value="Specimen.collection.bodySite.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Specimen.collection.bodySite.coding:snomedCT">
-      <path value="Specimen.collection.bodySite.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
+    <element id="Specimen.collection.bodySite">
+      <path value="Specimen.collection.bodySite" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED UK Clinical Terminology coding system" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite" />
       </binding>
-    </element>
-    <element id="Specimen.collection.bodySite.coding:snomedCT.system">
-      <path value="Specimen.collection.bodySite.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="Specimen.collection.bodySite.coding:snomedCT.code">
-      <path value="Specimen.collection.bodySite.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="Specimen.collection.bodySite.coding:snomedCT.display">
-      <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable">
-        <valueBoolean value="true" />
-      </extension>
-      <path value="Specimen.collection.bodySite.coding.display" />
-      <min value="1" />
     </element>
     <element id="Specimen.processing.additive.identifier.assigner">
       <path value="Specimen.processing.additive.identifier.assigner" />


### PR DESCRIPTION
>The draft UKCore-Specimen profile, has an open slice on element Specimen.collection.bodySite, snomedCT, bound to >[ValueSet UKCore-SpecimenBodySite](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence>/Home/Terminology/AllValueSets/ValueSet-UKCore-SpecimenBodySite?version=1.6.0) (preferred).
>
>The origins of this slice are from the FHIR STU3 CareConnect Specimen profile, and the now retired Extension-UKCore-CodingSCTDescId.
>
>    Remove the slice
>    Bind Specimen.collection.bodySite to [ValueSet UKCore-SpecimenBodySite](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-SpecimenBodySite?version=1.6.0) (preferred)