### PR TITLE
Fix/value set description

### DIFF
--- a/structuredefinitions/UKCore-Procedure.xml
+++ b/structuredefinitions/UKCore-Procedure.xml
@@ -107,7 +107,7 @@
           <valueString value="ProcedureCode" />
         </extension>
         <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK with the expression (&lt;&lt;71388002 |Procedure|&lt;&lt;129125009 |Procedure with explicit context|)." />
+        <description value="A code from the SNOMED Clinical Terminology UK." />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
       </binding>
     </element>

--- a/valuesets/ValueSet-UKCore-ObservationMethod.xml
+++ b/valuesets/ValueSet-UKCore-ObservationMethod.xml
@@ -16,7 +16,7 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-   <description value="Selected from the following SNOMED CT UK coding system: \n - descendantOrSelfOf 386053000 - Evaluation procedure"/>
+   <description value="Selected from the following SNOMED CT UK coding system: \n - descendantOrSelfOf 386053000 | Evaluation procedure"/>
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
    <compose>
       <include>

--- a/valuesets/ValueSet-UKCore-ObservationMethod.xml
+++ b/valuesets/ValueSet-UKCore-ObservationMethod.xml
@@ -16,7 +16,7 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-   <description value="A code from the SNOMED Clinical Terminology UK with the expression (&lt;&lt;386053000 | Evaluation procedure|)."/>
+   <description value="Selected from the following SNOMED CT UK coding system: \n - descendantOrSelfOf 386053000 - Evaluation procedure"/>
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
    <compose>
       <include>
@@ -24,7 +24,7 @@
          <filter>
             <property value="constraint"/>
             <op value="="/>
-            <value value="(&lt;&lt;386053000 | Evaluation procedure|)"/>
+            <value value="descendantOrSelfOf 386053000"/>
          </filter>
       </include>
    </compose>

--- a/valuesets/ValueSet-UKCore-ObservationType.xml
+++ b/valuesets/ValueSet-UKCore-ObservationType.xml
@@ -16,7 +16,7 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-	<description value="Selected from the following SNOMED CT UK coding system: \n - descendantOrSelfOf 363787002 - Observable entity."/>
+	<description value="Selected from the following SNOMED CT UK coding system: \n - descendantOrSelfOf 363787002 | Observable entity."/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>

--- a/valuesets/ValueSet-UKCore-ObservationType.xml
+++ b/valuesets/ValueSet-UKCore-ObservationType.xml
@@ -16,7 +16,7 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-	<description value="A code from the SNOMED Clinical Terminology UK with the expression (&lt;&lt;363787002 | Observable entity|)."/>
+	<description value="Selected from the following SNOMED CT UK coding system: \n - descendantOrSelfOf 363787002 - Observable entity."/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
 	<compose>
 		<include>
@@ -24,7 +24,7 @@
 			<filter>
 				<property value="constraint"/>
 				<op value="="/>
-				<value value="(&lt;&lt;363787002 | Observable entity|)"/>
+				<value value="descendantOrSelfOf 363787002"/>
 			</filter>
 		</include>
 	</compose>

--- a/valuesets/ValueSet-UKCore-ProcedureCode.xml
+++ b/valuesets/ValueSet-UKCore-ProcedureCode.xml
@@ -16,7 +16,7 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system: \n - descendantOrSelfOf 71388002 - Procedure \n - descendantOrSelfOf 129125009 - Procedure with explicit context"/>
+	<description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system: \n - descendantOrSelfOf 71388002 | Procedure \n - descendantOrSelfOf 129125009 | Procedure with explicit context"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html. This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement."/>
 	<compose>
 		<include>

--- a/valuesets/ValueSet-UKCore-ProcedureCode.xml
+++ b/valuesets/ValueSet-UKCore-ProcedureCode.xml
@@ -16,7 +16,7 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system."/>
+	<description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system: \n - descendantOrSelfOf 71388002 - Procedure \n - descendantOrSelfOf 129125009 - Procedure with explicit context"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html. This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement."/>
 	<compose>
 		<include>

--- a/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
+++ b/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
@@ -16,7 +16,7 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="A set of codes that define a reason for a service request. Selected from the following hierarchies within the SNOMED CT UK coding system: &#13; - descendantOrSelfOf 404684003 - Clinical finding &#13; - descendantOrSelfOf 71388002 - Procedure &#13; - descendantOrSelfOf 272379006 - Event &#13; - descendantOrSelfOf 363787002 - Observable entity &#13; - descendantOrSelfOf 243796009 - Situation with explicit context"/>
+	<description value="A set of codes that define a reason for a service request. Selected from the following hierarchies within the SNOMED CT UK coding system: &#13; - descendantOrSelfOf 404684003 | Clinical finding &#13; - descendantOrSelfOf 71388002 | Procedure &#13; - descendantOrSelfOf 272379006 | Event &#13; - descendantOrSelfOf 363787002 | Observable entity &#13; - descendantOrSelfOf 243796009 | Situation with explicit context"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<compose>
 		<include>

--- a/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
+++ b/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
@@ -16,7 +16,7 @@
 			<rank value="1"/>
 		</telecom>
 	</contact>
-	<description value="A set of codes that define a reason for a service request. Selected from the following hierarchies within the SNOMED CT UK coding system: &#13; - Clinical finding &#13; - Procedure &#13; - Event &#13; - Observable entity &#13; - Situation with explicit context"/>
+	<description value="A set of codes that define a reason for a service request. Selected from the following hierarchies within the SNOMED CT UK coding system: &#13; - descendantOrSelfOf 404684003 - Clinical finding &#13; - descendantOrSelfOf 71388002 - Procedure &#13; - descendantOrSelfOf 272379006 - Event &#13; - descendantOrSelfOf 363787002 - Observable entity &#13; - descendantOrSelfOf 243796009 - Situation with explicit context"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html."/>
 	<compose>
 		<include>

--- a/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
+++ b/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
 	<id value="UKCore-SourceOfServiceRequest"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SourceOfServiceRequest"/>
-	<version value="1.1.0"/>
+	<version value="1.2.0"/>
 	<name value="UKCoreSourceOfServiceRequest"/>
 	<title value="UK Core Source Of ServiceRequest"/>
 	<status value="active" />
-	<date value="2022-05-20" />
+	<date value="2023-04-28" />
 	<publisher value="HL7 UK" />
 	<contact>
 		<name value="HL7 UK" />
@@ -16,7 +16,7 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-	<description value="A set of codes that describe the source of the service request. Selected from the Referred by person and Self-referral hierarchies of the SNOMED CT UK coding system: \n - descendantOf 309013001 - Referred by person \n - descendantOf 306098008 - Self-referral"/>
+	<description value="A set of codes that describe the source of the service request. Selected from the Referred by person and Self-referral hierarchies of the SNOMED CT UK coding system: \n - descendantOf 309013001 | Referred by person \n - descendantOf 306098008 | Self-referral"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
+++ b/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
@@ -1,5 +1,5 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-	<id value="UKCore-ServiceRequestMethod"/>
+	<id value="UKCore-SourceOfServiceRequest"/>
 	<url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SourceOfServiceRequest"/>
 	<version value="1.1.0"/>
 	<name value="UKCoreSourceOfServiceRequest"/>
@@ -16,7 +16,7 @@
 			<rank value="1" />
 		</telecom>
 	</contact>
-	<description value="A set of codes that describe the source of the service request. Selected from the Referred by person and Self-referral hierarchies of the SNOMED CT UK coding system."/>
+	<description value="A set of codes that describe the source of the service request. Selected from the Referred by person and Self-referral hierarchies of the SNOMED CT UK coding system: \n - descendantOf 309013001 - Referred by person \n - descendantOf 306098008 - Self-referral"/>
 	<copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
     <compose>
         <include>


### PR DESCRIPTION
havent changed version number of dates for descriptions only. Might be patch update but to discuss?

The design and development approach says to use in the description:
SCTID - term

would 
SCTID | term

be better?