### PR TITLE
Set ID on extension examples to match updated filenames

### DIFF
--- a/examples/UKCore-DiagnosticReport-Extension-DeviceReference-Example.xml
+++ b/examples/UKCore-DiagnosticReport-Extension-DeviceReference-Example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <DiagnosticReport xmlns="http://hl7.org/fhir">
-	<id value="UKCore-DiagnosticReport-DeviceReference-Example"/>
+	<id value="UKCore-DiagnosticReport-Extension-DeviceReference-Example"/>
 	<status value="final"/>
 	<code>
 		<coding>

--- a/examples/UKCore-Specimen-Extension-SampleState-Example.xml
+++ b/examples/UKCore-Specimen-Extension-SampleState-Example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Specimen xmlns="http://hl7.org/fhir">
-	<id value="UKCore-Specimen-SampleState-Example"/>
+	<id value="UKCore-Specimen-Extension-SampleState-Example"/>
 	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SampleState">
 		<valueCodeableConcept>
 			<coding>


### PR DESCRIPTION
updated DeviceReference and SampleState example filenames to matcht he standard, but forgot to update the ID's, hence this pr