### PR TITLE
Sprint 6 service req priority reason extension

### DIFF
--- a/structuredefinitions/Extension-UKCore-PriorityReason.xml
+++ b/structuredefinitions/Extension-UKCore-PriorityReason.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="Extension-UKCore-PriorityReason" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
-  <version value="1.0.0" />
-  <name value="ExtensionUKCorePriorityReason" />
-  <title value="Extension UK Core Priority Reason" />
-  <status value="active" />
-  <date value="2023-04-28" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This extension describes the underlying reason why a Service Request is urgent." />
-  <purpose value="This extension extends the Service Request Resource to support the reason why a Service Request is urgent, which is currently not supported by the FHIR standard." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <mapping>
-    <identity value="rim" />
-    <uri value="http://hl7.org/v3" />
-    <name value="RIM Mapping" />
-  </mapping>
-  <kind value="complex-type" />
-  <abstract value="false" />
-  <context>
-    <type value="element" />
-    <expression value="ServiceRequest" />
-  </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Extension">
-      <path value="Extension" />
-      <short value="A SNOMED CT concept representing the reason a Service Request is urgent." />
-      <definition value="A SNOMED CT concept representing the reason a Service Request is urgent" />
-    </element>
-    <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
-    </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]" />
-      <short value="This describes the form in which a service request is sent and received" />
-      <min value="1" />
-      <type>
-        <code value="CodeableConcept" />
-      </type>
-      <binding>
-        <strength value="preferred" />
-        <description value="A set of codes that define the reason why a service request is urgent." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode" />
-      </binding>
-    </element>
-  </differential>
+	<id value="Extension-UKCore-PriorityReason"/>
+	<url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason"/>
+	<version value="1.0.0"/>
+	<name value="ExtensionUKCorePriorityReason"/>
+	<title value="Extension UK Core Priority Reason"/>
+	<status value="active"/>
+	<date value="2023-04-28"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<description value="This extension describes the underlying reason why a Service Request is urgent."/>
+	<purpose value="This extension extends the Service Request Resource to support the reason why a Service Request is urgent, which is currently not supported by the FHIR standard."/>
+	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<fhirVersion value="4.0.1"/>
+	<mapping>
+		<identity value="rim"/>
+		<uri value="http://hl7.org/v3"/>
+		<name value="RIM Mapping"/>
+	</mapping>
+	<kind value="complex-type"/>
+	<abstract value="false"/>
+	<context>
+		<type value="element"/>
+		<expression value="ServiceRequest"/>
+	</context>
+	<type value="Extension"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="Extension">
+			<path value="Extension"/>
+			<short value="A SNOMED CT concept representing the reason a Service Request is urgent."/>
+			<definition value="A SNOMED CT concept representing the reason a Service Request is urgent"/>
+		</element>
+		<element id="Extension.url">
+			<path value="Extension.url"/>
+			<fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason"/>
+		</element>
+		<element id="Extension.value[x]">
+			<path value="Extension.value[x]"/>
+			<short value="This describes the reason a service request is urgent"/>
+			<min value="1"/>
+			<type>
+				<code value="CodeableConcept"/>
+			</type>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A set of codes that define the reason why a service request is urgent."/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode"/>
+			</binding>
+		</element>
+	</differential>
 </StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-PriorityReason.xml
+++ b/structuredefinitions/Extension-UKCore-PriorityReason.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="Extension-UKCore-PriorityReason" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
+  <version value="1.0.0" />
+  <name value="ExtensionUKCorePriorityReason" />
+  <title value="Extension UK Core Priority Reason" />
+  <status value="active" />
+  <date value="2023-04-28" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This extension describes the underlying reason why a Service Request is urgent." />
+  <purpose value="This extension extends the Service Request Resource to support the reason why a Service Request is urgent, which is currently not supported by the FHIR standard." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="ServiceRequest" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="A SNOMED CT concept representing the reason a Service Request is urgent." />
+      <definition value="A SNOMED CT concept representing the reason a Service Request is urgent" />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <short value="This describes the form in which a service request is sent and received" />
+      <min value="1" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="preferred" />
+        <description value="A set of codes that define the reason why a service request is urgent." />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/UKCore-ServiceRequest.xml
+++ b/structuredefinitions/UKCore-ServiceRequest.xml
@@ -84,6 +84,16 @@
       </type>
       <isModifier value="false" />
     </element>
+	<element id="ServiceRequest.extension:priorityReason">
+      <path value="ServiceRequest.extension" />
+      <sliceName value="priorityReason" />
+      <min value="0" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
+      </type>
+      <isModifier value="false" />
+    </element>
     <element id="ServiceRequest.identifier.assigner">
       <path value="ServiceRequest.identifier.assigner" />
       <type>

--- a/structuredefinitions/UKCore-ServiceRequest.xml
+++ b/structuredefinitions/UKCore-ServiceRequest.xml
@@ -1,310 +1,310 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-ServiceRequest" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
-  <version value="2.4.0" />
-  <name value="UKCoreServiceRequest" />
-  <title value="UK Core ServiceRequest" />
-  <status value="active" />
-  <date value="2023-04-28" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [ServiceRequest](https://hl7.org/fhir/R4/ServiceRequest.html)." />
-  <purpose value="This profile is a record of a request for a procedure or diagnostic or other service to be planned, proposed, or performed, as distinguished by the ServiceRequest.intent field value, with or on a patient." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <mapping>
-    <identity value="workflow" />
-    <uri value="http://hl7.org/fhir/workflow" />
-    <name value="Workflow Pattern" />
-  </mapping>
-  <mapping>
-    <identity value="v2" />
-    <uri value="http://hl7.org/v2" />
-    <name value="HL7 v2 Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="rim" />
-    <uri value="http://hl7.org/v3" />
-    <name value="RIM Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="w5" />
-    <uri value="http://hl7.org/fhir/fivews" />
-    <name value="FiveWs Pattern Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="quick" />
-    <uri value="http://siframework.org/cqf" />
-    <name value="Quality Improvement and Clinical Knowledge (QUICK)" />
-  </mapping>
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="ServiceRequest" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ServiceRequest" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="ServiceRequest.extension">
-      <path value="ServiceRequest.extension" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="url" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <min value="0" />
-    </element>
-    <element id="ServiceRequest.extension:sourceOfServiceRequest">
-      <path value="ServiceRequest.extension" />
-      <sliceName value="sourceOfServiceRequest" />
-      <min value="0" />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SourceOfServiceRequest" />
-      </type>
-      <isModifier value="false" />
-    </element>
-	<element id="ServiceRequest.extension:additionalContact">
-      <path value="ServiceRequest.extension" />
-      <sliceName value="additionalContact" />
-      <min value="0" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact" />
-      </type>
-      <isModifier value="false" />
-    </element>
-	<element id="ServiceRequest.extension:priorityReason">
-      <path value="ServiceRequest.extension" />
-      <sliceName value="priorityReason" />
-      <min value="0" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="ServiceRequest.identifier.assigner">
-      <path value="ServiceRequest.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.basedOn">
-      <path value="ServiceRequest.basedOn" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CarePlan" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
-      </type>
-    </element>
-    <element id="ServiceRequest.basedOn.identifier.assigner">
-      <path value="ServiceRequest.basedOn.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.replaces">
-      <path value="ServiceRequest.replaces" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
-      </type>
-    </element>
-    <element id="ServiceRequest.replaces.identifier.assigner">
-      <path value="ServiceRequest.replaces.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.requisition.assigner">
-      <path value="ServiceRequest.requisition.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.code">
-      <path value="ServiceRequest.code" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.subject">
-      <path value="ServiceRequest.subject" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-      </type>
-    </element>
-    <element id="ServiceRequest.subject.identifier.assigner">
-      <path value="ServiceRequest.subject.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.encounter">
-      <path value="ServiceRequest.encounter" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter" />
-      </type>
-    </element>
-    <element id="ServiceRequest.encounter.identifier.assigner">
-      <path value="ServiceRequest.encounter.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.requester">
-      <path value="ServiceRequest.requester" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson" />
-      </type>
-    </element>
-    <element id="ServiceRequest.requester.identifier.assigner">
-      <path value="ServiceRequest.requester.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.performer">
-      <path value="ServiceRequest.performer" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CareTeam" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-HealthcareService" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson" />
-      </type>
-    </element>
-    <element id="ServiceRequest.performer.identifier.assigner">
-      <path value="ServiceRequest.performer.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.locationReference">
-      <path value="ServiceRequest.locationReference" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location" />
-      </type>
-    </element>
-    <element id="ServiceRequest.locationReference.identifier.assigner">
-      <path value="ServiceRequest.locationReference.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.reasonCode">
-      <path value="ServiceRequest.reasonCode" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A set of codes that define a reason for a service request." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.reasonReference">
-      <path value="ServiceRequest.reasonReference" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-      </type>
-    </element>
-    <element id="ServiceRequest.reasonReference.identifier.assigner">
-      <path value="ServiceRequest.reasonReference.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.insurance.identifier.assigner">
-      <path value="ServiceRequest.insurance.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.supportingInfo.identifier.assigner">
-      <path value="ServiceRequest.supportingInfo.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.specimen">
-      <path value="ServiceRequest.specimen" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
-      </type>
-    </element>
-    <element id="ServiceRequest.specimen.identifier.assigner">
-      <path value="ServiceRequest.specimen.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="ServiceRequest.bodySite">
-      <path value="ServiceRequest.bodySite" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A set of codes that define an anatomical or acquired body structure site. Selected from the SNOMED CT UK coding system." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.relevantHistory">
-      <path value="ServiceRequest.relevantHistory" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Provenance" />
-      </type>
-    </element>
-    <element id="ServiceRequest.relevantHistory.identifier.assigner">
-      <path value="ServiceRequest.relevantHistory.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-  </differential>
+	<id value="UKCore-ServiceRequest"/>
+	<url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest"/>
+	<version value="2.4.0"/>
+	<name value="UKCoreServiceRequest"/>
+	<title value="UK Core ServiceRequest"/>
+	<status value="active"/>
+	<date value="2023-04-28"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<description value="This profile defines the UK constraints and extensions on the International FHIR resource [ServiceRequest](https://hl7.org/fhir/R4/ServiceRequest.html)."/>
+	<purpose value="This profile is a record of a request for a procedure or diagnostic or other service to be planned, proposed, or performed, as distinguished by the ServiceRequest.intent field value, with or on a patient."/>
+	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<fhirVersion value="4.0.1"/>
+	<mapping>
+		<identity value="workflow"/>
+		<uri value="http://hl7.org/fhir/workflow"/>
+		<name value="Workflow Pattern"/>
+	</mapping>
+	<mapping>
+		<identity value="v2"/>
+		<uri value="http://hl7.org/v2"/>
+		<name value="HL7 v2 Mapping"/>
+	</mapping>
+	<mapping>
+		<identity value="rim"/>
+		<uri value="http://hl7.org/v3"/>
+		<name value="RIM Mapping"/>
+	</mapping>
+	<mapping>
+		<identity value="w5"/>
+		<uri value="http://hl7.org/fhir/fivews"/>
+		<name value="FiveWs Pattern Mapping"/>
+	</mapping>
+	<mapping>
+		<identity value="quick"/>
+		<uri value="http://siframework.org/cqf"/>
+		<name value="Quality Improvement and Clinical Knowledge (QUICK)"/>
+	</mapping>
+	<kind value="resource"/>
+	<abstract value="false"/>
+	<type value="ServiceRequest"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/ServiceRequest"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="ServiceRequest.extension">
+			<path value="ServiceRequest.extension"/>
+			<slicing>
+				<discriminator>
+					<type value="value"/>
+					<path value="url"/>
+				</discriminator>
+				<rules value="open"/>
+			</slicing>
+			<min value="0"/>
+		</element>
+		<element id="ServiceRequest.extension:sourceOfServiceRequest">
+			<path value="ServiceRequest.extension"/>
+			<sliceName value="sourceOfServiceRequest"/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SourceOfServiceRequest"/>
+			</type>
+			<isModifier value="false"/>
+		</element>
+		<element id="ServiceRequest.extension:additionalContact">
+			<path value="ServiceRequest.extension"/>
+			<sliceName value="additionalContact"/>
+			<min value="0"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact"/>
+			</type>
+			<isModifier value="false"/>
+		</element>
+		<element id="ServiceRequest.extension:priorityReason">
+			<path value="ServiceRequest.extension"/>
+			<sliceName value="priorityReason"/>
+			<min value="0"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason"/>
+			</type>
+			<isModifier value="false"/>
+		</element>
+		<element id="ServiceRequest.identifier.assigner">
+			<path value="ServiceRequest.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.basedOn">
+			<path value="ServiceRequest.basedOn"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CarePlan"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.basedOn.identifier.assigner">
+			<path value="ServiceRequest.basedOn.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.replaces">
+			<path value="ServiceRequest.replaces"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.replaces.identifier.assigner">
+			<path value="ServiceRequest.replaces.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.requisition.assigner">
+			<path value="ServiceRequest.requisition.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.code">
+			<path value="ServiceRequest.code"/>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system."/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode"/>
+			</binding>
+		</element>
+		<element id="ServiceRequest.subject">
+			<path value="ServiceRequest.subject"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.subject.identifier.assigner">
+			<path value="ServiceRequest.subject.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.encounter">
+			<path value="ServiceRequest.encounter"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.encounter.identifier.assigner">
+			<path value="ServiceRequest.encounter.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.requester">
+			<path value="ServiceRequest.requester"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.requester.identifier.assigner">
+			<path value="ServiceRequest.requester.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.performer">
+			<path value="ServiceRequest.performer"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CareTeam"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-HealthcareService"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.performer.identifier.assigner">
+			<path value="ServiceRequest.performer.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.locationReference">
+			<path value="ServiceRequest.locationReference"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.locationReference.identifier.assigner">
+			<path value="ServiceRequest.locationReference.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.reasonCode">
+			<path value="ServiceRequest.reasonCode"/>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A set of codes that define a reason for a service request."/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode"/>
+			</binding>
+		</element>
+		<element id="ServiceRequest.reasonReference">
+			<path value="ServiceRequest.reasonReference"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.reasonReference.identifier.assigner">
+			<path value="ServiceRequest.reasonReference.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.insurance.identifier.assigner">
+			<path value="ServiceRequest.insurance.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.supportingInfo.identifier.assigner">
+			<path value="ServiceRequest.supportingInfo.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.specimen">
+			<path value="ServiceRequest.specimen"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.specimen.identifier.assigner">
+			<path value="ServiceRequest.specimen.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.bodySite">
+			<path value="ServiceRequest.bodySite"/>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A set of codes that define an anatomical or acquired body structure site. Selected from the SNOMED CT UK coding system."/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite"/>
+			</binding>
+		</element>
+		<element id="ServiceRequest.relevantHistory">
+			<path value="ServiceRequest.relevantHistory"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Provenance"/>
+			</type>
+		</element>
+		<element id="ServiceRequest.relevantHistory.identifier.assigner">
+			<path value="ServiceRequest.relevantHistory.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+	</differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-ServiceRequest.xml
+++ b/structuredefinitions/UKCore-ServiceRequest.xml
@@ -84,16 +84,6 @@
 			</type>
 			<isModifier value="false"/>
 		</element>
-		<element id="ServiceRequest.extension:priorityReason">
-			<path value="ServiceRequest.extension"/>
-			<sliceName value="priorityReason"/>
-			<min value="0"/>
-			<type>
-				<code value="Extension"/>
-				<profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason"/>
-			</type>
-			<isModifier value="false"/>
-		</element>
 		<element id="ServiceRequest.identifier.assigner">
 			<path value="ServiceRequest.identifier.assigner"/>
 			<type>
@@ -137,6 +127,16 @@
 				<code value="Reference"/>
 				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
 			</type>
+		</element>
+		<element id="ServiceRequest.priority.extension:priorityReason">
+			<path value="ServiceRequest.priority.extension"/>
+			<sliceName value="priorityReason"/>
+			<min value="0"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason"/>
+			</type>
+			<isModifier value="false"/>
 		</element>
 		<element id="ServiceRequest.code">
 			<path value="ServiceRequest.code"/>


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/IOPS-1316

https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Proposed-Changes/Issue-27?version=1.6.0

There is a Genomics use case to record the reason why an urgent test has been requested. This differs from supportingInfo in that it does not necessarily indicate why the test is being requested. No other fields in ServiceRequest were appropriate.

Add a new extension: Extension-UKCore-PriorityReason, with a binding to [ValueSet UKCore-ServiceRequestReasonCode](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-ServiceRequestReasonCode?version=1.6.0)