### PR TITLE
Sprint6/iops 1301

### DIFF
--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-DiagnosticReport-Lab" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
+  <version value="1.0.0" />
+  <name value="UKCoreDiagnosticReportLab" />
+  <title value="UK Core DiagnosticReport Lab" />
+  <status value="active" />
+  <date value="2023-04-28" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="Defines the DiagnosticReport constraints and extensions on the UK Core Profile {{pagelink:Profile-DiagnosticReport-54417}}" />
+  <purpose value="To provide implementers with additional support when implementing test result data and to provide a consistant structure to this data." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="DiagnosticReport" />
+  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="DiagnosticReport.category">
+      <path value="DiagnosticReport.category" />
+      <min value="1" />
+    </element>
+    <element id="DiagnosticReport.subject">
+      <path value="DiagnosticReport.subject" />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
+      </type>
+    </element>
+    <element id="DiagnosticReport.effective[x]">
+      <path value="DiagnosticReport.effective[x]" />
+      <min value="1" />
+    </element>
+    <element id="DiagnosticReport.result">
+      <path value="DiagnosticReport.result" />
+      <min value="1" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -44,7 +44,7 @@
         <key value="ukcore-vit-lab-001" />
         <severity value="error" />
         <human value="An effective time SHALL be given present if status = partial, preliminary, final, amended, corrected or appended" />
-        <expression value="(status != 'partial') or (status != 'preliminary') or (status != 'final') or (status != 'amended') or (status != 'corrected') or (status != 'appended')" />
+        <expression value="(effective.empty() and ((status != 'partial') or (status != 'preliminary') or (status != 'final') or (status != 'amended') or (status != 'corrected') or (status != 'appended'))) or effective.exists()" />
         <source value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
       </constraint>
     </element>

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -17,7 +17,7 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="Defines the DiagnosticReport constraints and extensions on the UK Core Profile {{pagelink:Profile-DiagnosticReport-54417}}" />
+  <description value="Defines the DiagnosticReport constraints and extensions on the UK Core Profile DiagnosticReport" />
   <purpose value="To provide implementers with additional support when implementing test result data and to provide a consistant structure to this data." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
@@ -41,7 +41,7 @@
     <element id="DiagnosticReport.effective[x]">
       <path value="DiagnosticReport.effective[x]" />
       <constraint>
-        <key value="ukcore-vit-lab-001" />
+        <key value="ukcore-diag-lab-001" />
         <severity value="error" />
         <human value="An effective time SHALL be given present if status = partial, preliminary, final, amended, corrected or appended" />
         <expression value="(effective.empty() and ((status != 'partial') or (status != 'preliminary') or (status != 'final') or (status != 'amended') or (status != 'corrected') or (status != 'appended'))) or effective.exists()" />

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -40,7 +40,13 @@
     </element>
     <element id="DiagnosticReport.effective[x]">
       <path value="DiagnosticReport.effective[x]" />
-      <min value="1" />
+      <constraint>
+        <key value="ukcore-vit-lab-001" />
+        <severity value="error" />
+        <human value="An effective time SHALL be given present if status = partial, preliminary, final, amended, corrected or appended" />
+        <expression value="(status != 'partial') or (status != 'preliminary') or (status != 'final') or (status != 'amended') or (status != 'corrected') or (status != 'appended')" />
+        <source value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
+      </constraint>
     </element>
     <element id="DiagnosticReport.result">
       <path value="DiagnosticReport.result" />

--- a/valuesets/ValueSet-UKCore-ReportCode.xml
+++ b/valuesets/ValueSet-UKCore-ReportCode.xml
@@ -17,8 +17,7 @@
 		</telecom>
 	</contact>
 	<description value="A code from the SNOMED Clinical Terminology UK coding system that describes a diagnostic report. Selected from the following SNOMED CT UK coding system: \n 
-- descendantOrSelfOf 371525003 | Clinical procedure report
-- 721981007 |  Diagnostic studies report"/>
+- descendantOrSelfOf 371525003 | Clinical procedure report"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>
@@ -26,7 +25,7 @@
 			<filter>
 				<property value="constraint"/>
 				<op value="="/>
-				<value value="descendantOrSelfOf 371525003 OR 721981007"/>
+				<value value="descendantOrSelfOf 371525003"/>
 			</filter>
 		</include>
 	</compose>

--- a/valuesets/ValueSet-UKCore-ReportCode.xml
+++ b/valuesets/ValueSet-UKCore-ReportCode.xml
@@ -17,7 +17,8 @@
 		</telecom>
 	</contact>
 	<description value="A code from the SNOMED Clinical Terminology UK coding system that describes a diagnostic report. Selected from the following SNOMED CT UK coding system: \n 
-- descendantOrSelfOf 371525003 | Clinical procedure report"/>
+- descendantOrSelfOf 371525003 | Clinical procedure report
+- 721981007 |  Diagnostic studies report"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>
@@ -25,7 +26,7 @@
 			<filter>
 				<property value="constraint"/>
 				<op value="="/>
-				<value value="descendantOrSelfOf 371525003"/>
+				<value value="descendantOrSelfOf 371525003 OR 721981007"/>
 			</filter>
 		</include>
 	</compose>


### PR DESCRIPTION
>  Each UKCore-DiagnosticReport-Lab must have
    a status
    a category code of ‘LAB’ (additional categories can also be provided e.g., ‘Pathology’ etc)
    a generic code of ‘Diagnostic studies report’ (a code to indicate what is being measured is carried in the Observation-Group)
    a Patient
    one or more UKCore-Observation-Groups
    the diagnostically relevant time (known as the “effective time” and typically the time of specimen collection)*
    when the report was released*
>
>    These elements have the following constraints: SHALL be present if status is ‘partial’, ‘preliminary’, ‘final’, ‘amended’, ‘corrected’ or ‘appended’.

---
- set status to 1..1
- category set to 1..* . This element binds to https://simplifier.net/packages/hl7.fhir.r4.core/4.0.1/files/82137 as example which already has 'LAB' code - no changes made to ValueSet. 
- added code (721981007 | Diagnostic studies report) to the Observation-Group 
- set subject to 1..1 with reference to UKCore Patient only
- set result to 1..* UK Core Observation only
- set effective to follow rules as above