### PR TITLE
Add Short Descs to Extensions / MustSupport, plus 1..1 MustSupports (Stu3)

### DIFF
--- a/structuredefinitions/UKCore-AllergyIntolerance.xml
+++ b/structuredefinitions/UKCore-AllergyIntolerance.xml
@@ -30,7 +30,7 @@
     <element id="AllergyIntolerance.extension:evidence">
       <path value="AllergyIntolerance.extension" />
       <sliceName value="evidence" />
-      <short value="A reference to results of investigations that confirmed the certainty of the diagnosis." />
+      <short value="A reference to a DiagnosticReport resource for investigations that confirm the certainty of the allergy or intolerance diagnosis." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Evidence" />
@@ -38,11 +38,13 @@
     </element>
     <element id="AllergyIntolerance.clinicalStatus">
       <path value="AllergyIntolerance.clinicalStatus" />
+      <short value="Defines whether the allergy or intolerance is active, inactive or resolved." />
       <mustSupport value="true" />
     </element>
     <element id="AllergyIntolerance.clinicalStatus.extension:allergyIntoleranceEnd">
       <path value="AllergyIntolerance.clinicalStatus.extension" />
       <sliceName value="allergyIntoleranceEnd" />
+      <short value="The date when the allergy or intolerance clinicalStatus is updated to inactive or resolved." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AllergyIntoleranceEnd" />
@@ -51,10 +53,12 @@
     </element>
     <element id="AllergyIntolerance.verificationStatus">
       <path value="AllergyIntolerance.verificationStatus" />
+      <short value="Defines the assertion of the allergy or intolerance." />
       <mustSupport value="true" />
     </element>
     <element id="AllergyIntolerance.code">
       <path value="AllergyIntolerance.code" />
+      <short value="This code identifies the allergy or intolerance." />
       <min value="1" />
       <mustSupport value="true" />
       <binding>
@@ -64,10 +68,12 @@
     </element>
     <element id="AllergyIntolerance.patient">
       <path value="AllergyIntolerance.patient" />
+      <short value="Links the allergy or intolerance to the patient." />
       <mustSupport value="true" />
     </element>
     <element id="AllergyIntolerance.reaction">
       <path value="AllergyIntolerance.reaction" />
+      <short value="Details about each adverse reaction event." />
       <mustSupport value="true" />
     </element>
     <element id="AllergyIntolerance.reaction.substance">
@@ -86,6 +92,7 @@
     </element>
     <element id="AllergyIntolerance.reaction.severity">
       <path value="AllergyIntolerance.reaction.severity" />
+      <short value="A clinical assessment of the severity of the reaction event as a whole." />
       <mustSupport value="true" />
     </element>
     <element id="AllergyIntolerance.reaction.exposureRoute">

--- a/structuredefinitions/UKCore-Appointment.xml
+++ b/structuredefinitions/UKCore-Appointment.xml
@@ -30,6 +30,7 @@
     <element id="Appointment.extension:bookingOrganization">
       <path value="Appointment.extension" />
       <sliceName value="bookingOrganization" />
+      <short value="A reference to the source Organization of the booked appointment." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BookingOrganization" />
@@ -39,6 +40,7 @@
     <element id="Appointment.extension:deliveryChannel">
       <path value="Appointment.extension" />
       <sliceName value="deliveryChannel" />
+      <short value="Defines the delivery channel of a scheduled appointment." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -48,10 +50,12 @@
     </element>
     <element id="Appointment.status">
       <path value="Appointment.status" />
+      <short value="The overall status of the appointment." />
       <mustSupport value="true" />
     </element>
     <element id="Appointment.specialty">
       <path value="Appointment.specialty" />
+      <short value="The specialty of a practitioner that would be required to perform the service requested in this appointment." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -60,6 +64,7 @@
     </element>
     <element id="Appointment.appointmentType">
       <path value="Appointment.appointmentType" />
+      <short value="The type of appointment or patient that has been booked in the slot." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -69,22 +74,27 @@
     </element>
     <element id="Appointment.reasonCode">
       <path value="Appointment.reasonCode" />
+      <short value="The reason for the appointment." />
       <mustSupport value="true" />
     </element>
     <element id="Appointment.reasonReference">
       <path value="Appointment.reasonReference" />
+      <short value="A reference to the Observation, Condition, Procedure, or ImmunizationRecommendation that is the reason for the appointment." />
       <mustSupport value="true" />
     </element>
     <element id="Appointment.start">
       <path value="Appointment.start" />
+      <short value="The start time of the appointment." />
       <mustSupport value="true" />
     </element>
     <element id="Appointment.basedOn">
       <path value="Appointment.basedOn" />
+      <short value="The service request this appointment is allocated to assess." />
       <mustSupport value="true" />
     </element>
     <element id="Appointment.participant">
       <path value="Appointment.participant" />
+      <short value="A list of participants involved in the appointment." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Composition.xml
+++ b/structuredefinitions/UKCore-Composition.xml
@@ -34,6 +34,7 @@
     <element id="Composition.extension:careSettingType">
       <path value="Composition.extension" />
       <sliceName value="careSettingType" />
+      <short value="Used to support the type of care setting associated with a composition or a list." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -42,11 +43,12 @@
     </element>
     <element id="Composition.status">
       <path value="Composition.status" />
+      <short value="The workflow / clinical status of this composition." />
       <mustSupport value="true" />
     </element>
     <element id="Composition.type">
       <path value="Composition.type" />
-      <short value="Kind of composition (SNOMED CT)" />
+      <short value="Specifies the particular kind of composition." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -64,18 +66,22 @@
     </element>
     <element id="Composition.subject">
       <path value="Composition.subject" />
+      <short value="Who and / or what the composition is about." />
       <mustSupport value="true" />
     </element>
     <element id="Composition.author">
       <path value="Composition.author" />
+      <short value="Identifies who is responsible for the information in the composition." />
       <mustSupport value="true" />
     </element>
     <element id="Composition.confidentiality">
       <path value="Composition.confidentiality" />
+      <short value="The code specifying the level of confidentiality of the Composition." />
       <mustSupport value="true" />
     </element>
     <element id="Composition.custodian">
       <path value="Composition.custodian" />
+      <short value="Identifies the organization or group who is responsible for ongoing maintenance of and access to the composition/document information." />
       <mustSupport value="true" />
     </element>
     <element id="Composition.section.code">

--- a/structuredefinitions/UKCore-Condition.xml
+++ b/structuredefinitions/UKCore-Condition.xml
@@ -30,6 +30,7 @@
     <element id="Condition.extension:conditionEpisode">
       <path value="Condition.extension" />
       <sliceName value="conditionEpisode" />
+      <short value="The episodicity value of the condition can be represented by one of the following codes: \nfirst | new | review | end." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ConditionEpisode" />
@@ -37,10 +38,12 @@
     </element>
     <element id="Condition.clinicalStatus">
       <path value="Condition.clinicalStatus" />
+      <short value="The clinical status of the condition." />
       <mustSupport value="true" />
     </element>
     <element id="Condition.verificationStatus">
       <path value="Condition.verificationStatus" />
+      <short value="The verification status to support the clinical status of the condition." />
       <mustSupport value="true" />
     </element>
     <element id="Condition.category">
@@ -53,10 +56,12 @@
     </element>
     <element id="Condition.severity">
       <path value="Condition.severity" />
+      <short value="A subjective assessment of the severity of the condition as evaluated by the clinician." />
       <mustSupport value="true" />
     </element>
     <element id="Condition.code">
       <path value="Condition.code" />
+      <short value="Identification of the condition, problem or diagnosis." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -72,10 +77,12 @@
     </element>
     <element id="Condition.subject">
       <path value="Condition.subject" />
+      <short value="Indicates the patient or group who the condition record is associated with." />
       <mustSupport value="true" />
     </element>
     <element id="Condition.recorder">
       <path value="Condition.recorder" />
+      <short value="Individual who recorded the record and takes responsibility for its content." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Device-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Device-BloodPressure.xml
@@ -30,6 +30,7 @@
     <element id="Device.extension:cuffSize">
       <path value="Device.extension" />
       <sliceName value="cuffSize" />
+      <short value="A code representing the cuff size of a sphygmomanometer." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CuffSize" />

--- a/structuredefinitions/UKCore-Device.xml
+++ b/structuredefinitions/UKCore-Device.xml
@@ -29,10 +29,12 @@
   <differential>
     <element id="Device.status">
       <path value="Device.status" />
+      <short value="The status of the Device." />
       <mustSupport value="true" />
     </element>
     <element id="Device.type">
       <path value="Device.type" />
+      <short value="The type of the Device." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -82,10 +82,12 @@
     </element>
     <element id="DiagnosticReport.status">
       <path value="DiagnosticReport.status" />
+      <short value="The status of the diagnostic report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.category">
       <path value="DiagnosticReport.category" />
+      <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
       <slicing>
         <discriminator>
           <type value="value" />
@@ -99,6 +101,7 @@
     <element id="DiagnosticReport.category:laboratory">
       <path value="DiagnosticReport.category" />
       <sliceName value="laboratory" />
+      <short value="A mandatory slice that states this resource is categorized as laboratory related content." />
       <min value="1" />
       <max value="1" />
     </element>
@@ -112,6 +115,7 @@
     </element>
     <element id="DiagnosticReport.code">
       <path value="DiagnosticReport.code" />
+      <short value="A code or name that describes this diagnostic report." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -120,6 +124,7 @@
     </element>
     <element id="DiagnosticReport.subject">
       <path value="DiagnosticReport.subject" />
+      <short value="The patient that is the subject of the report." />
       <min value="1" />
       <type>
         <code value="Reference" />
@@ -129,11 +134,13 @@
     </element>
     <element id="DiagnosticReport.issued">
       <path value="DiagnosticReport.issued" />
+      <short value="Clinically relevant time / time-period for report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.performer.extension:deviceReference">
       <path value="DiagnosticReport.performer.extension" />
       <sliceName value="deviceReference" />
+      <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -144,6 +151,7 @@
     <element id="DiagnosticReport.resultsInterpreter.extension:deviceReference">
       <path value="DiagnosticReport.resultsInterpreter.extension" />
       <sliceName value="deviceReference" />
+      <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference" />
@@ -152,6 +160,7 @@
     </element>
     <element id="DiagnosticReport.result">
       <path value="DiagnosticReport.result" />
+      <short value="Lab related Observations that are part of this diagnostic report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.conclusionCode">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -73,14 +73,17 @@
     </element>
     <element id="DiagnosticReport.status">
       <path value="DiagnosticReport.status" />
+      <short value="The status of the diagnostic report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.category">
       <path value="DiagnosticReport.category" />
+      <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.code">
       <path value="DiagnosticReport.code" />
+      <short value="A code or name that describes this diagnostic report." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -89,19 +92,23 @@
     </element>
     <element id="DiagnosticReport.subject">
       <path value="DiagnosticReport.subject" />
+      <short value="The subject of the report - usually, but not always, the patient." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.encounter">
       <path value="DiagnosticReport.encounter" />
+      <short value="Health care event when test ordered." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.issued">
       <path value="DiagnosticReport.issued" />
+      <short value="Clinically relevant time / time-period for report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.performer.extension:deviceReference">
       <path value="DiagnosticReport.performer.extension" />
       <sliceName value="deviceReference" />
+      <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -112,6 +119,7 @@
     <element id="DiagnosticReport.resultsInterpreter.extension:deviceReference">
       <path value="DiagnosticReport.resultsInterpreter.extension" />
       <sliceName value="deviceReference" />
+      <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference" />
@@ -120,6 +128,7 @@
     </element>
     <element id="DiagnosticReport.result">
       <path value="DiagnosticReport.result" />
+      <short value="Observations that are part of this diagnostic report." />
       <mustSupport value="true" />
     </element>
     <element id="DiagnosticReport.conclusionCode">

--- a/structuredefinitions/UKCore-Encounter.xml
+++ b/structuredefinitions/UKCore-Encounter.xml
@@ -69,10 +69,12 @@
     </element>
     <element id="Encounter.identifier">
       <path value="Encounter.identifier" />
+      <short value="Identifier(s) by which this encounter is known." />
       <mustSupport value="true" />
     </element>
     <element id="Encounter.class">
       <path value="Encounter.class" />
+      <short value="Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations." />
       <mustSupport value="true" />
     </element>
     <element id="Encounter.type">
@@ -93,18 +95,22 @@
     </element>
     <element id="Encounter.subject">
       <path value="Encounter.subject" />
+      <short value="The patient or group present at the encounter." />
       <mustSupport value="true" />
     </element>
     <element id="Encounter.participant">
       <path value="Encounter.participant" />
+      <short value="The list of people responsible for providing the service." />
       <mustSupport value="true" />
     </element>
     <element id="Encounter.reasonCode">
       <path value="Encounter.reasonCode" />
+      <short value="Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis." />
       <mustSupport value="true" />
     </element>
     <element id="Encounter.reasonReference">
       <path value="Encounter.reasonReference" />
+      <short value="Reason the encounter takes place, expressed as a reference to a Condition, Procedure, Observation, or ImmunizationRecommendation." />
       <mustSupport value="true" />
     </element>
     <element id="Encounter.hospitalization.extension:admissionMethod">

--- a/structuredefinitions/UKCore-FamilyMemberHistory.xml
+++ b/structuredefinitions/UKCore-FamilyMemberHistory.xml
@@ -30,6 +30,7 @@
     <element id="FamilyMemberHistory.extension:associatedEncounter">
       <path value="FamilyMemberHistory.extension" />
       <sliceName value="associatedEncounter" />
+      <short value="This extension is used to reference an associated encounter." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AssociatedEncounter" />
@@ -66,6 +67,7 @@
     </element>
     <element id="FamilyMemberHistory.status">
       <path value="FamilyMemberHistory.status" />
+      <short value="A code specifying the status of the record of the family history of a specific family member." />
       <mustSupport value="true" />
     </element>
     <element id="FamilyMemberHistory.dataAbsentReason">
@@ -76,18 +78,22 @@
     </element>
     <element id="FamilyMemberHistory.patient">
       <path value="FamilyMemberHistory.patient" />
+      <short value="The person who this history concerns." />
       <mustSupport value="true" />
     </element>
     <element id="FamilyMemberHistory.date">
       <path value="FamilyMemberHistory.date" />
+      <short value="The date (and possibly time) when the family member history was recorded or last updated." />
       <mustSupport value="true" />
     </element>
     <element id="FamilyMemberHistory.name">
       <path value="FamilyMemberHistory.name" />
+      <short value="Allows greater ease in ensuring the same person is being talked about." />
       <mustSupport value="true" />
     </element>
     <element id="FamilyMemberHistory.relationship">
       <path value="FamilyMemberHistory.relationship" />
+      <short value="Relationship to the subject." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -96,6 +102,7 @@
     </element>
     <element id="FamilyMemberHistory.condition">
       <path value="FamilyMemberHistory.condition" />
+      <short value="Condition that the related person had." />
       <mustSupport value="true" />
     </element>
     <element id="FamilyMemberHistory.condition.code">

--- a/structuredefinitions/UKCore-HealthcareService.xml
+++ b/structuredefinitions/UKCore-HealthcareService.xml
@@ -29,10 +29,12 @@
   <differential>
     <element id="HealthcareService.providedBy">
       <path value="HealthcareService.providedBy" />
+      <short value="The organization that provides this healthcare service." />
       <mustSupport value="true" />
     </element>
     <element id="HealthcareService.type">
       <path value="HealthcareService.type" />
+      <short value="The type of service provided by this healthcare service." />
       <mustSupport value="true" />
     </element>
     <element id="HealthcareService.specialty">

--- a/structuredefinitions/UKCore-List.xml
+++ b/structuredefinitions/UKCore-List.xml
@@ -30,7 +30,7 @@
     <element id="List.extension:careSettingType">
       <path value="List.extension" />
       <sliceName value="careSettingType" />
-      <short value="An extension to carry the Care setting type." />
+      <short value="An extension to support the type of care setting associated with a composition or a list." />
       <definition value="An extension to carry the Care setting type." />
       <max value="1" />
       <type>
@@ -41,7 +41,7 @@
     <element id="List.extension:listWarningCode">
       <path value="List.extension" />
       <sliceName value="listWarningCode" />
-      <short value="To capture warnings that the list may be incomplete." />
+      <short value="To support warnings that a list may be incomplete as data has been excluded due to confidentiality or may be missing due to data being in transit." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ListWarningCode" />
@@ -49,10 +49,12 @@
     </element>
     <element id="List.status">
       <path value="List.status" />
+      <short value="Indicates the current state of this list." />
       <mustSupport value="true" />
     </element>
     <element id="List.code">
       <path value="List.code" />
+      <short value="This code defines the purpose of the list - why it was created." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -61,6 +63,7 @@
     </element>
     <element id="List.subject">
       <path value="List.subject" />
+      <short value="The common subject (or patient) of the resources that are in the list if there is one." />
       <mustSupport value="true" />
     </element>
     <element id="List.emptyReason">

--- a/structuredefinitions/UKCore-Location.xml
+++ b/structuredefinitions/UKCore-Location.xml
@@ -57,14 +57,17 @@
     </element>
     <element id="Location.status">
       <path value="Location.status" />
+      <short value="Is the location active, inactive, or suspended" />
       <mustSupport value="true" />
     </element>
     <element id="Location.name">
       <path value="Location.name" />
+      <short value="Name of the location as used by humans. This does not need to be unique." />
       <mustSupport value="true" />
     </element>
     <element id="Location.address">
       <path value="Location.address" />
+      <short value="If locations can be visited, we need to keep track of their address." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Medication.xml
+++ b/structuredefinitions/UKCore-Medication.xml
@@ -30,7 +30,7 @@
     <element id="Medication.extension:MedicationTradeFamily">
       <path value="Medication.extension" />
       <sliceName value="MedicationTradeFamily" />
-      <short value="A Trade Family or brand associated with a Medication, in particular a Virtual Therapeutic Moiety (VTM)" />
+      <short value="Used to identify a Trade Family or brand associated with a Medication, specifically when the medication is defined using a dm+d Virtual Therapeutic Moiety (VTM) concept" />
       <definition value="A Trade Family or brand associated with a Medication, in particular a Virtual Therapeutic Moiety (VTM)." />
       <type>
         <code value="Extension" />
@@ -39,6 +39,7 @@
     </element>
     <element id="Medication.code">
       <path value="Medication.code" />
+      <short value="Codes that identify this medication" />
       <min value="1" />
       <mustSupport value="true" />
       <binding>

--- a/structuredefinitions/UKCore-MedicationAdministration.xml
+++ b/structuredefinitions/UKCore-MedicationAdministration.xml
@@ -29,10 +29,12 @@
   <differential>
     <element id="MedicationAdministration.identifier">
       <path value="MedicationAdministration.identifier" />
+      <short value="Allows the resource to be referenced within / by other resources." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationAdministration.status">
       <path value="MedicationAdministration.status" />
+      <short value="Allows an administration to be marked as in-progress or completed." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationAdministration.category">
@@ -44,6 +46,7 @@
     </element>
     <element id="MedicationAdministration.medication[x]">
       <path value="MedicationAdministration.medication[x]" />
+      <short value="Identifies the medication that was administered." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -52,14 +55,17 @@
     </element>
     <element id="MedicationAdministration.subject">
       <path value="MedicationAdministration.subject" />
+      <short value="Identifies the patient receiving the medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationAdministration.effective[x]">
       <path value="MedicationAdministration.effective[x]" />
+      <short value="The start and end time of the administration." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationAdministration.dosage">
       <path value="MedicationAdministration.dosage" />
+      <short value="The dosage instruction for the administered medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationAdministration.dosage.site">

--- a/structuredefinitions/UKCore-MedicationDispense.xml
+++ b/structuredefinitions/UKCore-MedicationDispense.xml
@@ -29,14 +29,17 @@
   <differential>
     <element id="MedicationDispense.identifier">
       <path value="MedicationDispense.identifier" />
+      <short value="Allows the resource to be referenced within / by other resources." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.status">
       <path value="MedicationDispense.status" />
+      <short value="A code that describes the status of the dispensing event." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.medication[x]">
       <path value="MedicationDispense.medication[x]" />
+      <short value="What medication was supplied." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -45,10 +48,12 @@
     </element>
     <element id="MedicationDispense.subject">
       <path value="MedicationDispense.subject" />
+      <short value="Identifies the patient." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.performer">
       <path value="MedicationDispense.performer" />
+      <short value="Who or what performed the dispensing event." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.type">
@@ -60,22 +65,27 @@
     </element>
     <element id="MedicationDispense.quantity">
       <path value="MedicationDispense.quantity" />
+      <short value="Quantity of medication dispensed." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.whenPrepared">
       <path value="MedicationDispense.whenPrepared" />
+      <short value="Timestamp for when the medication was prepared." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.dosageInstruction">
       <path value="MedicationDispense.dosageInstruction" />
+      <short value="Dosage instruction for the dispensed medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.dosageInstruction.text">
       <path value="MedicationDispense.dosageInstruction.text" />
+      <short value="Free text dosage instructions." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.dosageInstruction.timing">
       <path value="MedicationDispense.dosageInstruction.timing" />
+      <short value="When medication should be administered." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.dosageInstruction.asNeeded[x]">
@@ -107,14 +117,17 @@
     </element>
     <element id="MedicationDispense.dosageInstruction.doseAndRate">
       <path value="MedicationDispense.dosageInstruction.doseAndRate" />
+      <short value="Dosage instructions for the medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.dosageInstruction.doseAndRate.dose[x]">
       <path value="MedicationDispense.dosageInstruction.doseAndRate.dose[x]" />
+      <short value="Quantity of medication administered." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationDispense.dosageInstruction.doseAndRate.rate[x]">
       <path value="MedicationDispense.dosageInstruction.doseAndRate.rate[x]" />
+      <short value="Rate at which the medication is to be administered." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-MedicationRequest.xml
+++ b/structuredefinitions/UKCore-MedicationRequest.xml
@@ -30,6 +30,7 @@
     <element id="MedicationRequest.extension:medicationRepeatInformation">
       <path value="MedicationRequest.extension" />
       <sliceName value="medicationRepeatInformation" />
+      <short value="Allows the resource to be referenced within / by other resources." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation" />
@@ -37,18 +38,22 @@
     </element>
     <element id="MedicationRequest.identifier">
       <path value="MedicationRequest.identifier" />
+      <short value="Allows the resource to be referenced within / by other resources." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.status">
       <path value="MedicationRequest.status" />
+      <short value="A code specifying the current state of the order." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.intent">
       <path value="MedicationRequest.intent" />
+      <short value="Whether the request is a proposal, plan, or an original order." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.category">
       <path value="MedicationRequest.category" />
+      <short value="Provides the business context for the relevant dispensing processes." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -57,6 +62,7 @@
     </element>
     <element id="MedicationRequest.medication[x]">
       <path value="MedicationRequest.medication[x]" />
+      <short value="Identifies the medication being requested." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -65,14 +71,17 @@
     </element>
     <element id="MedicationRequest.subject">
       <path value="MedicationRequest.subject" />
+      <short value="Who the medication request is for." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.authoredOn">
       <path value="MedicationRequest.authoredOn" />
+      <short value="The date / time that the medication request was initially authored." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.requester">
       <path value="MedicationRequest.requester" />
+      <short value="Who is requesting the medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.courseOfTherapyType">
@@ -86,14 +95,17 @@
     </element>
     <element id="MedicationRequest.dosageInstruction">
       <path value="MedicationRequest.dosageInstruction" />
+      <short value="Dosage instructions for the medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dosageInstruction.text">
       <path value="MedicationRequest.dosageInstruction.text" />
+      <short value="Free text dosage instructions." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dosageInstruction.timing">
       <path value="MedicationRequest.dosageInstruction.timing" />
+      <short value="When the medication should be administered." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dosageInstruction.asNeeded[x]">
@@ -125,26 +137,32 @@
     </element>
     <element id="MedicationRequest.dosageInstruction.doseAndRate">
       <path value="MedicationRequest.dosageInstruction.doseAndRate" />
+      <short value="Dosage instructions for the requested medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dosageInstruction.doseAndRate.dose[x]">
       <path value="MedicationRequest.dosageInstruction.doseAndRate.dose[x]" />
+      <short value="Quantity of requested medication to be administered." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dosageInstruction.doseAndRate.rate[x]">
       <path value="MedicationRequest.dosageInstruction.doseAndRate.rate[x]" />
+      <short value="Rate at which the requested medication is to be administered." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dispenseRequest">
       <path value="MedicationRequest.dispenseRequest" />
+      <short value="Specific dispensing quantity instructions." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.dispenseRequest.quantity">
       <path value="MedicationRequest.dispenseRequest.quantity" />
+      <short value=">Amount of medication to supply per dispense." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationRequest.substitution">
       <path value="MedicationRequest.substitution" />
+      <short value="Any restrictions on medication substitution." />
       <min value="1" />
       <mustSupport value="true" />
     </element>

--- a/structuredefinitions/UKCore-MedicationStatement.xml
+++ b/structuredefinitions/UKCore-MedicationStatement.xml
@@ -30,7 +30,7 @@
     <element id="MedicationStatement.extension:pharmacistVerifiedIndicator">
       <path value="MedicationStatement.extension" />
       <sliceName value="pharmacistVerifiedIndicator" />
-      <short value="Indicates whether a pharmacist verified a medication" />
+      <short value="Indicates whether a pharmacist verified a medication." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PharmacistVerifiedIndicator" />
@@ -39,6 +39,7 @@
     <element id="MedicationStatement.extension:medicationPrescribingOrganizationType">
       <path value="MedicationStatement.extension" />
       <sliceName value="medicationPrescribingOrganizationType" />
+      <short value="Identifies if the medication was `prescribed-at-gp-practice` or `prescribed-by-another-organisation`.\n\nThis extension is likely only to be populated by GP systems." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationPrescribingOrganizationType" />
@@ -47,6 +48,7 @@
     <element id="MedicationStatement.extension:medicationStatementLastIssueDate">
       <path value="MedicationStatement.extension" />
       <sliceName value="medicationStatementLastIssueDate" />
+      <short value="The date or date/time that the medication described in the `MedicationStatement` was last requested/prescribed.\n\nThe presence of this data does not imply medication has been dispensed or supplied to the patient." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationStatementLastIssueDate" />
@@ -54,6 +56,7 @@
     </element>
     <element id="MedicationStatement.identifier">
       <path value="MedicationStatement.identifier" />
+      <short value="Allows the resource to be referenced within / by other resources." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.identifier.system">
@@ -66,14 +69,17 @@
     </element>
     <element id="MedicationStatement.basedOn">
       <path value="MedicationStatement.basedOn" />
+      <short value="To reference to a `MedicationRequest` resource, where applicable." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.status">
       <path value="MedicationStatement.status" />
+      <short value="A code representing the patient or other source's judgement about the state of the medication used that this statement is about." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.category">
       <path value="MedicationStatement.category" />
+      <short value="Indicates where the medication is expected to be consumed or administered." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -82,6 +88,7 @@
     </element>
     <element id="MedicationStatement.medication[x]">
       <path value="MedicationStatement.medication[x]" />
+      <short value="Identifies the medication being administered." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -90,26 +97,32 @@
     </element>
     <element id="MedicationStatement.subject">
       <path value="MedicationStatement.subject" />
+      <short value="Who is / was taking the medication." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.effective[x]">
       <path value="MedicationStatement.effective[x]" />
+      <short value="The date / time, or interval, when the medication is / was / will be taken." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.dateAsserted">
       <path value="MedicationStatement.dateAsserted" />
+      <short value="To timestamp the statement assertion." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.informationSource">
       <path value="MedicationStatement.informationSource" />
+      <short value="To reference other resources, where applicable." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.derivedFrom">
       <path value="MedicationStatement.derivedFrom" />
+      <short value="To reference other resources, where applicable." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.dosage">
       <path value="MedicationStatement.dosage" />
+      <short value="The medication dosage for the statement." />
       <mustSupport value="true" />
     </element>
     <element id="MedicationStatement.dosage.asNeeded[x]">

--- a/structuredefinitions/UKCore-Observation-Group-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Group-Lab.xml
@@ -83,10 +83,6 @@
     </element>
     <element id="Observation.status">
       <path value="Observation.status" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.status">
-      <path value="Observation.status" />
       <short value="The status of the result value." />
       <mustSupport value="true" />
     </element>

--- a/structuredefinitions/UKCore-Observation-Group-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Group-Lab.xml
@@ -32,7 +32,7 @@
       <constraint>
         <key value="ukcore-obs-grplab-001" />
         <severity value="warning" />
-        <human value="value[x] SHOULD NOT be used within this Profile" />
+        <human value="`value[x]` SHOULD NOT be used within this Profile" />
         <expression value="value.empty()" />
       </constraint>
     </element>
@@ -85,8 +85,14 @@
       <path value="Observation.extension.url" />
       <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure" />
     </element>
+    <element id="Observation.status">
+      <path value="Observation.status" />
+      <short value="The status of the result value." />
+      <mustSupport value="true" />
+    </element>
     <element id="Observation.category">
       <path value="Observation.category" />
+      <short value="A code that classifies the general type of observation being made." />
       <slicing>
         <discriminator>
           <type value="value" />
@@ -99,6 +105,7 @@
     <element id="Observation.category:laboratory">
       <path value="Observation.category" />
       <sliceName value="laboratory" />
+      <short value="A mandatory code, to identify this observation as being Lab related." />
       <min value="1" />
       <max value="1" />
     </element>
@@ -112,6 +119,8 @@
     </element>
     <element id="Observation.code">
       <path value="Observation.code" />
+      <short value="The type of observation (code / type)." />
+      <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
         <description value="A code from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test requests and test group results" />

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -32,7 +32,7 @@
       <constraint>
         <key value="ukcore-obs-lab-001" />
         <severity value="warning" />
-        <human value="Either value, dataAbsentReason or note SHOULD be populated" />
+        <human value="Either `value`, `dataAbsentReason` or `note` SHOULD be populated" />
         <expression value="value.exists() or dataAbsentReason.exists() or note.exists()" />
       </constraint>
     </element>
@@ -81,8 +81,14 @@
         <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure" />
       </type>
     </element>
+    <element id="Observation.status">
+      <path value="Observation.status" />
+      <short value="The status of the result value." />
+      <mustSupport value="true" />
+    </element>
     <element id="Observation.category">
       <path value="Observation.category" />
+      <short value="A code that classifies the general type of observation being made." />
       <slicing>
         <discriminator>
           <type value="value" />
@@ -95,6 +101,7 @@
     <element id="Observation.category:laboratory">
       <path value="Observation.category" />
       <sliceName value="laboratory" />
+      <short value="A mandatory code, to identify this observation as being Lab related." />
       <min value="1" />
       <max value="1" />
     </element>
@@ -108,6 +115,8 @@
     </element>
     <element id="Observation.code">
       <path value="Observation.code" />
+      <short value="The type of lab related observation (code / type)." />
+      <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
         <description value="A code from the SNOMED Clinical Terminology UK coding system regrading laboratory medicine test results" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -32,13 +32,14 @@
       <constraint>
         <key value="ukcore-obs-vs-001" />
         <severity value="error" />
-        <human value="code.coding SHALL include a LOINC &quot;magic code&quot;" />
+        <human value="`code.coding` SHALL include a LOINC &quot;magic code&quot;" />
         <expression value="code.coding.where(system='http://loinc.org').exists()" />
       </constraint>
     </element>
     <element id="Observation.extension:bodyPosition">
       <path value="Observation.extension" />
       <sliceName value="bodyPosition" />
+      <short value="The patients body position when the vital signs observation was recorded." />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition" />
@@ -55,6 +56,7 @@
     <element id="Observation.extension:recordingSetting">
       <path value="Observation.extension" />
       <sliceName value="recordingSetting" />
+      <short value="Records whether the vital signs observation was performed in a clinical or non clinical setting." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting" />
@@ -64,9 +66,11 @@
     <element id="Observation.status">
       <path value="Observation.status" />
       <fixedCode value="final" />
+      <short value="A status of `final` SHALL be present." />
     </element>
     <element id="Observation.category">
       <path value="Observation.category" />
+      <short value="A category of `vital-signs` SHALL be present." />
       <min value="1" />
       <max value="1" />
     </element>
@@ -77,6 +81,12 @@
     <element id="Observation.category.coding.code">
       <path value="Observation.category.coding.code" />
       <fixedCode value="vital-signs" />
+    </element>
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <short value="The type of vital signs observation (code / type)." />
+      <min value="1" />
+      <max value="1" />
     </element>
     <element id="Observation.code.coding">
       <path value="Observation.code.coding" />
@@ -91,6 +101,7 @@
     <element id="Observation.code.coding:loinc">
       <path value="Observation.code.coding" />
       <sliceName value="loinc" />
+      <short value="A LOINC &quot;magic code&quot; describing the type of observation SHALL be present." />
       <min value="1" />
       <max value="1" />
       <binding>
@@ -105,6 +116,7 @@
     <element id="Observation.code.coding:snomedCT">
       <path value="Observation.code.coding" />
       <sliceName value="snomedCT" />
+      <short value="A SNOMED CT concept describing the type of observation SHALL be present." />
       <min value="1" />
       <binding>
         <strength value="preferred" />
@@ -118,10 +130,12 @@
     </element>
     <element id="Observation.subject">
       <path value="Observation.subject" />
+      <short value="Who or what the observation relates to SHALL be present." />
       <min value="1" />
     </element>
     <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
+      <short value="A clinically relevant time / time-period for observation SHALL be present." />
       <min value="1" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Observation.xml
+++ b/structuredefinitions/UKCore-Observation.xml
@@ -74,14 +74,17 @@
     </element>
     <element id="Observation.status">
       <path value="Observation.status" />
+      <short value="The status of the result value." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.category">
       <path value="Observation.category" />
+      <short value="A code that classifies the general type of observation being made." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.code">
       <path value="Observation.code" />
+      <short value="The type of observation (code / type)." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -91,18 +94,22 @@
     </element>
     <element id="Observation.subject">
       <path value="Observation.subject" />
+      <short value="Who and / or what the observation is about." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
+      <short value="A clinically relevant time / time-period for observation." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.performer">
       <path value="Observation.performer" />
+      <short value="Who is responsible for the observation." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
+      <short value="The actual observed result." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.bodySite">
@@ -119,6 +126,7 @@
     </element>
     <element id="Observation.component">
       <path value="Observation.component" />
+      <short value="Component / sub results." />
       <mustSupport value="true" />
     </element>
     <element id="Observation.component.code">

--- a/structuredefinitions/UKCore-Organization.xml
+++ b/structuredefinitions/UKCore-Organization.xml
@@ -30,7 +30,7 @@
     <element id="Organization.extension:mainLocation">
       <path value="Organization.extension" />
       <sliceName value="mainLocation" />
-      <short value="Main location" />
+      <short value="The main location of the organisation." />
       <definition value="The main location of the organisation." />
       <type>
         <code value="Extension" />
@@ -54,6 +54,7 @@
     </element>
     <element id="Organization.identifier">
       <path value="Organization.identifier" />
+      <short value="Identifies this organization across multiple systems." />
       <slicing>
         <discriminator>
           <type value="value" />
@@ -98,6 +99,7 @@
     </element>
     <element id="Organization.active">
       <path value="Organization.active" />
+      <short value="Identifies this organization across multiple systems." />
       <mustSupport value="true" />
     </element>
     <element id="Organization.type">
@@ -110,14 +112,17 @@
     </element>
     <element id="Organization.name">
       <path value="Organization.name" />
+      <short value="A name associated with the organization." />
       <mustSupport value="true" />
     </element>
     <element id="Organization.telecom">
       <path value="Organization.telecom" />
+      <short value="Contact details for the organization." />
       <mustSupport value="true" />
     </element>
     <element id="Organization.address">
       <path value="Organization.address" />
+      <short value="An address for the organization." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Patient.xml
+++ b/structuredefinitions/UKCore-Patient.xml
@@ -76,6 +76,7 @@
     <element id="Patient.extension:deathNotificationStatus">
       <path value="Patient.extension" />
       <sliceName value="deathNotificationStatus" />
+      <short value="The patient's death notification status." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeathNotificationStatus" />
@@ -88,7 +89,7 @@
     <element id="Patient.extension:ethnicCategory">
       <path value="Patient.extension" />
       <sliceName value="ethnicCategory" />
-      <short value="The ethnicity of the subject" />
+      <short value="The ethnicity of the subject." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -107,6 +108,7 @@
     <element id="Patient.extension:patientInterpreterRequired">
       <path value="Patient.extension" />
       <sliceName value="patientInterpreterRequired" />
+      <short value="Indicator showing whether the patient needs an interpreter." />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired" />
@@ -120,7 +122,7 @@
     <element id="Patient.extension:nhsNumberUnavailableReason">
       <path value="Patient.extension" />
       <sliceName value="nhsNumberUnavailableReason" />
-      <short value="Reason why this Patient does not include an NHS Number identifier" />
+      <short value="Reason why this Patient does not include an NHS Number identifier." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberUnavailableReason" />
@@ -129,6 +131,7 @@
     </element>
     <element id="Patient.identifier">
       <path value="Patient.identifier" />
+      <short value="An identifier for this patient." />
       <slicing>
         <discriminator>
           <type value="value" />
@@ -142,7 +145,7 @@
     <element id="Patient.identifier:nhsNumber">
       <path value="Patient.identifier" />
       <sliceName value="nhsNumber" />
-      <short value="The patient's NHS number" />
+      <short value="The patient's NHS number." />
       <max value="1" />
       <mustSupport value="false" />
     </element>
@@ -160,61 +163,49 @@
       <path value="Patient.identifier.system" />
       <min value="1" />
       <fixedUri value="https://fhir.nhs.uk/Id/nhs-number" />
-      <mustSupport value="true" />
     </element>
     <element id="Patient.identifier:nhsNumber.value">
       <path value="Patient.identifier.value" />
       <min value="1" />
-      <mustSupport value="true" />
     </element>
     <element id="Patient.active">
       <path value="Patient.active" />
+      <short value="Whether this patient's record is in active use." />
       <mustSupport value="true" />
     </element>
     <element id="Patient.name">
       <path value="Patient.name" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.name.family">
-      <path value="Patient.name.family" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.name.given">
-      <path value="Patient.name.given" />
+      <short value="A name associated with the patient." />
       <mustSupport value="true" />
     </element>
     <element id="Patient.telecom">
       <path value="Patient.telecom" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.telecom.system">
-      <path value="Patient.telecom.system" />
+      <short value="A contact detail for the individual." />
       <mustSupport value="true" />
     </element>
     <element id="Patient.telecom.system.extension:otherContactSystem">
       <path value="Patient.telecom.system.extension" />
       <sliceName value="otherContactSystem" />
+      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
       </type>
     </element>
-    <element id="Patient.telecom.value">
-      <path value="Patient.telecom.value" />
-      <mustSupport value="true" />
-    </element>
     <element id="Patient.gender">
       <path value="Patient.gender" />
+      <short value="The gender that the patient is considered to have for administration and record keeping purposes." />
       <mustSupport value="true" />
     </element>
     <element id="Patient.birthDate">
       <path value="Patient.birthDate" />
+      <short value="The date of birth for the individual." />
       <mustSupport value="true" />
     </element>
     <element id="Patient.birthDate.extension:birthTime">
       <path value="Patient.birthDate.extension" />
       <sliceName value="birthTime" />
-      <short value="Time of day of birth." />
+      <short value="The time of day that the patient was born. This SHOULD be included when the birth time is relevant." />
       <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
       <type>
         <code value="Extension" />
@@ -228,7 +219,7 @@
     </element>
     <element id="Patient.address">
       <path value="Patient.address" />
-      <definition value="An address for the individual" />
+      <definition value="An address for the individual." />
       <mustSupport value="true" />
     </element>
     <element id="Patient.address.extension:addressKey">
@@ -242,18 +233,6 @@
       </type>
       <mustSupport value="false" />
     </element>
-    <element id="Patient.address.line">
-      <path value="Patient.address.line" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.address.city">
-      <path value="Patient.address.city" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.address.postalCode">
-      <path value="Patient.address.postalCode" />
-      <mustSupport value="true" />
-    </element>
     <element id="Patient.maritalStatus">
       <path value="Patient.maritalStatus" />
       <binding>
@@ -265,6 +244,7 @@
     <element id="Patient.contact.extension:contactRank">
       <path value="Patient.contact.extension" />
       <sliceName value="contactRank" />
+      <short value="The preferred ranking or order of contact applied to a contact on a Patient's contact list." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactRank" />
@@ -273,6 +253,7 @@
     <element id="Patient.contact.extension:copyCorrespondenceIndicator">
       <path value="Patient.contact.extension" />
       <sliceName value="copyCorrespondenceIndicator" />
+      <short value="Indicates that a must be copied in to all related correspondence." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CopyCorrespondenceIndicator" />
@@ -288,6 +269,7 @@
     <element id="Patient.contact.telecom.system.extension:otherContactSystem">
       <path value="Patient.contact.telecom.system.extension" />
       <sliceName value="otherContactSystem" />
+      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
@@ -296,6 +278,7 @@
     <element id="Patient.communication.extension:proficiency">
       <path value="Patient.communication.extension" />
       <sliceName value="proficiency" />
+      <short value="The patient's proficiency level of the communication method." />
       <max value="1" />
       <type>
         <code value="Extension" />

--- a/structuredefinitions/UKCore-Practitioner.xml
+++ b/structuredefinitions/UKCore-Practitioner.xml
@@ -29,38 +29,17 @@
   <differential>
     <element id="Practitioner.identifier">
       <path value="Practitioner.identifier" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Practitioner.identifier.system">
-      <path value="Practitioner.identifier.system" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Practitioner.identifier.value">
-      <path value="Practitioner.identifier.value" />
+      <short value="An identifier that applies to this person in this role." />
       <mustSupport value="true" />
     </element>
     <element id="Practitioner.name">
       <path value="Practitioner.name" />
+      <short value="The name(s) associated with the practitioner." />
       <mustSupport value="true" />
-    </element>
-    <element id="Practitioner.name.family">
-      <path value="Practitioner.name.family" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Practitioner.name.given">
-      <path value="Practitioner.name.given" />
-      <mustSupport value="false" />
     </element>
     <element id="Practitioner.telecom">
       <path value="Practitioner.telecom" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Practitioner.telecom.system">
-      <path value="Practitioner.telecom.system" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Practitioner.telecom.value">
-      <path value="Practitioner.telecom.value" />
+      <short value="A contact detail for the practitioner (that apply to all roles)." />
       <mustSupport value="true" />
     </element>
     <element id="Practitioner.communication">

--- a/structuredefinitions/UKCore-PractitionerRole.xml
+++ b/structuredefinitions/UKCore-PractitionerRole.xml
@@ -29,22 +29,27 @@
   <differential>
     <element id="PractitionerRole.active">
       <path value="PractitionerRole.active" />
+      <short value="Whether this practitioner role record is in active use." />
       <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.period">
       <path value="PractitionerRole.period" />
+      <short value="The period during which the practitioner is authorized to perform in these role(s)." />
       <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.practitioner">
       <path value="PractitionerRole.practitioner" />
+      <short value="Practitioner that is able to provide the defined services for the organization." />
       <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.organization">
       <path value="PractitionerRole.organization" />
+      <short value="Organization where the roles are available." />
       <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.specialty">
       <path value="PractitionerRole.specialty" />
+      <short value="Specific specialty of the practitioner." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -53,18 +58,12 @@
     </element>
     <element id="PractitionerRole.location">
       <path value="PractitionerRole.location" />
+      <short value="The location(s) at which this practitioner provides care." />
       <mustSupport value="true" />
     </element>
     <element id="PractitionerRole.telecom">
       <path value="PractitionerRole.telecom" />
-      <mustSupport value="true" />
-    </element>
-    <element id="PractitionerRole.telecom.system">
-      <path value="PractitionerRole.telecom.system" />
-      <mustSupport value="true" />
-    </element>
-    <element id="PractitionerRole.telecom.value">
-      <path value="PractitionerRole.telecom.value" />
+      <short value="Contact details that are specific to the role/location/service." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Procedure.xml
+++ b/structuredefinitions/UKCore-Procedure.xml
@@ -29,10 +29,12 @@
   <differential>
     <element id="Procedure.status">
       <path value="Procedure.status" />
+      <short value="A code specifying the state of the procedure." />
       <mustSupport value="true" />
     </element>
     <element id="Procedure.code">
       <path value="Procedure.code" />
+      <short value="A code identifying the procedure performed." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -42,10 +44,12 @@
     </element>
     <element id="Procedure.subject">
       <path value="Procedure.subject" />
+      <short value="Who the procedure was performed on." />
       <mustSupport value="true" />
     </element>
     <element id="Procedure.performed[x]">
       <path value="Procedure.performed[x]" />
+      <short value="When the procedure was performed." />
       <mustSupport value="true" />
     </element>
     <element id="Procedure.bodySite">

--- a/structuredefinitions/UKCore-RelatedPerson.xml
+++ b/structuredefinitions/UKCore-RelatedPerson.xml
@@ -30,6 +30,7 @@
     <element id="RelatedPerson.extension:contactPreference">
       <path value="RelatedPerson.extension" />
       <sliceName value="contactPreference" />
+      <short value="The preferred method of contact, contact times and written communication format given by a Patient or Related Person." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference" />
@@ -38,6 +39,7 @@
     <element id="RelatedPerson.extension:copyCorrespondenceIndicator">
       <path value="RelatedPerson.extension" />
       <sliceName value="copyCorrespondenceIndicator" />
+      <short value="Indicates that a Patient contact or RelatedPerson must be copied in to Patient correspondence." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CopyCorrespondenceIndicator" />
@@ -45,14 +47,17 @@
     </element>
     <element id="RelatedPerson.active">
       <path value="RelatedPerson.active" />
+      <short value="Whether this related person's record is in active use." />
       <mustSupport value="true" />
     </element>
     <element id="RelatedPerson.patient">
       <path value="RelatedPerson.patient" />
+      <short value="The patient this person is related to." />
       <mustSupport value="true" />
     </element>
     <element id="RelatedPerson.relationship">
       <path value="RelatedPerson.relationship" />
+      <short value="The nature of the relationship." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -61,42 +66,26 @@
     </element>
     <element id="RelatedPerson.name">
       <path value="RelatedPerson.name" />
+      <short value="A name associated with the person." />
       <mustSupport value="true" />
     </element>
     <element id="RelatedPerson.telecom">
       <path value="RelatedPerson.telecom" />
-      <mustSupport value="true" />
-    </element>
-    <element id="RelatedPerson.telecom.system">
-      <path value="RelatedPerson.telecom.system" />
+      <short value="A contact detail for the person." />
       <mustSupport value="true" />
     </element>
     <element id="RelatedPerson.telecom.system.extension:otherContactSystem">
       <path value="RelatedPerson.telecom.system.extension" />
       <sliceName value="otherContactSystem" />
+      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
       </type>
     </element>
-    <element id="RelatedPerson.telecom.value">
-      <path value="RelatedPerson.telecom.value" />
-      <mustSupport value="true" />
-    </element>
     <element id="RelatedPerson.address">
       <path value="RelatedPerson.address" />
-      <mustSupport value="true" />
-    </element>
-    <element id="RelatedPerson.address.line">
-      <path value="RelatedPerson.address.line" />
-      <mustSupport value="true" />
-    </element>
-    <element id="RelatedPerson.address.city">
-      <path value="RelatedPerson.address.city" />
-      <mustSupport value="true" />
-    </element>
-    <element id="RelatedPerson.address.postalCode">
-      <path value="RelatedPerson.address.postalCode" />
+      <short value="Address where the related person can be contacted or visited." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Schedule.xml
+++ b/structuredefinitions/UKCore-Schedule.xml
@@ -29,10 +29,12 @@
   <differential>
     <element id="Schedule.active">
       <path value="Schedule.active" />
+      <short value="Whether this schedule is in active use." />
       <mustSupport value="true" />
     </element>
     <element id="Schedule.specialty">
       <path value="Schedule.specialty" />
+      <short value="Type of specialty needed." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -41,10 +43,12 @@
     </element>
     <element id="Schedule.actor">
       <path value="Schedule.actor" />
+      <short value="Resource(s) that availability information is being provided for." />
       <mustSupport value="true" />
     </element>
     <element id="Schedule.planningHorizon">
       <path value="Schedule.planningHorizon" />
+      <short value="Period of time covered by schedule." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-ServiceRequest-Lab.xml
+++ b/structuredefinitions/UKCore-ServiceRequest-Lab.xml
@@ -30,6 +30,7 @@
     <element id="ServiceRequest.extension:sourceOfServiceRequest">
       <path value="ServiceRequest.extension" />
       <sliceName value="sourceOfServiceRequest" />
+      <short value="Describes the source of the Service Request." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -40,6 +41,7 @@
     <element id="ServiceRequest.extension:additionalContact">
       <path value="ServiceRequest.extension" />
       <sliceName value="additionalContact" />
+      <short value="Supports recording of additional contacts, who should be contacted regarding questions arising from the service request. This differs from the requester and responsibleClinician." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact" />
@@ -49,6 +51,7 @@
     <element id="ServiceRequest.extension:coverage">
       <path value="ServiceRequest.extension" />
       <sliceName value="coverage" />
+      <short value="Supports the exchange of information describing the method of funding for the Service Request." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -58,10 +61,12 @@
     </element>
     <element id="ServiceRequest.status">
       <path value="ServiceRequest.status" />
+      <short value="The status of the order." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.intent">
       <path value="ServiceRequest.intent" />
+      <short value="Whether the request is a proposal, plan, an original order or a reflex order." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.category">
@@ -91,6 +96,7 @@
     <element id="ServiceRequest.priority.extension:priorityReason">
       <path value="ServiceRequest.priority.extension" />
       <sliceName value="priorityReason" />
+      <short value="Supports the underlying reason why a Service Request is urgent." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
@@ -115,10 +121,12 @@
     </element>
     <element id="ServiceRequest.subject">
       <path value="ServiceRequest.subject" />
+      <short value="The individual or entity the service is ordered for." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.requester">
       <path value="ServiceRequest.requester" />
+      <short value="Who / what is requesting the service" />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.reasonCode">

--- a/structuredefinitions/UKCore-ServiceRequest.xml
+++ b/structuredefinitions/UKCore-ServiceRequest.xml
@@ -30,6 +30,7 @@
     <element id="ServiceRequest.extension:sourceOfServiceRequest">
       <path value="ServiceRequest.extension" />
       <sliceName value="sourceOfServiceRequest" />
+      <short value="Describes the source of the Service Request." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -40,6 +41,7 @@
     <element id="ServiceRequest.extension:additionalContact">
       <path value="ServiceRequest.extension" />
       <sliceName value="additionalContact" />
+      <short value="Supports recording of additional contacts, who should be contacted regarding questions arising from the service request. This differs from the requester and responsibleClinician." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact" />
@@ -49,6 +51,7 @@
     <element id="ServiceRequest.extension:coverage">
       <path value="ServiceRequest.extension" />
       <sliceName value="coverage" />
+      <short value="Supports the exchange of information describing the method of funding for the Service Request." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -58,18 +61,22 @@
     </element>
     <element id="ServiceRequest.basedOn">
       <path value="ServiceRequest.basedOn" />
+      <short value="What the service request fulfils." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.status">
       <path value="ServiceRequest.status" />
+      <short value="The status of the order." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.intent">
       <path value="ServiceRequest.intent" />
+      <short value="Whether the request is a proposal, plan, an original order or a reflex order." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.category">
       <path value="ServiceRequest.category" />
+      <short value="A code that classifies the service for searching, sorting and display purposes." />
       <slicing>
         <discriminator>
           <type value="value" />
@@ -95,11 +102,13 @@
     </element>
     <element id="ServiceRequest.priority">
       <path value="ServiceRequest.priority" />
+      <short value="Indicates how quickly the ServiceRequest should be addressed with respect to other requests." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.priority.extension:priorityReason">
       <path value="ServiceRequest.priority.extension" />
       <sliceName value="priorityReason" />
+      <short value="Supports the underlying reason why a Service Request is urgent." />
       <type>
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
@@ -108,6 +117,7 @@
     </element>
     <element id="ServiceRequest.code">
       <path value="ServiceRequest.code" />
+      <short value="What is being requested/ordered." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -124,14 +134,17 @@
     </element>
     <element id="ServiceRequest.subject">
       <path value="ServiceRequest.subject" />
+      <short value="The individual or entity the service is ordered for." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.authoredOn">
       <path value="ServiceRequest.authoredOn" />
+      <short value="The date the request was signed." />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.requester">
       <path value="ServiceRequest.requester" />
+      <short value="Who / what is requesting the service" />
       <mustSupport value="true" />
     </element>
     <element id="ServiceRequest.reasonCode">

--- a/structuredefinitions/UKCore-Slot.xml
+++ b/structuredefinitions/UKCore-Slot.xml
@@ -30,6 +30,7 @@
     <element id="Slot.extension:deliveryChannel">
       <path value="Slot.extension" />
       <sliceName value="deliveryChannel" />
+      <short value="This describes the delivery channel of a scheduled appointment." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -39,6 +40,7 @@
     </element>
     <element id="Slot.specialty">
       <path value="Slot.specialty" />
+      <short value="The specialty of a practitioner that would be required to perform the service requested in this appointment." />
       <mustSupport value="true" />
       <binding>
         <strength value="extensible" />
@@ -47,18 +49,22 @@
     </element>
     <element id="Slot.appointmentType">
       <path value="Slot.appointmentType" />
+      <short value="The style of appointment or patient that may be booked in the slot." />
       <mustSupport value="true" />
     </element>
     <element id="Slot.status">
       <path value="Slot.status" />
+      <short value="The status of the slot, e.g free, busy, etc." />
       <mustSupport value="true" />
     </element>
     <element id="Slot.start">
       <path value="Slot.start" />
+      <short value="Date/Time that the slot is to begin." />
       <mustSupport value="true" />
     </element>
     <element id="Slot.end">
       <path value="Slot.end" />
+      <short value="Date/Time that the slot is to conclude." />
       <mustSupport value="true" />
     </element>
   </differential>

--- a/structuredefinitions/UKCore-Specimen.xml
+++ b/structuredefinitions/UKCore-Specimen.xml
@@ -32,13 +32,14 @@
       <constraint>
         <key value="ukcore-spec-001" />
         <severity value="error" />
-        <human value="There SHALL be only one reference between collection.collector and the extension collectionCollectorR5" />
+        <human value="There SHALL be only one reference between `collection.collector` and the extension `collectionCollectorR5`" />
         <expression value="collection.collector.reference.empty() or collection.collector.extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.collector').empty()" />
       </constraint>
     </element>
     <element id="Specimen.extension:sampleCategory">
       <path value="Specimen.extension" />
       <sliceName value="sampleCategory" />
+      <short value="An extension to record the category of a sample." />
       <max value="1" />
       <type>
         <code value="Extension" />
@@ -48,10 +49,12 @@
     </element>
     <element id="Specimen.status">
       <path value="Specimen.status" />
+      <short value="The availability of the specimen sample." />
       <mustSupport value="true" />
     </element>
     <element id="Specimen.type">
       <path value="Specimen.type" />
+      <short value="The kind of material that forms the specimen." />
       <mustSupport value="true" />
       <binding>
         <strength value="preferred" />
@@ -61,15 +64,18 @@
     </element>
     <element id="Specimen.subject">
       <path value="Specimen.subject" />
+      <short value="Where the specimen came from." />
       <mustSupport value="true" />
     </element>
     <element id="Specimen.receivedTime">
       <path value="Specimen.receivedTime" />
+      <short value="The time when specimen was received for processing." />
       <mustSupport value="true" />
     </element>
     <element id="Specimen.collection.extension:specialHandling">
       <path value="Specimen.collection.extension" />
       <sliceName value="specialHandling" />
+      <short value="This SHOULD be included if there is a high contamination risk reason for a sample / biopsy." />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/specimen-specialHandling" />
@@ -78,7 +84,7 @@
     <element id="Specimen.collection.collector.extension:collectionCollectorR5">
       <path value="Specimen.collection.collector.extension" />
       <sliceName value="collectionCollectorR5" />
-      <short value="Person who collected the specimen" />
+      <short value="The person who collected the specimen. This is an R5 backport." />
       <definition value="Person who collected the specimen. This is an R5 backport" />
       <max value="1" />
       <type>
@@ -89,7 +95,6 @@
     </element>
     <element id="Specimen.collection.collector.extension:collectionCollectorR5.value[x]">
       <path value="Specimen.collection.collector.extension.value[x]" />
-      <short value="Person who collected the specimen" />
     </element>
     <element id="Specimen.collection.bodySite">
       <path value="Specimen.collection.bodySite" />
@@ -101,7 +106,7 @@
     <element id="Specimen.collection.bodySite.extension:bodySiteReference">
       <path value="Specimen.collection.bodySite.extension" />
       <sliceName value="bodySiteReference" />
-      <short value="An extension to allow referencing to a BodyStructure" />
+      <short value="An extension to allow referencing to a BodyStructure." />
       <max value="1" />
       <type>
         <code value="Extension" />


### PR DESCRIPTION
Add Short Descs to Extensions / MustSupport elements to allow new templating to work

Tweaked Patient/Practitioner/RelatedPerson MustSupports - removed it on identifer and telecom system/value, and address.line's as we're saying suppliers/consumers have to support the main data element