### PR TITLE
Sprint 6 service request - coverage extension

### DIFF
--- a/codesystems/CodeSystem-UKCore-FundingCategory.xml
+++ b/codesystems/CodeSystem-UKCore-FundingCategory.xml
@@ -16,7 +16,7 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="A set of codes that define the funding cateogry for a patient."/>
+	<description value="A set of codes that define the funding category for a patient."/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<caseSensitive value="true"/>
 	<content value="complete"/>

--- a/codesystems/CodeSystem-UKCore-FundingCategory.xml
+++ b/codesystems/CodeSystem-UKCore-FundingCategory.xml
@@ -1,0 +1,31 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+	<id value="UKCore-FundingCategory"/>
+	<url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory"/>
+	<version value="1.0.0"/>
+	<name value="UKCoreFundingCategory"/>
+	<title value="UK Core Funding Category"/>
+	<status value="active"/>
+	<date value="2023-04-28"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<description value="A set of codes that define the funding cateogry for a patient."/>
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<caseSensitive value="true"/>
+	<content value="complete"/>
+	<concept>
+		<code value="NHS"/>
+		<display value="NHS"/>
+	</concept>
+	<concept>
+		<code value="Private"/>
+		<display value="Private"/>
+	</concept>
+</CodeSystem>

--- a/examples/UKCore-ServiceRequest-Extension-Coverage-Example.xml
+++ b/examples/UKCore-ServiceRequest-Extension-Coverage-Example.xml
@@ -1,0 +1,19 @@
+<ServiceRequest xmlns="http://hl7.org/fhir">
+	<id value="UKCore-ServiceRequest-Extension-Coverage-Example"/>
+	<!-- ***************extension start*************** -->
+	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage">
+		<valueCodeableConcept>
+			<coding>
+				<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory"/>
+				<code value="Private"/>
+				<display value="Private"/>
+			</coding>
+		</valueCodeableConcept>
+	</extension>
+	<!-- **************extension end ****************** -->
+	<status value="active"/>
+	<intent value="order"/>
+	<subject>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
+	</subject>
+</ServiceRequest>

--- a/structuredefinitions/Extension-UKCore-Coverage.xml
+++ b/structuredefinitions/Extension-UKCore-Coverage.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="Extension-UKCore-Coverage" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage" />
+  <version value="1.0.0" />
+  <name value="ExtensionUKCoreCoverage" />
+  <title value="Extension UK Core Coverage" />
+  <status value="active" />
+  <date value="2023-04-28" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This extension describes the funding category or coverage for a Service Request." />
+  <purpose value="This extension extends the Service Request Resource to support the exchange of information describing the method used to send or receive a Service Request which is currently not supported by the FHIR standard." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="ServiceRequest" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="The funding category for the Service Request" />
+      <definition value="The funding category for the Service Request." />
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <short value="This describes the funding category for a service request." />
+      <min value="1" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="extensible" />
+        <description value="A set of codes that define the form in which a service request is sent and received." />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-FundingCategory" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-Coverage.xml
+++ b/structuredefinitions/Extension-UKCore-Coverage.xml
@@ -17,8 +17,8 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="This extension describes the funding category or coverage for a Service Request."/>
-	<purpose value="This extension extends the Service Request Resource to support the exchange of information describing the method used to send or receive a Service Request which is currently not supported by the FHIR standard."/>
+	<description value="This extends the Service Request Resource to support the exchange of information describing the method of funding for the Service Request"/>
+	<purpose value="This extension is a Genomics use case to record the funding category for a ServiceRequest. It is expected this will be populated with a code indicating whether the service request is part of NHS coverage or private, and will be used for reimbursement purposes by receiving labs."/>
 	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<fhirVersion value="4.0.1"/>
 	<mapping>

--- a/structuredefinitions/Extension-UKCore-Coverage.xml
+++ b/structuredefinitions/Extension-UKCore-Coverage.xml
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="Extension-UKCore-Coverage" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage" />
-  <version value="1.0.0" />
-  <name value="ExtensionUKCoreCoverage" />
-  <title value="Extension UK Core Coverage" />
-  <status value="active" />
-  <date value="2023-04-28" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This extension describes the funding category or coverage for a Service Request." />
-  <purpose value="This extension extends the Service Request Resource to support the exchange of information describing the method used to send or receive a Service Request which is currently not supported by the FHIR standard." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <mapping>
-    <identity value="rim" />
-    <uri value="http://hl7.org/v3" />
-    <name value="RIM Mapping" />
-  </mapping>
-  <kind value="complex-type" />
-  <abstract value="false" />
-  <context>
-    <type value="element" />
-    <expression value="ServiceRequest" />
-  </context>
-  <type value="Extension" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Extension">
-      <path value="Extension" />
-      <short value="The funding category for the Service Request" />
-      <definition value="The funding category for the Service Request." />
-    </element>
-    <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage" />
-    </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]" />
-      <short value="This describes the funding category for a service request." />
-      <min value="1" />
-      <type>
-        <code value="CodeableConcept" />
-      </type>
-      <binding>
-        <strength value="extensible" />
-        <description value="A set of codes that define the form in which a service request is sent and received." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-FundingCategory" />
-      </binding>
-    </element>
-  </differential>
+	<id value="Extension-UKCore-Coverage"/>
+	<url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage"/>
+	<version value="1.0.0"/>
+	<name value="ExtensionUKCoreCoverage"/>
+	<title value="Extension UK Core Coverage"/>
+	<status value="active"/>
+	<date value="2023-04-28"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<description value="This extension describes the funding category or coverage for a Service Request."/>
+	<purpose value="This extension extends the Service Request Resource to support the exchange of information describing the method used to send or receive a Service Request which is currently not supported by the FHIR standard."/>
+	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<fhirVersion value="4.0.1"/>
+	<mapping>
+		<identity value="rim"/>
+		<uri value="http://hl7.org/v3"/>
+		<name value="RIM Mapping"/>
+	</mapping>
+	<kind value="complex-type"/>
+	<abstract value="false"/>
+	<context>
+		<type value="element"/>
+		<expression value="ServiceRequest"/>
+	</context>
+	<type value="Extension"/>
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+	<derivation value="constraint"/>
+	<differential>
+		<element id="Extension">
+			<path value="Extension"/>
+			<short value="The funding category for the Service Request"/>
+			<definition value="The funding category for the Service Request."/>
+		</element>
+		<element id="Extension.url">
+			<path value="Extension.url"/>
+			<fixedUri value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage"/>
+		</element>
+		<element id="Extension.value[x]">
+			<path value="Extension.value[x]"/>
+			<short value="This describes the funding category for a service request."/>
+			<min value="1"/>
+			<type>
+				<code value="CodeableConcept"/>
+			</type>
+			<binding>
+				<strength value="extensible"/>
+				<description value="A set of codes that define the funding category for a service request."/>
+				<valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-FundingCategory"/>
+			</binding>
+		</element>
+	</differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-ServiceRequest.xml
+++ b/structuredefinitions/UKCore-ServiceRequest.xml
@@ -84,6 +84,17 @@
 			</type>
 			<isModifier value="false"/>
 		</element>
+		<element id="ServiceRequest.extension:coverage">
+			<path value="ServiceRequest.extension"/>
+			<sliceName value="coverage"/>
+			<min value="0"/>
+			<max value="1"/>
+			<type>
+				<code value="Extension"/>
+				<profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage"/>
+			</type>
+			<isModifier value="false"/>
+		</element>
 		<element id="ServiceRequest.identifier.assigner">
 			<path value="ServiceRequest.identifier.assigner"/>
 			<type>

--- a/valuesets/ValueSet-UKCore-FundingCategory.xml
+++ b/valuesets/ValueSet-UKCore-FundingCategory.xml
@@ -1,0 +1,42 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+	<id value="UKCore-FundingCategory"/>
+	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-FundingCategory"/>
+	<version value="1.0.0"/>
+	<name value="UKCoreFundingCategory"/>
+	<title value="UK Core Funding Category"/>
+	<status value="active"/>
+	<date value="2023-04-28"/>
+	<publisher value="HL7 UK"/>
+	<contact>
+		<name value="HL7 UK"/>
+		<telecom>
+			<system value="email"/>
+			<value value="ukcore@hl7.org.uk"/>
+			<use value="work"/>
+			<rank value="1"/>
+		</telecom>
+	</contact>
+	<description value="A set of codes that define the funding category."/>
+	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
+	<compose>
+		<include>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory"/>
+		</include>
+	</compose>
+	<expansion>
+		<identifier value="c2047257-9de9-45c5-b0cb-38a6d478fcfa"/>
+		<timestamp value="2023-04-28T09:15:53+00:00"/>
+		<total value="2"/>
+		<offset value="0"/>
+		<contains>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory"/>
+			<code value="NHS"/>
+			<display value="NHS"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory"/>
+			<code value="Private"/>
+			<display value="Private"/>
+		</contains>
+	</expansion>
+</ValueSet>


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/IOPS-1317

https://simplifier.net/guide/uk-core-implementation-guide-stu3-sequence/Home/Proposed-Changes/Issue-28?version=1.6.0

There is a Genomics use case to record the funding category for a ServiceRequest. It is expected this would be populated with a code indicating whether the service request is part of NHS coverage or private, and would be used for reimbursement purposes by receiving labs.

Add a new extension: Extension-UKCore-Coverage