### PR TITLE
added changes as discussed

### DIFF
--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -28,7 +28,35 @@
   <differential>
     <element id="DiagnosticReport.category">
       <path value="DiagnosticReport.category" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="coding.code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
       <min value="1" />
+    </element>
+    <element id="DiagnosticReport.category:sliceLaboratory">
+      <path value="DiagnosticReport.category" />
+      <sliceName value="sliceLaboratory" />
+      <fixedCodeableConcept>
+        <coding>
+          <system value="http://terminology.hl7.org/CodeSystem/v2-0074" />
+          <code value="LAB" />
+          <display value="Laboratory" />
+        </coding>
+      </fixedCodeableConcept>
+    </element>
+    <element id="DiagnosticReport.code">
+      <path value="DiagnosticReport.code" />
+      <fixedCodeableConcept>
+        <coding>
+          <system value="http://snomed.info/sct" />
+          <code value="721981007" />
+          <display value="Diagnostic studies report" />
+        </coding>
+      </fixedCodeableConcept>
     </element>
     <element id="DiagnosticReport.subject">
       <path value="DiagnosticReport.subject" />
@@ -42,15 +70,19 @@
       <path value="DiagnosticReport.effective[x]" />
       <constraint>
         <key value="ukcore-diag-lab-001" />
-        <severity value="error" />
+        <severity value="warning" />
         <human value="An effective time SHALL be given present if status = partial, preliminary, final, amended, corrected or appended" />
         <expression value="(effective.empty() and ((status != 'partial') or (status != 'preliminary') or (status != 'final') or (status != 'amended') or (status != 'corrected') or (status != 'appended'))) or effective.exists()" />
-        <source value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
       </constraint>
     </element>
     <element id="DiagnosticReport.result">
       <path value="DiagnosticReport.result" />
-      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-LabGroup" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />
+      </type>
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -26,6 +26,15 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
   <derivation value="constraint" />
   <differential>
+    <element id="Observation">
+      <path value="Observation" />
+      <constraint>
+        <key value="ukcore-obs-lab-001" />
+        <severity value="warning" />
+        <human value="Either value, dataAbsenseReason or note SHALL exist" />
+        <expression value="value.exists() or dataAbsentReason.exists() or note.exists()" />
+      </constraint>
+    </element>
     <element id="Observation.category">
       <path value="Observation.category" />
       <fixedCodeableConcept>

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -37,6 +37,20 @@
     </element>
     <element id="Observation.category">
       <path value="Observation.category" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="coding.code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="1" />
+    </element>
+    <element id="Observation.category:sliceLaboratory">
+      <path value="Observation.category" />
+      <sliceName value="sliceLaboratory" />
+      <min value="1" />
+      <max value="1" />
       <fixedCodeableConcept>
         <coding>
           <system value="http://terminology.hl7.org/CodeSystem/observation-category" />

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -51,9 +51,5 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
       </type>
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
-      <min value="1" />
-    </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-LabGroup.xml
+++ b/structuredefinitions/UKCore-Observation-LabGroup.xml
@@ -84,6 +84,8 @@
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-LabGroup" />
       </type>
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Observation-LabGroup.xml
+++ b/structuredefinitions/UKCore-Observation-LabGroup.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Observation-Group" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Group"/>
+  <id value="UKCore-Observation-LabGroup" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-LabGroup" />
   <version value="1.0.0" />
-  <name value="UKCoreObservationGroup" />
+  <name value="UKCoreObservationLabGroup" />
   <title value="UK Core Observation Group" />
   <status value="active" />
   <date value="2023-04-28" />
@@ -28,6 +28,25 @@
   <differential>
     <element id="Observation.category">
       <path value="Observation.category" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="coding.code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="1" />
+      <fixedCodeableConcept>
+        <coding>
+          <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+        </coding>
+      </fixedCodeableConcept>
+    </element>
+    <element id="Observation.category:sliceLaboratory">
+      <path value="Observation.category" />
+      <sliceName value="sliceLaboratory" />
+      <min value="1" />
+      <max value="1" />
       <fixedCodeableConcept>
         <coding>
           <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
@@ -50,6 +69,15 @@
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
       </type>
+    </element>
+    <element id="Observation.value[x]">
+      <path value="Observation.value[x]" />
+      <constraint>
+        <key value="ukcore-obs-labgrp-001" />
+        <severity value="warning" />
+        <human value="This element SHOULD NOT be used within this Profile" />
+        <expression value="value.empty()" />
+      </constraint>
     </element>
     <element id="Observation.hasMember">
       <path value="Observation.hasMember" />


### PR DESCRIPTION
# DiagnosticReport-Lab
- change result cardinality back to base
- add derived profiles to result
- change effective constraint to warning
- create slice on category
- change code to fixed value

# Observation-Group
- rename to include Lab in title
- slice category as above
- value[x] add constraint to warn not to use

# Observation-Lab
- change value back to base
- slice on category for Obs-Lab (I did not explicitly write this down as an action but presume it wanted doing?)
- warning constraint on value[x] / dataAbsenseReason / Note to say 1 of 3 SHALL exist

TODO
- Check UTL codes have changed  
- change examples to ensure constraints work
