### PR TITLE
removed slice, changed binding

### DIFF
--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -245,37 +245,12 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
       </type>
     </element>
-    <element id="DiagnosticReport.conclusionCode.coding">
-      <path value="DiagnosticReport.conclusionCode.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="DiagnosticReport.conclusionCode.coding:snomedCT">
-      <path value="DiagnosticReport.conclusionCode.coding" />
-      <sliceName value="snomedCT" />
+    <element id="DiagnosticReport.conclusionCode">
+      <path value="DiagnosticReport.conclusionCode" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED UK Clinical Terminology coding system" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-FindingCode" />
       </binding>
-    </element>
-    <element id="DiagnosticReport.conclusionCode.coding:snomedCT.system">
-      <path value="DiagnosticReport.conclusionCode.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="DiagnosticReport.conclusionCode.coding:snomedCT.code">
-      <path value="DiagnosticReport.conclusionCode.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="DiagnosticReport.conclusionCode.coding:snomedCT.display">
-      <path value="DiagnosticReport.conclusionCode.coding.display" />
-      <min value="1" />
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
>The draft UKCore-DiagnosticReport profile, has an open slice on element DiagnosticReport.conclusionCode, snomedCT, bound to [ValueSet UKCore-FindingCode](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-FindingCode?version=1.6.0) (preferred).
>
>The origins of this slice are from the FHIR STU3 CareConnect Specimen profile, and the now retired Extension-UKCore-CodingSCTDescId.
>
>Remove the slice
>Bind DiagnosticReport.conclusionCode to [ValueSet UKCore-FindingCode](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-FindingCode?version=1.6.0) (preferred)