### PR TITLE
removed slice to code, added new binding

### DIFF
--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -99,37 +99,12 @@
       <path value="DiagnosticReport.category.coding.display" />
       <min value="1" />
     </element>
-    <element id="DiagnosticReport.code.coding">
-      <path value="DiagnosticReport.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="DiagnosticReport.code.coding:snomedCT">
-      <path value="DiagnosticReport.code.coding" />
-      <sliceName value="snomedCT" />
+    <element id="DiagnosticReport.code">
+      <path value="DiagnosticReport.code" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED UK Clinical Terminology coding system" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode" />
       </binding>
-    </element>
-    <element id="DiagnosticReport.code.coding:snomedCT.system">
-      <path value="DiagnosticReport.code.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="DiagnosticReport.code.coding:snomedCT.code">
-      <path value="DiagnosticReport.code.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="DiagnosticReport.code.coding:snomedCT.display">
-      <path value="DiagnosticReport.code.coding.display" />
-      <min value="1" />
     </element>
     <element id="DiagnosticReport.subject">
       <path value="DiagnosticReport.subject" />


### PR DESCRIPTION
>The draft UKCore-DiagnosticReport profile, has an open slice on element DiagnosticReport.code, snomedCT, bound to [ValueSet UKCore-ReportCodeSnCT](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-ReportCodeSnCT?version=1.6.0) (preferred).
>
>The origins of this slice are from the FHIR STU3 CareConnect Specimen profile, and the now retired Extension-UKCore-CodingSCTDescId.

Note the ValueSet UKCore-ReportCodeSnCT has now been renamed to UKCore-ReportCode