### PR TITLE
created servicerequest profile

### DIFF
--- a/structuredefinitions/UKCore-ServiceRequest-Lab.xml
+++ b/structuredefinitions/UKCore-ServiceRequest-Lab.xml
@@ -35,5 +35,18 @@
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
       </binding>
     </element>
+    <element id="ServiceRequest.reasonReference">
+      <path value="ServiceRequest.reasonReference" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Lab" />
+        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-LabGroup" />
+      </type>
+    </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-ServiceRequest-Lab.xml
+++ b/structuredefinitions/UKCore-ServiceRequest-Lab.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-ServiceRequest-Lab" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest-Lab" />
+  <version value="1.0.0" />
+  <name value="UKCoreServiceRequestLab" />
+  <title value="UK Core ServiceRequest Lab" />
+  <status value="active" />
+  <date value="2023-04-28" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="tba" />
+  <purpose value="tba" />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="ServiceRequest" />
+  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="ServiceRequest.code">
+      <path value="ServiceRequest.code" />
+      <definition value="A set of codes from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests and results." />
+      <binding>
+        <strength value="preferred" />
+        <description value="A set of codes that define laboratory medicine test requests and results. Selected from the SNOMED CT UK coding system." />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Created new derived profile and amended code element to bind to UTL ValueSet.

Needs a review to see if anything else needs changing. Should we have all the UTL ValueSet bindings (observation/diagnosticReport) as extensive? 