### PR TITLE
fix 'Sending SNOMED concept with its associated pref term' example

### DIFF
--- a/examples/UKCore-Extension-CodingSCT-Myocardial-Example.xml
+++ b/examples/UKCore-Extension-CodingSCT-Myocardial-Example.xml
@@ -3,11 +3,8 @@
   <!-- **************Snippet start************** -->
   <code>
     <coding>
-      <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay">
-        <valueString value="Heart attack" />
-      </extension>
       <extension url="http://hl7.org/fhir/StructureDefinition/coding-sctdescid">
-        <valueId value="37443015" />
+        <valueId value="37436014" />
       </extension>
       <system value="http://snomed.info/sct" />
       <code value="22298006" />


### PR DESCRIPTION
Example did not have description id of the pt, and had the term when it didn't need to

Examples should have shown "In the example below, the SNOMED CT Description Id is populated with the Id of the preferred term, but there is no display term, as the Concept Id was entered by the user and the preferred term was displayed to them when it was added."