### PR TITLE
Removed Observation bodySite Slice

### DIFF
--- a/structuredefinitions/UKCore-Observation.xml
+++ b/structuredefinitions/UKCore-Observation.xml
@@ -1,368 +1,339 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Observation" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-  <version value="2.3.0" />
-  <name value="UKCoreObservation" />
-  <title value="UK Core Observation" />
-  <status value="draft" />
-  <date value="2023-02-14" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Observation](https://hl7.org/fhir/R4/Observation.html)." />
-  <purpose value="This profile allows exchange of information of Measurements and simple assertions made about an individual, device or other subject. Note: this profile SHALL NOT be used where a more specific UK Core profile exists." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <mapping>
-    <identity value="workflow" />
-    <uri value="http://hl7.org/fhir/workflow" />
-    <name value="Workflow Pattern" />
-  </mapping>
-  <mapping>
-    <identity value="sct-concept" />
-    <uri value="http://snomed.info/conceptdomain" />
-    <name value="SNOMED CT Concept Domain Binding" />
-  </mapping>
-  <mapping>
-    <identity value="v2" />
-    <uri value="http://hl7.org/v2" />
-    <name value="HL7 v2 Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="rim" />
-    <uri value="http://hl7.org/v3" />
-    <name value="RIM Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="w5" />
-    <uri value="http://hl7.org/fhir/fivews" />
-    <name value="FiveWs Pattern Mapping" />
-  </mapping>
-  <mapping>
-    <identity value="sct-attr" />
-    <uri value="http://snomed.org/attributebinding" />
-    <name value="SNOMED CT Attribute Binding" />
-  </mapping>
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Observation" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Observation.identifier.assigner">
-      <path value="Observation.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.basedOn">
-      <path value="Observation.basedOn" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceRequest" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/NutritionOrder" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CarePlan" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
-      </type>
-    </element>
-    <element id="Observation.basedOn.identifier.assigner">
-      <path value="Observation.basedOn.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.partOf">
-      <path value="Observation.partOf" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ImagingStudy" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationAdministration" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationDispense" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Procedure" />
-      </type>
-    </element>
-    <element id="Observation.partOf.identifier.assigner">
-      <path value="Observation.partOf.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationType" />
-      </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.display">
-      <path value="Observation.code.coding.display" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://loinc.org" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:loinc.display">
-      <path value="Observation.code.coding.display" />
-      <min value="1" />
-    </element>
-    <element id="Observation.subject">
-      <path value="Observation.subject" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-      </type>
-    </element>
-    <element id="Observation.subject.identifier.assigner">
-      <path value="Observation.subject.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.focus.identifier.assigner">
-      <path value="Observation.focus.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.encounter">
-      <path value="Observation.encounter" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter" />
-      </type>
-    </element>
-    <element id="Observation.encounter.identifier.assigner">
-      <path value="Observation.encounter.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.performer">
-      <path value="Observation.performer" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CareTeam" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson" />
-      </type>
-    </element>
-    <element id="Observation.performer.identifier.assigner">
-      <path value="Observation.performer.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.note.author[x]">
-      <path value="Observation.note.author[x]" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson" />
-      </type>
-      <type>
-        <code value="string" />
-      </type>
-    </element>
-    <element id="Observation.bodySite.coding">
-      <path value="Observation.bodySite.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="code" />
-        </discriminator>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.bodySite.coding:snomedCT">
-      <path value="Observation.bodySite.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK with the expression (&lt;&lt;442083009 |anatomical or acquired body structure|)" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite" />
-      </binding>
-    </element>
-    <element id="Observation.bodySite.coding:snomedCT.system">
-      <path value="Observation.bodySite.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="Observation.bodySite.coding:snomedCT.code">
-      <path value="Observation.bodySite.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="Observation.bodySite.coding:snomedCT.display">
-      <path value="Observation.bodySite.coding.display" />
-      <min value="1" />
-    </element>
-    <element id="Observation.method">
-      <path value="Observation.method" />
-      <binding>
-        <strength value="extensible" />
-      </binding>
-    </element>
-    <element id="Observation.specimen">
-      <path value="Observation.specimen" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen" />
-      </type>
-    </element>
-    <element id="Observation.specimen.identifier.assigner">
-      <path value="Observation.specimen.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.device">
-      <path value="Observation.device" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceMetric" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device" />
-      </type>
-    </element>
-    <element id="Observation.device.identifier.assigner">
-      <path value="Observation.device.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.hasMember">
-      <path value="Observation.hasMember" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MolecularSequence" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse" />
-      </type>
-    </element>
-    <element id="Observation.hasMember.identifier.assigner">
-      <path value="Observation.hasMember.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.derivedFrom">
-      <path value="Observation.derivedFrom" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Media" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MolecularSequence" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ImagingStudy" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse" />
-      </type>
-    </element>
-    <element id="Observation.derivedFrom.identifier.assigner">
-      <path value="Observation.derivedFrom.identifier.assigner" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-      </type>
-    </element>
-    <element id="Observation.component.code.coding">
-      <path value="Observation.component.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="code" />
-        </discriminator>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.component.code.coding:snomedCT">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="snomedCT" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationType" />
-      </binding>
-    </element>
-    <element id="Observation.component.code.coding:snomedCT.system">
-      <path value="Observation.component.code.coding.system" />
-      <min value="1" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="Observation.component.code.coding:snomedCT.code">
-      <path value="Observation.component.code.coding.code" />
-      <min value="1" />
-    </element>
-    <element id="Observation.component.code.coding:snomedCT.display">
-      <path value="Observation.component.code.coding.display" />
-      <min value="1" />
-    </element>
-  </differential>
+	<id value="UKCore-Observation"/>
+	<url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
+	<version value="2.4.0"/>
+	<name value="UKCoreObservation"/>
+	<title value="UK Core Observation"/>
+	<status value="active"/>
+	<date value="2023-04-28"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<description value="This profile defines the UK constraints and extensions on the International FHIR resource [Observation](https://hl7.org/fhir/R4/Observation.html)."/>
+	<purpose value="This profile allows exchange of information of Measurements and simple assertions made about an individual, device or other subject. Note: this profile SHALL NOT be used where a more specific UK Core profile exists."/>
+	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<fhirVersion value="4.0.1"/>
+	<mapping>
+		<identity value="workflow"/>
+		<uri value="http://hl7.org/fhir/workflow"/>
+		<name value="Workflow Pattern"/>
+	</mapping>
+	<mapping>
+		<identity value="sct-concept"/>
+		<uri value="http://snomed.info/conceptdomain"/>
+		<name value="SNOMED CT Concept Domain Binding"/>
+	</mapping>
+	<mapping>
+		<identity value="v2"/>
+		<uri value="http://hl7.org/v2"/>
+		<name value="HL7 v2 Mapping"/>
+	</mapping>
+	<mapping>
+		<identity value="rim"/>
+		<uri value="http://hl7.org/v3"/>
+		<name value="RIM Mapping"/>
+	</mapping>
+	<mapping>
+		<identity value="w5"/>
+		<uri value="http://hl7.org/fhir/fivews"/>
+		<name value="FiveWs Pattern Mapping"/>
+	</mapping>
+	<mapping>
+		<identity value="sct-attr"/>
+		<uri value="http://snomed.org/attributebinding"/>
+		<name value="SNOMED CT Attribute Binding"/>
+	</mapping>
+	<kind value="resource"/>
+	<abstract value="false"/>
+	<type value="Observation"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="Observation.identifier.assigner">
+			<path value="Observation.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.basedOn">
+			<path value="Observation.basedOn"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceRequest"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/NutritionOrder"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CarePlan"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest"/>
+			</type>
+		</element>
+		<element id="Observation.basedOn.identifier.assigner">
+			<path value="Observation.basedOn.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.partOf">
+			<path value="Observation.partOf"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ImagingStudy"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationAdministration"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationDispense"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Procedure"/>
+			</type>
+		</element>
+		<element id="Observation.partOf.identifier.assigner">
+			<path value="Observation.partOf.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.code.coding">
+			<path value="Observation.code.coding"/>
+			<slicing>
+				<discriminator>
+					<type value="value"/>
+					<path value="system"/>
+				</discriminator>
+				<rules value="open"/>
+			</slicing>
+		</element>
+		<element id="Observation.code.coding:snomedCT">
+			<path value="Observation.code.coding"/>
+			<sliceName value="snomedCT"/>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation"/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationType"/>
+			</binding>
+		</element>
+		<element id="Observation.code.coding:snomedCT.system">
+			<path value="Observation.code.coding.system"/>
+			<min value="1"/>
+			<fixedUri value="http://snomed.info/sct"/>
+		</element>
+		<element id="Observation.code.coding:snomedCT.code">
+			<path value="Observation.code.coding.code"/>
+			<min value="1"/>
+		</element>
+		<element id="Observation.code.coding:snomedCT.display">
+			<path value="Observation.code.coding.display"/>
+			<min value="1"/>
+		</element>
+		<element id="Observation.code.coding:loinc">
+			<path value="Observation.code.coding"/>
+			<sliceName value="loinc"/>
+		</element>
+		<element id="Observation.code.coding:loinc.system">
+			<path value="Observation.code.coding.system"/>
+			<min value="1"/>
+			<fixedUri value="http://loinc.org"/>
+		</element>
+		<element id="Observation.code.coding:loinc.code">
+			<path value="Observation.code.coding.code"/>
+			<min value="1"/>
+		</element>
+		<element id="Observation.code.coding:loinc.display">
+			<path value="Observation.code.coding.display"/>
+			<min value="1"/>
+		</element>
+		<element id="Observation.subject">
+			<path value="Observation.subject"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Group"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
+			</type>
+		</element>
+		<element id="Observation.subject.identifier.assigner">
+			<path value="Observation.subject.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.focus.identifier.assigner">
+			<path value="Observation.focus.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.encounter">
+			<path value="Observation.encounter"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter"/>
+			</type>
+		</element>
+		<element id="Observation.encounter.identifier.assigner">
+			<path value="Observation.encounter.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.performer">
+			<path value="Observation.performer"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-CareTeam"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson"/>
+			</type>
+		</element>
+		<element id="Observation.performer.identifier.assigner">
+			<path value="Observation.performer.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.note.author[x]">
+			<path value="Observation.note.author[x]"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson"/>
+			</type>
+			<type>
+				<code value="string"/>
+			</type>
+		</element>
+		<element id="Observation.bodySite">
+			<path value="Observation.bodySite"/>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A code from the SNOMED Clinical Terminology UK with the expression (&lt;&lt;442083009 | Anatomical or acquired body structure)"/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite"/>
+			</binding>
+		</element>
+		<element id="Observation.method">
+			<path value="Observation.method"/>
+			<binding>
+				<strength value="extensible"/>
+			</binding>
+		</element>
+		<element id="Observation.specimen">
+			<path value="Observation.specimen"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen"/>
+			</type>
+		</element>
+		<element id="Observation.specimen.identifier.assigner">
+			<path value="Observation.specimen.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.device">
+			<path value="Observation.device"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceMetric"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device"/>
+			</type>
+		</element>
+		<element id="Observation.device.identifier.assigner">
+			<path value="Observation.device.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.hasMember">
+			<path value="Observation.hasMember"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/MolecularSequence"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse"/>
+			</type>
+		</element>
+		<element id="Observation.hasMember.identifier.assigner">
+			<path value="Observation.hasMember.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.derivedFrom">
+			<path value="Observation.derivedFrom"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Media"/>
+				<targetProfile value="http://hl7.org/fhir/StructureDefinition/MolecularSequence"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ImagingStudy"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-QuestionnaireResponse"/>
+			</type>
+		</element>
+		<element id="Observation.derivedFrom.identifier.assigner">
+			<path value="Observation.derivedFrom.identifier.assigner"/>
+			<type>
+				<code value="Reference"/>
+				<targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization"/>
+			</type>
+		</element>
+		<element id="Observation.component.code.coding">
+			<path value="Observation.component.code.coding"/>
+			<slicing>
+				<discriminator>
+					<type value="value"/>
+					<path value="code"/>
+				</discriminator>
+				<discriminator>
+					<type value="value"/>
+					<path value="system"/>
+				</discriminator>
+				<rules value="open"/>
+			</slicing>
+		</element>
+		<element id="Observation.component.code.coding:snomedCT">
+			<path value="Observation.component.code.coding"/>
+			<sliceName value="snomedCT"/>
+			<binding>
+				<strength value="preferred"/>
+				<description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation"/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationType"/>
+			</binding>
+		</element>
+		<element id="Observation.component.code.coding:snomedCT.system">
+			<path value="Observation.component.code.coding.system"/>
+			<min value="1"/>
+			<fixedUri value="http://snomed.info/sct"/>
+		</element>
+		<element id="Observation.component.code.coding:snomedCT.code">
+			<path value="Observation.component.code.coding.code"/>
+			<min value="1"/>
+		</element>
+		<element id="Observation.component.code.coding:snomedCT.display">
+			<path value="Observation.component.code.coding.display"/>
+			<min value="1"/>
+		</element>
+	</differential>
 </StructureDefinition>


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/IOPS-1303

https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Proposed-Changes/Issue-12?version=1.6.0

The draft UKCore-Observation profile, has an open slice on element Observation.bodySite, snomedCT, bound to [ValueSet UKCore-BodySite](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-BodySite?version=1.6.0) (preferred).

The origins of this slice are from the FHIR STU3 CareConnect Specimen profile, and the now retired Extension-UKCore-CodingSCTDescId.

Remove slice
Bind Observation.bodySite to [ValueSet UKCore-BodySite](https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Terminology/AllValueSets/ValueSet-UKCore-BodySite?version=1.6.0) (preferred)