### PR TITLE
removed slice from category.coding

### DIFF
--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -202,4 +202,3 @@
     </element>
   </differential>
 </StructureDefinition>
-</StructureDefinition>

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -72,33 +72,6 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
-    <element id="DiagnosticReport.category.coding">
-      <path value="DiagnosticReport.category.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="DiagnosticReport.category.coding:snomedCT">
-      <path value="DiagnosticReport.category.coding" />
-      <sliceName value="snomedCT" />
-    </element>
-    <element id="DiagnosticReport.category.coding:snomedCT.system">
-      <path value="DiagnosticReport.category.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="DiagnosticReport.category.coding:snomedCT.code">
-      <path value="DiagnosticReport.category.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="DiagnosticReport.category.coding:snomedCT.display">
-      <path value="DiagnosticReport.category.coding.display" />
-      <min value="1" />
-    </element>
     <element id="DiagnosticReport.code.coding">
       <path value="DiagnosticReport.code.coding" />
       <slicing>


### PR DESCRIPTION
>The draft UKCore-DiagnosticReport profile, has an open slice on element DiagnosticReport.category, snomedCT, with no ValueSet bound.
>
>The origins of this slice are from the FHIR STU3 CareConnect Specimen profile, and the now retired Extension-UKCore-CodingSCTDescId. 