### PR TITLE
Fix missing / slightly broken references on RequestGroup example

### DIFF
--- a/examples/UKCore-MedicationDispense-ParacetamolOral-Example.xml
+++ b/examples/UKCore-MedicationDispense-ParacetamolOral-Example.xml
@@ -27,7 +27,7 @@
 		</actor>
 	</performer>
 	<authorizingPrescription>
-		<reference value="UKCore-MedicationRequest-ParacetamolOral-Example"/>
+		<reference value="MedicationRequest/UKCore-MedicationRequest-ParacetamolOral-Example"/>
 	</authorizingPrescription>
 	<quantity>
 		<value value="16"/>

--- a/examples/UKCore-RequestGroup-Paracetamol-Example.xml
+++ b/examples/UKCore-RequestGroup-Paracetamol-Example.xml
@@ -24,10 +24,10 @@
 			</coding>
 		</type>
 		<selectionBehavior value="at-most-one"/>
-		<action id="UKCore-MedicationDispense-ParacetamolOral-Example">
+		<action id="UKCore-MedicationRequest-ParacetamolOral-Example">
 			<description value="Paracetamol 500mg, four times a day orally."/>
 			<resource>
-				<reference value="MedicationRequest/UKCore-MedicationDispense-ParacetamolOral-Example"/>
+				<reference value="MedicationRequest/UKCore-MedicationRequest-ParacetamolOral-Example"/>
 			</resource>
 		</action>
 		<action id="UKCore-MedicationRequest-ParacetamolIV-Example">


### PR DESCRIPTION
Lack of resource/ on the med dispense meant simplifier couldn't render it

and request group had the right resource/ but not the right resource within that