### PR TITLE
Add AssociatedEncounter extension to FMH profile

### DIFF
--- a/structuredefinitions/UKCore-FamilyMemberHistory.xml
+++ b/structuredefinitions/UKCore-FamilyMemberHistory.xml
@@ -5,8 +5,8 @@
   <version value="1.0.0" />
   <name value="UKCoreFamilyMemberHistory" />
   <title value="UKCore FamilyMemberHistory" />
-  <status value="draft" />
-  <date value="2022-12-16" />
+  <status value="active" />
+  <date value="2023-04-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -27,6 +27,28 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory" />
   <derivation value="constraint" />
   <differential>
+    <element id="FamilyMemberHistory.extension">
+      <path value="FamilyMemberHistory.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="0" />
+    </element>
+    <element id="FamilyMemberHistory.extension:associatedEncounter">
+      <path value="FamilyMemberHistory.extension" />
+      <sliceName value="associatedEncounter" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AssociatedEncounter" />
+      </type>
+      <isModifier value="false" />
+    </element>
     <element id="FamilyMemberHistory.identifier.assigner">
       <path value="FamilyMemberHistory.identifier.assigner" />
       <type>


### PR DESCRIPTION
Extension-UKCore-AssociatedEncounter was created for the FamilyMemberHistory profile for sprint 6, but not actually added to the profile.