### PR TITLE
Ballot2/iops 1405

### DIFF
--- a/structuredefinitions/Extension-UKCore-ActualProblem.xml
+++ b/structuredefinitions/Extension-UKCore-ActualProblem.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="A reference to a Condition, Observation, FamilyMemberHistory, or AllergyIntolerance that is the actual problem." />
-  <purpose value="This extension extends the Condition Resource to support the exchange of information referencing a Condition, Observation, FamilyMemberHistory, or AllergyIntolerance that is the actual problem, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Condition Resource to support the exchange of information referencing a Condition, Observation, FamilyMemberHistory, or AllergyIntolerance that is the actual problem." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-AddressKey.xml
+++ b/structuredefinitions/Extension-UKCore-AddressKey.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This carries an address identifier which will be included in an address." />
-  <purpose value="This extension extends the Address datatype to support the exchange of the type of address identifier and the address identifier value, which are currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Address datatype to support the exchange of the type of address identifier and the address identifier value." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-AdmissionMethod.xml
+++ b/structuredefinitions/Extension-UKCore-AdmissionMethod.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the method by which an individual was admitted into hospital." />
-  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the method by which a patient was admitted to hospital, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the method by which a patient was admitted to hospital." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-AllergyIntoleranceEnd.xml
+++ b/structuredefinitions/Extension-UKCore-AllergyIntoleranceEnd.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Supports the date when the allergy or intolerance was no longer valid, and/or, the reason why the allergy or intolerance is no longer valid." />
-  <purpose value="This extension extends the AllergyIntolerance resource to support the exchange of information describing the date when the allergy or intolerance was no longer valid, and/or, the reason why the allergy or intolerance is no longer valid, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the AllergyIntolerance resource to support the exchange of information describing the date when the allergy or intolerance was no longer valid, and/or, the reason why the allergy or intolerance is no longer valid." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-AnaestheticIssues.xml
+++ b/structuredefinitions/Extension-UKCore-AnaestheticIssues.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support recording of details of any adverse reaction to any anaesthetic agents including local anaesthesia and problematic intubation, transfusion reaction, etc." />
-  <purpose value="This extension extends the Procedure Resource to support the exchange of information supporting the recording of details of any adverse reaction to any anaesthetic agents (including local anaesthesia and problematic intubation, transfusion reaction, etc.), which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Procedure Resource to support the exchange of information supporting the recording of details of any adverse reaction to any anaesthetic agents (including local anaesthesia and problematic intubation, transfusion reaction, etc.)." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-BirthSex.xml
+++ b/structuredefinitions/Extension-UKCore-BirthSex.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the patient's phenotypic sex at birth." />
-  <purpose value="This extension extends the Patient resource to support the exchange of the patient's phenotypic sex at birth information, as a Codeable Concept, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient resource to support the exchange of the patient's phenotypic sex at birth information, as a Codeable Concept." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-BookingOrganization.xml
+++ b/structuredefinitions/Extension-UKCore-BookingOrganization.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This supports the recording of the organisation booking the appointment." />
-  <purpose value="This extension extends the Appointment resource to support the exchange of information describing the organisation booking the appointment, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Appointment resource to support the exchange of information describing the organisation booking the appointment." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-CareSettingType.xml
+++ b/structuredefinitions/Extension-UKCore-CareSettingType.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the type of care setting associated with a composition or a list." />
-  <purpose value="This extension extends the Composition and List resources to support the exchange of information about the type of care setting associated with the resource being extended, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Composition and List resources to support the exchange of information about the type of care setting associated with the resource being extended." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-CodingSCTDescDisplay.xml
+++ b/structuredefinitions/Extension-UKCore-CodingSCTDescDisplay.xml
@@ -18,7 +18,7 @@
 		</telecom>
 	</contact>
 	<description value="The description display term for a SNOMED CT concept.  The description display term associated with the ID within the sctdescid extension is important to enable the representation of the exact term that was entered by the clinician that recorded the data, or the exact term that a legacy code e.g. a Read v2 code has been translated to using an assured mapping table."/>
-	<purpose value="This extension extends the sctdescid extension to support the exchange of the selected description display term for a SNOMED CT concept, which is currently not supported by the FHIR standard."/>
+	<purpose value="This extension extends the sctdescid extension to support the exchange of the selected description display term for a SNOMED CT concept."/>
 	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<fhirVersion value="4.0.1"/>
 	<mapping>

--- a/structuredefinitions/Extension-UKCore-ConditionEpisode.xml
+++ b/structuredefinitions/Extension-UKCore-ConditionEpisode.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This supports the episodicity status of a condition." />
-  <purpose value="This extension extends the Condition resource to support the exchange of information describing the episodicity status of a condition, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Condition resource to support the exchange of information describing the episodicity status of a condition." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-ContactPreference.xml
+++ b/structuredefinitions/Extension-UKCore-ContactPreference.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="The preferred method of contact, contact times and written communication format given by a Patient or Related Person." />
-  <purpose value="This extension extends the Patient and RelatedPerson resources to support the exchange of their preferred method of contact, contact times and written communication format, which are currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient and RelatedPerson resources to support the exchange of their preferred method of contact, contact times and written communication format." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-ContactRank.xml
+++ b/structuredefinitions/Extension-UKCore-ContactRank.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="The preferred ranking or order of contact applied to a contact on a Patient's contact list." />
-  <purpose value="This extension extends the Patient resource to support the exchange of the preferred ranking or order of contact applied to a contact on a Patient's contact list, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient resource to support the exchange of the preferred ranking or order of contact applied to a contact on a Patient's contact list." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-CopyCorrespondenceIndicator.xml
+++ b/structuredefinitions/Extension-UKCore-CopyCorrespondenceIndicator.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Indicates that a Patient contact or RelatedPerson SHALL be copied in to Patient correspondence." />
-  <purpose value="This extension extends the Patient and RelatedPerson resources, to support the exchange of information to indicate that a Patient contact or RelatedPerson SHALL be copied in to Patient correspondence. This is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient and RelatedPerson resources, to support the exchange of information to indicate that a Patient contact or RelatedPerson SHALL be copied in to Patient correspondence." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-DeathNotificationStatus.xml
+++ b/structuredefinitions/Extension-UKCore-DeathNotificationStatus.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="The patient's death notification status." />
-  <purpose value="This extension extends the Patient resource to support the exchange of the patient's death notification status, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient resource to support the exchange of the patient's death notification status." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-DeliveryChannel.xml
+++ b/structuredefinitions/Extension-UKCore-DeliveryChannel.xml
@@ -18,7 +18,7 @@
 		</telecom>
 	</contact>
 	<description value="This describes the delivery channel of a scheduled appointment."/>
-	<purpose value="This extension extends the Appointment and Slot resources to support the exchange of information describing the delivery channel of a scheduled appointment, which is currently not supported by the FHIR standard."/>
+	<purpose value="This extension extends the Appointment and Slot resources to support the exchange of information describing the delivery channel of a scheduled appointment."/>
 	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<fhirVersion value="4.0.1"/>
 	<mapping>

--- a/structuredefinitions/Extension-UKCore-DischargeMethod.xml
+++ b/structuredefinitions/Extension-UKCore-DischargeMethod.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the method of discharge from a hospital." />
-  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the method by which a patient was discharged from hospital ." />
+  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the method by which a patient was discharged from hospital." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-DischargeMethod.xml
+++ b/structuredefinitions/Extension-UKCore-DischargeMethod.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the method of discharge from a hospital." />
-  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the method by which a patient was discharged from hospital which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the method by which a patient was discharged from hospital ." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-EmergencyCareDischargeStatus.xml
+++ b/structuredefinitions/Extension-UKCore-EmergencyCareDischargeStatus.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the status of an individual on discharge from an Emergency Care Department." />
-  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the status of a patient on discharge from an Emergency Care Department, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the status of a patient on discharge from an Emergency Care Department." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-EthnicCategory.xml
+++ b/structuredefinitions/Extension-UKCore-EthnicCategory.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information that describes the patient's ethnic category." />
-  <purpose value="This extension extends the Patient resource to support the exchange of ethnic category information, as a Codeable Concept, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient resource to support the exchange of ethnic category information, as a Codeable Concept." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-Evidence.xml
+++ b/structuredefinitions/Extension-UKCore-Evidence.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="A reference to results of investigations that confirmed the certainty of the diagnosis.  Examples might include results of skin prick allergy tests." />
-  <purpose value="This extension extends the AllergyIntolerance resource to support the exchange of information describing the reference to results of investigations that confirmed the certainty of the diagnosis, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the AllergyIntolerance resource to support the exchange of information describing the reference to results of investigations that confirmed the certainty of the diagnosis." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-LegalStatus.xml
+++ b/structuredefinitions/Extension-UKCore-LegalStatus.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information relating to a patient's legal status on admission or discharge." />
-  <purpose value="This extension extends the Encounter Resource to support the exchange of information relating to a patient's legal status on admission or discharge, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Encounter Resource to support the exchange of information relating to a patient's legal status on admission or discharge." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-ListWarningCode.xml
+++ b/structuredefinitions/Extension-UKCore-ListWarningCode.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support warnings that a list may be incomplete as data has been excluded due to confidentiality or may be missing due to data being in transit." />
-  <purpose value="This extension extends the List Resource to support the exchange of information representing warnings that the list may be incomplete as data has been excluded due to confidentiality or may be missing due to data being in transit, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the List Resource to support the exchange of information representing warnings that the list may be incomplete as data has been excluded due to confidentiality or may be missing due to data being in transit." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-MainLocation.xml
+++ b/structuredefinitions/Extension-UKCore-MainLocation.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information describing the main location of the organisation." />
-  <purpose value="This extension extends the Organization resource to support the exchange of information on the Organization's main location, as a reference to a Location resource, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Organization resource to support the exchange of information on the Organization's main location, as a reference to a Location resource." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-MedicationPrescribingOrganizationType.xml
+++ b/structuredefinitions/Extension-UKCore-MedicationPrescribingOrganizationType.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This describes the type of organisation or setting responsible for authorising and issuing a medication, but not the organisation or setting delivering the patient care." />
-  <purpose value="This extension extends the MedicationStatement resource to hold the type of organisation or setting responsible for authorising and issuing a medication, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the MedicationStatement resource to hold the type of organisation or setting responsible for authorising and issuing a medication." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
+++ b/structuredefinitions/Extension-UKCore-MedicationRepeatInformation.xml
@@ -17,7 +17,7 @@
     </telecom>
   </contact>
   <description value="The specific repeat information of a medication item." />
-  <purpose value="This extension extends the MedicationRequest resource to support the exchange of repeat medication data items, which are currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the MedicationRequest resource to support the exchange of repeat medication data items." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-MedicationStatementLastIssueDate.xml
+++ b/structuredefinitions/Extension-UKCore-MedicationStatementLastIssueDate.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This describes the date when a prescription was last issued." />
-  <purpose value="This extension extends the MedicationStatement resource to support the exchange of the date information when a prescription was last issued, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the MedicationStatement resource to support the exchange of the date information when a prescription was last issued." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-MessageHeaderInstruction.xml
+++ b/structuredefinitions/Extension-UKCore-MessageHeaderInstruction.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="The Message Header Instruction extension is provided to carry a specific instruction for receivers of the message." />
-  <purpose value="This extension extends the Message Header resource to support the exchange of a specific instruction to specify additional receiver behaviour - this could be locally or nationally defined - which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Message Header resource to support the exchange of a specific instruction to specify additional receiver behaviour - this could be locally or nationally defined." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-NHSNumberVerificationStatus.xml
+++ b/structuredefinitions/Extension-UKCore-NHSNumberVerificationStatus.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information describing the verification and tracing status of a patient's NHS Number." />
-  <purpose value="This extension extends the identifier element of the Patient resource to support the exchange of information on the verification of a Patient's NHS number. This is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the identifier element of the Patient resource to support the exchange of information on the verification of a Patient's NHS number." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-OtherContactSystem.xml
+++ b/structuredefinitions/Extension-UKCore-OtherContactSystem.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information about other contact methods." />
-  <purpose value="This extension extends the ContactPoint datatype to support the exchange of other contact system information, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the ContactPoint datatype to support the exchange of other contact system information." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-OutcomeOfAttendance.xml
+++ b/structuredefinitions/Extension-UKCore-OutcomeOfAttendance.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="An extension to support the outcome of an Outpatient attendance." />
-  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the outcome of an Outpatient attendance, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Encounter Resource to support the exchange of information representing the outcome of an Outpatient attendance." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-ParentPresent.xml
+++ b/structuredefinitions/Extension-UKCore-ParentPresent.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This describes whether a parent was present at the immunisation of a child." />
-  <purpose value="This extension extends the Immunization resource to support the exchange of data to indicate whether the child's parent was present at the time of the immunisation, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Immunization resource to support the exchange of data to indicate whether the child's parent was present at the time of the immunisation." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-PharmacistVerifiedIndicator.xml
+++ b/structuredefinitions/Extension-UKCore-PharmacistVerifiedIndicator.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This Extension is used to indicate whether a pharmacist verified a medication." />
-  <purpose value="This Extension extends the MedicationStatement resource to allow the exchange of data to indicate whether a pharmacist verified the medication specified within or referenced by the medication statement, which is currently not supported by the FHIR standard." />
+  <purpose value="This Extension extends the MedicationStatement resource to allow the exchange of data to indicate whether a pharmacist verified the medication specified within or referenced by the medication statement." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-ProblemSignificance.xml
+++ b/structuredefinitions/Extension-UKCore-ProblemSignificance.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information that describes the significance of the problem header condition." />
-  <purpose value="This extension extends the Condition Resource to support the exchange of information describing the significance of the problem header condition, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Condition Resource to support the exchange of information describing the significance of the problem header condition." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-RelatedClinicalContent.xml
+++ b/structuredefinitions/Extension-UKCore-RelatedClinicalContent.xml
@@ -18,7 +18,7 @@
 		</telecom>
 	</contact>
 	<description value="An extension to support a reference to any resource that provides related clinical content to the Condition."/>
-	<purpose value="This extension extends the Condition Resource to support the exchange of information supporting a reference to any resource that provides related clinical content to the Condition which is currently not supported by the FHIR standard."/>
+	<purpose value="This extension extends the Condition Resource to support the exchange of information supporting a reference to any resource that provides related clinical content to the Condition ."/>
 	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<fhirVersion value="4.0.1"/>
 	<mapping>

--- a/structuredefinitions/Extension-UKCore-RelatedClinicalContent.xml
+++ b/structuredefinitions/Extension-UKCore-RelatedClinicalContent.xml
@@ -18,7 +18,7 @@
 		</telecom>
 	</contact>
 	<description value="An extension to support a reference to any resource that provides related clinical content to the Condition."/>
-	<purpose value="This extension extends the Condition Resource to support the exchange of information supporting a reference to any resource that provides related clinical content to the Condition ."/>
+	<purpose value="This extension extends the Condition Resource to support the exchange of information supporting a reference to any resource that provides related clinical content to the Condition."/>
 	<copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<fhirVersion value="4.0.1"/>
 	<mapping>

--- a/structuredefinitions/Extension-UKCore-RelatedProblemHeader.xml
+++ b/structuredefinitions/Extension-UKCore-RelatedProblemHeader.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="A reference to another related problem header condition (target) whose relationship is defined by the relationship type code." />
-  <purpose value="This extension extends the Condition or List Resource to support a reference to another related problem header condition (target) whose relationship is defined by the relationship type code, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Condition or List Resource to support a reference to another related problem header condition (target) whose relationship is defined by the relationship type code." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-ResidentialStatus.xml
+++ b/structuredefinitions/Extension-UKCore-ResidentialStatus.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="Information about a patient's residential status." />
-  <purpose value="This extension extends the Patient resource to support the exchange of information about a patient's residential status, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Patient resource to support the exchange of information about a patient's residential status." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-SourceOfServiceRequest.xml
+++ b/structuredefinitions/Extension-UKCore-SourceOfServiceRequest.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This extension describes the source of the Service Request." />
-  <purpose value="This extension extends the Service Request Resource to support the exchange of information describing the source of the Service Request, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Service Request Resource to support the exchange of information describing the source of the Service Request." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/Extension-UKCore-VaccinationProcedure.xml
+++ b/structuredefinitions/Extension-UKCore-VaccinationProcedure.xml
@@ -18,7 +18,7 @@
     </telecom>
   </contact>
   <description value="This describes the immunization procedure code." />
-  <purpose value="This extension extends the Immunization resource to support the exchange of an immunization procedure code, which is currently not supported by the FHIR standard." />
+  <purpose value="This extension extends the Immunization resource to support the exchange of an immunization procedure code." />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>

--- a/structuredefinitions/UKCore-Procedure.xml
+++ b/structuredefinitions/UKCore-Procedure.xml
@@ -66,7 +66,7 @@
       <path value="Procedure.extension" />
       <sliceName value="AnaestheticIssues" />
       <short value="An extension to support recording of details of any adverse reaction to any anaesthetic agents including local anaesthesia and problematic intubation, transfusion reaction, etc." />
-      <definition value="This extension extends the Procedure resource to support the exchange of the recording of details of any adverse reaction to any anaesthetic agents ." />
+      <definition value="This extension extends the Procedure resource to support the exchange of the recording of details of any adverse reaction to any anaesthetic agents." />
       <min value="0" />
       <type>
         <code value="Extension" />

--- a/structuredefinitions/UKCore-Procedure.xml
+++ b/structuredefinitions/UKCore-Procedure.xml
@@ -66,7 +66,7 @@
       <path value="Procedure.extension" />
       <sliceName value="AnaestheticIssues" />
       <short value="An extension to support recording of details of any adverse reaction to any anaesthetic agents including local anaesthesia and problematic intubation, transfusion reaction, etc." />
-      <definition value="This extension extends the Procedure resource to support the exchange of the recording of details of any adverse reaction to any anaesthetic agents which is currently not supported by the FHIR standard." />
+      <definition value="This extension extends the Procedure resource to support the exchange of the recording of details of any adverse reaction to any anaesthetic agents ." />
       <min value="0" />
       <type>
         <code value="Extension" />


### PR DESCRIPTION
Remove the filler ", which is currently not supported by the FHIR standard"

dtae/version not changed due to such a minor update