### PR TITLE
Add PriorityReason Example for sending text

### DIFF
--- a/examples/UKCore-ServiceRequest-Extension-PriorityReason_SendingAsText-Example.xml
+++ b/examples/UKCore-ServiceRequest-Extension-PriorityReason_SendingAsText-Example.xml
@@ -1,0 +1,20 @@
+<ServiceRequest xmlns="http://hl7.org/fhir">
+	<id value="UKCore-ServiceRequest-Extension-PriorityReasonString-Example"/>
+	<priority value="urgent">
+		<!-- ***************extension start*************** -->
+		<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason">
+			<valueCodeableConcept>
+				<text value="Original assessment was delayed due to COVID-19 pandemic"/>
+			</valueCodeableConcept>
+		</extension>
+		<!-- **************extension end ****************** -->
+	</priority>
+	<status value="active"/>
+	<intent value="order"/>
+	<subject>
+		<reference value="Patient/UKCore-Patient-RichardSmith-Example"/>
+	</subject>
+	<requester>
+		<reference value="Practitioner/UKCore-Practitioner-DoctorPaulRastall-Example"/>
+	</requester>
+</ServiceRequest>


### PR DESCRIPTION
Add PriorityReason Example for sending text - no need to add anything to extension, ans codeableconcept allows us to use the .text