### PR TITLE
readd missing valuesets to STU2

### DIFF
--- a/examples/UKCore-Extension-BirthSex-Example.xml
+++ b/examples/UKCore-Extension-BirthSex-Example.xml
@@ -1,5 +1,9 @@
 <Patient xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Patient-Extension-BirthSex-Example"/>
+  <id value="UKCore-Extension-BirthSex-Example" />
+  <text>
+    <status value="additional" />
+    <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate the extension for a patient's birth sex</div>
+  </text>
   <!-- **************extension start************** -->
   <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex">
     <valueCodeableConcept>

--- a/examples/UKCore-Medication-Extension-MedicationTradeFamily-Example.xml
+++ b/examples/UKCore-Medication-Extension-MedicationTradeFamily-Example.xml
@@ -15,7 +15,7 @@
 		<coding>
 			<system value="https://dmd.nhs.uk"/>
 			<code value="18677911000001109"/>
-			<display value="Panadol Extra Advance 500mg/65mg tablets (Haleon UK Ltd)"/>
+			<display value="Panadol Extra Advance 500mg/65mg tablets (Haleon UK Trading Ltd)"/>
 		</coding>
 	</code>
 </Medication>

--- a/examples/UKCore-Patient-Extension-BirthSex-Example.xml
+++ b/examples/UKCore-Patient-Extension-BirthSex-Example.xml
@@ -4,7 +4,7 @@
   <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex">
     <valueCodeableConcept>
       <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-BirthSex" />
+        <system value="http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender" />
         <code value="F" />
         <display value="Female" />
       </coding>

--- a/examples/UKCore-Patient-Extension-BirthSex-Example.xml
+++ b/examples/UKCore-Patient-Extension-BirthSex-Example.xml
@@ -1,14 +1,14 @@
 <Patient xmlns="http://hl7.org/fhir">
   <id value="UKCore-Patient-Extension-BirthSex-Example"/>
-	<!-- **************extension start************** -->
-	<extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex">
-	  <valueCodeableConcept>
+  <!-- **************extension start************** -->
+  <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex">
+    <valueCodeableConcept>
       <coding>
-	      <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-BirthSex" />
+        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-BirthSex" />
         <code value="F" />
         <display value="Female" />
-	    </coding>
-	  </valueCodeableConcept>
-	</extension>
-	<!-- **************extension end************** -->
+      </coding>
+    </valueCodeableConcept>
+  </extension>
+  <!-- **************extension end************** -->
 </Patient>

--- a/structuredefinitions/Extension-UKCore-BirthSex.xml
+++ b/structuredefinitions/Extension-UKCore-BirthSex.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-BirthSex" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex" />
-  <version value="2.0.0" />
+  <version value="2.1.0" />
   <name value="ExtensionUKCoreBirthSex" />
   <title value="Extension UK Core Birth Sex" />
   <status value="active" />
-  <date value="2023-12-12" />
+  <date value="2024-06-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -54,6 +54,10 @@
       <type>
         <code value="CodeableConcept" />
       </type>
+      <binding>
+        <strength value="required" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BirthSex" />
+      </binding>
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-ConditionEpisode.xml
+++ b/structuredefinitions/Extension-UKCore-ConditionEpisode.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-ConditionEpisode" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ConditionEpisode" />
-  <version value="3.0.0" />
+  <version value="3.1.0" />
   <name value="ExtensionUKCoreConditionEpisode" />
   <title value="Extension UK Core Condition Episode" />
   <status value="active" />
-  <date value="2023-12-12" />
+  <date value="2024-06-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -53,6 +53,10 @@
       <type>
         <code value="CodeableConcept" />
       </type>
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ConditionEpisodicity" />
+      </binding>
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-DeliveryChannel.xml
+++ b/structuredefinitions/Extension-UKCore-DeliveryChannel.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-DeliveryChannel" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeliveryChannel" />
-  <version value="2.0.0" />
+  <version value="2.1.0" />
   <name value="ExtensionUKCoreDeliveryChannel" />
   <title value="Extension UK Core Delivery Channel" />
   <status value="active" />
-  <date value="2023-12-12" />
+  <date value="2024-06-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -57,6 +57,10 @@
       <type>
         <code value="CodeableConcept" />
       </type>
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-DeliveryChannel" />
+      </binding>
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-ListWarningCode.xml
+++ b/structuredefinitions/Extension-UKCore-ListWarningCode.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-ListWarningCode" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ListWarningCode" />
-  <version value="3.0.0" />
+  <version value="3.1.0" />
   <name value="ExtensionUKCoreListWarningCode" />
   <title value="Extension UK Core List Warning Code" />
   <status value="active" />
-  <date value="2023-12-12" />
+  <date value="2024-06-28" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -53,6 +53,10 @@
       <type>
         <code value="CodeableConcept" />
       </type>
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ListWarningCode" />
+      </binding>
     </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
- Fix the missing valueset bindings in STU2 as per https://github.com/NHSDigital/FHIR-R4-UKCORE-STAGING-MAIN/pull/552 . Note: structuredefinitions/Extension-UKCore-RecordingSetting.xml is not in this branch
- BirthSex example fixed and brought in line with STU3

The title values will not change in this version, so ignore QC Checker