### PR TITLE
stu3 iops2144 utl change

### DIFF
--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-Lab" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="UKCoreObservationLab" />
   <title value="UK Core Observation Lab" />
   <status value="active" />
-  <date value="2023-04-28" />
+  <date value="2023-11-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -65,8 +65,8 @@
       <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests and results" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
+        <description value="A code from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test results" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables" />
       </binding>
     </element>
     <element id="Observation.subject">

--- a/structuredefinitions/UKCore-Observation-LabGroup.xml
+++ b/structuredefinitions/UKCore-Observation-LabGroup.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-LabGroup" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-LabGroup" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="UKCoreObservationLabGroup" />
   <title value="UK Core Observation Lab Group" />
   <status value="active" />
-  <date value="2023-04-28" />
+  <date value="2023-11-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -70,8 +70,8 @@
       <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests and results" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
+        <description value="A code from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests and test group results" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
       </binding>
     </element>
     <element id="Observation.subject">

--- a/structuredefinitions/UKCore-ServiceRequest-Lab.xml
+++ b/structuredefinitions/UKCore-ServiceRequest-Lab.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-ServiceRequest-Lab" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest-Lab" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="UKCoreServiceRequestLab" />
   <title value="UK Core ServiceRequest Lab" />
   <status value="active" />
-  <date value="2023-04-28" />
+  <date value="2023-11-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -29,11 +29,11 @@
   <differential>
     <element id="ServiceRequest.code">
       <path value="ServiceRequest.code" />
-      <definition value="A set of codes from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests and results." />
+      <definition value="A set of codes from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests." />
       <binding>
         <strength value="preferred" />
-        <description value="A set of codes that define laboratory medicine test requests and results. Selected from the SNOMED CT UK coding system." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
+        <description value="A set of codes that define laboratory medicine test requests. Selected from the SNOMED CT UK coding system." />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
       </binding>
     </element>
     <element id="ServiceRequest.reasonReference">

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="UKCore-UnifiedTestList" />
-    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
+    <id value="UKCore-PathologyAndLaboratoryMedicineObservables" />
+    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables" />
     <version value="1.0.0" />
-    <name value="UKCoreUnifiedTestList" />
-    <title value="UK Core Unified Test List" />
+    <name value="UKCorePathologyAndLaboratoryMedicineObservables" />
+    <title value="UK Core Pathology And Laboratory Medicine Observables" />
     <status value="active" />
-    <date value="2023-04-28" />
+    <date value="2023-11-28" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />
@@ -16,8 +16,9 @@
             <rank value="1" />
         </telecom>
     </contact>
-    <description value="A set of codes regarding laboratory medicine test requests and results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
-	- memberOf 44991000237108 | Unified Test List simple reference set" />
+    <description value="A set of codes regarding laboratory medicine test results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: 
+	&#xD;&#xA; - memberOf 1853551000000106 | Pathology and laboratory medicine observable entity simple reference set
+	&#xD;&#xA; - memberOf 999002881000000100 | Pathology Bounded Code List observables simple reference set" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>
@@ -25,7 +26,7 @@
             <filter>
                 <property value="constraint" />
                 <op value="=" />
-                <value value="memberOf 44991000237108" />
+                <value value="memberOf 1853551000000106 or memberOf 999002881000000100" />
             </filter>
         </include>
     </compose>

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
@@ -1,0 +1,33 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="UKCore-PathologyAndLaboratoryMedicineProcedures" />
+    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
+    <version value="1.0.0" />
+    <name value="PathologyAndLaboratoryMedicineProcedures" />
+    <title value="UK Core Pathology And Laboratory Medicine Procedures" />
+    <status value="active" />
+    <date value="2023-11-28" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="A set of codes regarding laboratory medicine test requests and test group results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
+	- memberOf 1853561000000109 | Pathology and laboratory medicine procedure simple reference set" />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
+    <compose>
+        <include>
+            <system value="http://snomed.info/sct" />
+            <filter>
+                <property value="constraint" />
+                <op value="=" />
+                <value value="memberOf 1853561000000109" />
+            </filter>
+        </include>
+    </compose>
+</ValueSet>
+

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-PathologyAndLaboratoryMedicineProcedures" />
     <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
     <version value="1.0.0" />
-    <name value="PathologyAndLaboratoryMedicineProcedures" />
+    <name value="UKCorePathologyAndLaboratoryMedicineProcedures" />
     <title value="UK Core Pathology And Laboratory Medicine Procedures" />
     <status value="active" />
     <date value="2023-11-28" />

--- a/valuesets/ValueSet-UKCore-UnifiedTestList.xml
+++ b/valuesets/ValueSet-UKCore-UnifiedTestList.xml
@@ -1,0 +1,32 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="UKCore-UnifiedTestList" />
+    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-UnifiedTestList" />
+    <version value="1.0.0" />
+    <name value="UKCoreUnifiedTestList" />
+    <title value="UK Core Unified Test List" />
+    <status value="retired" />
+    <date value="2023-11-28" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="A set of codes regarding laboratory medicine test requests and results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
+	- memberOf 44991000237108 | Unified Test List simple reference set" />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
+    <compose>
+        <include>
+            <system value="http://snomed.info/sct" />
+            <filter>
+                <property value="constraint" />
+                <op value="=" />
+                <value value="memberOf 44991000237108" />
+            </filter>
+        </include>
+    </compose>
+</ValueSet>


### PR DESCRIPTION
UTL changed from single now inactive refset to two palm ones for observables and procedures. Observables valueset also needs the old pbcl refset, which is currently inactive (should be reactivated in end of nov snomed ct release)

2 new valuesets, and rebinding with version / date upgrade for 3 profiles that used utl

Will need to go into STU2, and IG changes in stu2/3