### PR TITLE
reordered elements to follow FHIR standards

### DIFF
--- a/examples/UKCore-Composition-Discharge-Example.xml
+++ b/examples/UKCore-Composition-Discharge-Example.xml
@@ -1,662 +1,333 @@
-<Composition>
-  <id value="UKCore-Composition-Discharge-Example" />
-  <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a composition containing a discharge summary</div>
-  </text>
-  <!-- Extension to carry details of the Correspondence Care Setting Type. -->
-  <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CareSettingType">
-    <valueCodeableConcept>
-      <coding>
-        <system value="http://snomed.info/sct" />
-        <code value="310000008" />
-        <display value="Accident and Emergency service" />
-      </coding>
-    </valueCodeableConcept>
-  </extension>
-  <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="2d361270-039f-4a48-827b-ef255ff8b6c4" />
-  </identifier>
-  <!--The workflow/clinical status of this composition. 
-The status is a marker for the clinical standing of the document.-->
-  <status value="final" />
-  <type>
-    <!--Discharge Summary document type-->
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="373942005" />
-      <display value="Discharge summary" />
-    </coding>
-  </type>
-  <!--Reference to the patient subject of the Composition-->
-  <subject>
-    <reference value="urn:uuid:c8225cc8-8026-466f-80f8-fc2832a4b9d5" />
-  </subject>
-  <!--Reference to the clinical encounter or type of care this documentation is associated with.-->
-  <encounter>
-    <reference value="urn:uuid:9a20cb92-354a-4015-82ec-ab0252efc5b9" />
-  </encounter>
-  <!--The composition editing time, when the composition was last logically changed by the author.-->
-  <date value="2021-02-12T19:00:00+00:00" />
-  <!--Identifies who is responsible for the information in the composition, 
-not necessarily who typed it in-->
-  <author>
-    <reference value="urn:uuid:369d88a8-9f6b-407f-8560-6ee9d7ccc8bb" />
-  </author>
-  <title value="Accident &amp; Emergency Discharge summary" />
-  <!--Identifies the organisation responsible for ongoing maintenance of and 
-access to the composition/document information.-->
-  <custodian>
-    <reference value="urn:uuid:120633ae-1a20-4e0e-b807-b78fb59679cc" />
-  </custodian>
-  <!--Allergies and adverse reactions-->
-  <section>
-    <title value="Allergies and adverse reaction" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="allergies-and-adverse-reaction" />
-        <display value="Allergies and adverse reaction" />
-      </coding>
-    </code>
+<Composition xmlns="http://hl7.org/fhir">
+    <id value="UKCore-Composition-Discharge-Example" />
     <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Causative agent</th>
-              <td>Penicillin -class of antibiotic</td>
-            </tr>
-            <tr>
-              <th>Description of reaction</th>
-              <td>Eruption due to drug</td>
-            </tr>
-            <tr>
-              <th>Severity</th>
-              <td>Mild</td>
-            </tr>
-            <tr>
-              <th>Certainty</th>
-              <td>Certain</td>
-            </tr>
-            <tr>
-              <th>Comment</th>
-              <td>No swelling</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+        <status value="additional" />
+        --- We have skipped the narrative for better readability of the resource ---
     </text>
-    <!--Reference to Allergies List as the source of information for this section-->
-    <entry>
-      <reference value="urn:uuid:b37c89af-c5da-425f-8e6d-58c043ccf94b" />
-    </entry>
-  </section>
-  <!--Attendance details-->
-  <section>
-    <title value="Attendance details" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="attendance-details" />
-        <display value="Attendance details" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Date and time of contact</th>
-              <td>12-Feb-2015 07:00</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-  </section>
-  <!--Clinical narrative-->
-  <section>
-    <title value="Clinical narrative" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="clinical-narrative" />
-        <display value="Clinical narrative" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Clinical narrative</th>
-            </tr>
-            <tr>
-              <td>
-                <p>60 year old man complaining of chest pain lasting around 2 hours.</p>
-                <p>Examination unremarkable.</p>
-                <p>Inferior ischaemic changes on ECG.</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table>
-          <tbody>
-            <tr>
-              <td>
-                <pre>Full Blood Count TestValueUnitsReference Range White Cell Count11.1x10*9/L3.5 - 10.0 Red Cell Count5.0x10*12/L4.25 - 5.75 Haemoglobin150g/L13.0 - 17.0 Haematocrit0.230L/L0.400 - 0.500 Mean Cell Volume90fL84 - 98 Mean Cell Hb33.0pg27.5 - 32.0 Mean Cell Hb Con34.0pg31.0 - 35.0 RDW12.0%&lt; 14.5 Platelet Count300x10*9/L150 - 400 Machine Differential TestValueUnitsReference Range Neutrophils7.0x10*9/L1.7 - 7.5 Lymphocytes3.5x10*9/L1.0 - 3.5 Monocytes0.3x10*9/L&lt; 0.6 Eosinophils0.4x10*9/L&lt; 0.4 Basophils0.1x10*9/L&lt; 0.1 LUCs0.2x10*9/L&lt; 0.4</pre>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-  </section>
-  <!--Contact for further information-->
-  <section>
-    <title value="Contact for further information" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="contact-for-further-information" />
-        <display value="Contact for further information" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Contact for further information</th>
-              <td>Dr Paul Rastall Tel: 0113 6323200</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-  </section>
-  <!--Diagnoses-->
-  <section>
-    <title value="Diagnoses" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="diagnoses" />
-        <display value="Diagnoses" />
-      </coding>
-    </code>
-    <text>
-      <status value="generated" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Diagnosis name</th>
-              <td>Acute ST segment elevation myocardial infarction</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--Reference to information in the Condition list resource-->
-    <entry>
-      <reference value="urn:uuid:0a46351b-bfe1-4085-956e-15d3b172e36f" />
-    </entry>
-  </section>
-  <!--Discharge details-->
-  <section>
-    <title value="Discharge details" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="discharge-details" />
-        <display value="Discharge details" />
-      </coding>
-    </code>
-    <text>
-      <status value="extensions" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Discharge status</th>
-              <td>Streamed from emergency department to urgent care service following initial assessment</td>
-            </tr>
-            <tr>
-              <th>Date/time of discharge</th>
-              <td>12-Feb-2015 08:00</td>
-            </tr>
-            <tr>
-              <th>Discharge destination</th>
-              <td>NHS other Hospital Provider - Ward for general Patients or the younger physically disabled</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--Reference to the Encounter entry as the source of information for this section-->
-    <entry>
-      <reference value="urn:uuid:9a20cb92-354a-4015-82ec-ab0252efc5b9" />
-    </entry>
-  </section>
-  <!-- GP Practice-->
-  <section>
-    <title value="GP practice" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="general-practitioner-practice" />
-        <display value="General practitioner practice" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>GP name</th>
-              <td>
-                <p>Prefix: Dr</p>
-                <p>Given Name: John</p>
-                <p>Family Name: Lorenzo</p>
-              </td>
-            </tr>
-            <tr>
-              <th>GP practice details</th>
-              <td>
-                <p>Name: MGP Medical Centre</p>
-                <p>Address:</p>
-                <p>Address Line: 1 MGP House, Overtown</p>
-                <p>City: Leeds</p>
-                <p>Post Code: LS21 7PA</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--Reference to the Organisation entry as the source of information for this section-->
-    <entry>
-      <reference value="urn:uuid:e4058bb2-bf1a-47a4-ab10-1471161380a1" />
-    </entry>
-  </section>
-  <!-- Information and advice given-->
-  <section>
-    <title value="Information and advice given" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="information-and-advice-given" />
-        <display value="Information and advice given" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Information and advice given</th>
-              <td>Patient advised to be admitted to ward for further tests after ECG results showed inferior ischaemic changes.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-  </section>
-  <!--Medications and medical devices-->
-  <section>
-    <title value="Medications and medical devices" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="medications-and-medical-devices" />
-        <display value="Medications and medical devices" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Medication name</th>
-              <td>Ramipril 2.5mg tablets (A A H Pharmaceuticals Ltd)</td>
-            </tr>
-            <tr>
-              <th>Form</th>
-              <td>Tablet</td>
-            </tr>
-            <tr>
-              <th>Route</th>
-              <td>Oral</td>
-            </tr>
-            <tr>
-              <th>Dose directions description</th>
-              <td>One 2.5mg tablet once a day.</td>
-            </tr>
-            <tr>
-              <th>Status</th>
-              <td>Continued</td>
-            </tr>
-          </tbody>
-        </table>
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Medication name</th>
-              <td>Aspirin 75mg tablets (Sigma Pharmaceuticals Plc)</td>
-            </tr>
-            <tr>
-              <th>Form</th>
-              <td>Tablet</td>
-            </tr>
-            <tr>
-              <th>Route</th>
-              <td>Oral</td>
-            </tr>
-            <tr>
-              <th>Dose directions description</th>
-              <td>Take one 75mg tablet once a day.</td>
-            </tr>
-            <tr>
-              <th>Status</th>
-              <td>Continued</td>
-            </tr>
-          </tbody>
-        </table>
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Medication name</th>
-              <td>Simvastatin 40mg tablets (Brown &amp; Burk UK Ltd)</td>
-            </tr>
-            <tr>
-              <th>Form</th>
-              <td>Tablet</td>
-            </tr>
-            <tr>
-              <th>Route</th>
-              <td>Oral</td>
-            </tr>
-            <tr>
-              <th>Dose directions description</th>
-              <td>Take one 40mg tablet once a day.</td>
-            </tr>
-            <tr>
-              <th>Status</th>
-              <td>Continued</td>
-            </tr>
-          </tbody>
-        </table>
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Medication name</th>
-              <td>Bisoprolol 5mg tablets (A A H Pharmaceuticals Ltd)</td>
-            </tr>
-            <tr>
-              <th>Form</th>
-              <td>Tablet</td>
-            </tr>
-            <tr>
-              <th>Route</th>
-              <td>Oral</td>
-            </tr>
-            <tr>
-              <th>Dose directions description</th>
-              <td>Take one 5mg tablet daily.</td>
-            </tr>
-            <tr>
-              <th>Comment/recommendation</th>
-              <td>Recommend Uptitrate according to BP and HR</td>
-            </tr>
-            <tr>
-              <th>Status</th>
-              <td>Continued</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--Reference to medication list-->
-    <entry>
-      <reference value="urn:uuid:e3c8b45f-22d4-4ce6-970c-10a959831dca" />
-    </entry>
-  </section>
-  <!-- Patient demographics-->
-  <section>
-    <title value="Patient demographics" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="patient-demographics" />
-        <display value="Patient demographics" />
-      </coding>
-    </code>
-    <text>
-      <status value="generated" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Patient name</th>
-              <td>
-                <p>Prefix: Mr</p>
-                <p>Given Name: Richard</p>
-                <p>Family Name: Smith</p>
-              </td>
-            </tr>
-            <tr>
-              <th>Date of birth</th>
-              <td>1 January 1957</td>
-            </tr>
-            <tr>
-              <th>Gender</th>
-              <td>Male</td>
-            </tr>
-            <tr>
-              <th>NHS number</th>
-              <td>1352465790</td>
-            </tr>
-            <tr>
-              <th>Patient address</th>
-              <td>
-                <p>Address Line: 21, Grove Street, Overtown</p>
-                <p>City: Leeds</p>
-                <p>Post Code: LS21 1PF</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--reference to further information carried in the patient resource-->
-    <entry>
-      <reference value="urn:uuid:c8225cc8-8026-466f-80f8-fc2832a4b9d5" />
-    </entry>
-  </section>
-  <!--Person completing record-->
-  <section>
-    <title value="Person completing record" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="person-completing-record" />
-        <display value="Person completing record" />
-      </coding>
-    </code>
-    <text>
-      <status value="generated" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Name</th>
-              <td>
-                <p>Prefix: Dr</p>
-                <p>Given Name: Paul</p>
-                <p>Family Name: Rastall</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--Reference to the practitioner entry as the source of information for this section-->
-    <entry>
-      <reference value="urn:uuid:369d88a8-9f6b-407f-8560-6ee9d7ccc8bb" />
-    </entry>
-  </section>
-  <!--Plan and requested actions-->
-  <section>
-    <title value="Plan and requested actions" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="plan-and-requested-actions" />
-        <display value="Plan and requested actions" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Action</th>
-              <td>
-                <p>Patient has agreed to be admitted to Cramer ward for further tests to investigate causes of his chest pain on 12 February 2015.</p>
-                <p>Person responsible: Dr. Paul Rastall (Accident and Emergency Consultant, St. James's University Hospital Accident and Emergency Department)</p>
-                <p>Status: Completed</p>
-                <p>Outcome: Patient expects to find out the more information about the reasons for his chest pain when tests are carried out after admission.</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-  </section>
-  <!--Presenting complaints or issues-->
-  <section>
-    <title value="Presenting complaints or issues" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="presenting-complaints-or-issues" />
-        <display value="Presenting complaints or issues" />
-      </coding>
-    </code>
-    <text>
-      <status value="generated" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Presenting complaints or issue</th>
-              <td>Chest pain</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--Reference to information in the Condition list resource-->
-    <entry>
-      <reference value="urn:uuid:0a46351b-bfe1-4085-956e-15d3b172e36f" />
-    </entry>
-  </section>
-  <!--Procedures-->
-  <section>
-    <title value="Procedures" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="procedures" />
-        <display value="Procedures" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table>
-          <tbody>
-            <tr>
-              <th>Procedure name</th>
-              <td>Electrocardiographic monitoring</td>
-            </tr>
-            <tr>
-              <th>Comment</th>
-              <td>ECGs showed inferior ischaemic changes.</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--reference to further information carried in the procedure list resource-->
-    <entry>
-      <reference value="urn:uuid:1e04ce96-6e52-4f82-bc26-93c89c5836a1" />
-    </entry>
-  </section>
-  <!--Referrer details-->
-  <section>
-    <title value="Referrer details" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="referrer-details" />
-        <display value="Referrer details" />
-      </coding>
-    </code>
-    <text>
-      <status value="additional" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Referrer details</th>
-              <td>Self-referral to accident and emergency department</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-  </section>
-  <!--Senior reviewing clinician-->
-  <section>
-    <title value="Senior reviewing clinician" />
-    <code>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
-        <code value="senior-reviewing-clinician" />
-        <display value="Senior reviewing clinician" />
-      </coding>
-    </code>
-    <text>
-      <status value="generated" />
-      <div xmlns="http://www.w3.org/1999/xhtml">
-        <table width="100%">
-          <tbody>
-            <tr>
-              <th>Name</th>
-              <td>
-                <p>Prefix: Mr</p>
-                <p>Family Name: Abacus</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </text>
-    <!--reference to further information carried in the practitioner resource-->
-    <entry>
-      <reference value="urn:uuid:d25fd1c6-2658-4db7-9af0-86c5f95e8ec9" />
-    </entry>
-  </section>
+    <!--  Extension to carry details of the Correspondence Care Setting Type.  -->
+    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CareSettingType">
+        <valueCodeableConcept>
+            <coding>
+                <system value="http://snomed.info/sct" />
+                <code value="310000008" />
+                <display value="Accident and Emergency service" />
+            </coding>
+        </valueCodeableConcept>
+    </extension>
+    <identifier>
+        <system value="https://tools.ietf.org/html/rfc4122" />
+        <value value="2d361270-039f-4a48-827b-ef255ff8b6c4" />
+    </identifier>
+    <!-- The workflow/clinical status of this composition. 
+The status is a marker for the clinical standing of the document. -->
+    <status value="final" />
+    <type>
+        <!-- Discharge Summary document type -->
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="373942005" />
+            <display value="Discharge summary" />
+        </coding>
+    </type>
+    <!-- Reference to the patient subject of the Composition -->
+    <subject>
+        <reference value="urn:uuid:c8225cc8-8026-466f-80f8-fc2832a4b9d5" />
+    </subject>
+    <!-- Reference to the clinical encounter or type of care this documentation is associated with. -->
+    <encounter>
+        <reference value="urn:uuid:9a20cb92-354a-4015-82ec-ab0252efc5b9" />
+    </encounter>
+    <!-- The composition editing time, when the composition was last logically changed by the author. -->
+    <date value="2021-02-12T19:00:00+00:00" />
+    <!-- Identifies who is responsible for the information in the composition, 
+not necessarily who typed it in -->
+    <author>
+        <reference value="urn:uuid:369d88a8-9f6b-407f-8560-6ee9d7ccc8bb" />
+    </author>
+    <title value="Accident &amp; Emergency Discharge summary" />
+    <!-- Identifies the organisation responsible for ongoing maintenance of and 
+access to the composition/document information. -->
+    <custodian>
+        <reference value="urn:uuid:120633ae-1a20-4e0e-b807-b78fb59679cc" />
+    </custodian>
+    <!-- Allergies and adverse reactions -->
+    <section>
+        <title value="Allergies and adverse reaction" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="allergies-and-adverse-reaction" />
+                <display value="Allergies and adverse reaction" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Causative agent</th><td>Penicillin -class of antibiotic</td></tr><tr><th>Description of reaction</th><td>Eruption due to drug</td></tr><tr><th>Severity</th><td>Mild</td></tr><tr><th>Certainty</th><td>Certain</td></tr><tr><th>Comment</th><td>No swelling</td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to Allergies List as the source of information for this section -->
+        <entry>
+            <reference value="urn:uuid:b37c89af-c5da-425f-8e6d-58c043ccf94b" />
+        </entry>
+    </section>
+    <!-- Attendance details -->
+    <section>
+        <title value="Attendance details" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="attendance-details" />
+                <display value="Attendance details" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Date and time of contact</th><td>12-Feb-2015 07:00</td></tr></tbody></table></div>
+        </text>
+    </section>
+    <!-- Clinical narrative -->
+    <section>
+        <title value="Clinical narrative" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="clinical-narrative" />
+                <display value="Clinical narrative" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Clinical narrative</th></tr><tr><td><p>60 year old man complaining of chest pain lasting around 2 hours.</p><p>Examination unremarkable.</p><p>Inferior ischaemic changes on ECG.</p></td></tr></tbody></table><table><tbody><tr><td><pre>Full Blood Count TestValueUnitsReference Range White Cell Count11.1x10*9/L3.5 - 10.0 Red Cell Count5.0x10*12/L4.25 - 5.75 Haemoglobin150g/L13.0 - 17.0 Haematocrit0.230L/L0.400 - 0.500 Mean Cell Volume90fL84 - 98 Mean Cell Hb33.0pg27.5 - 32.0 Mean Cell Hb Con34.0pg31.0 - 35.0 RDW12.0%&lt; 14.5 Platelet Count300x10*9/L150 - 400 Machine Differential TestValueUnitsReference Range Neutrophils7.0x10*9/L1.7 - 7.5 Lymphocytes3.5x10*9/L1.0 - 3.5 Monocytes0.3x10*9/L&lt; 0.6 Eosinophils0.4x10*9/L&lt; 0.4 Basophils0.1x10*9/L&lt; 0.1 LUCs0.2x10*9/L&lt; 0.4</pre></td></tr></tbody></table></div>
+        </text>
+    </section>
+    <!-- Contact for further information -->
+    <section>
+        <title value="Contact for further information" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="contact-for-further-information" />
+                <display value="Contact for further information" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Contact for further information</th><td>Dr Paul Rastall Tel: 0113 6323200</td></tr></tbody></table></div>
+        </text>
+    </section>
+    <!-- Diagnoses -->
+    <section>
+        <title value="Diagnoses" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="diagnoses" />
+                <display value="Diagnoses" />
+            </coding>
+        </code>
+        <text>
+            <status value="generated" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Diagnosis name</th><td>Acute ST segment elevation myocardial infarction</td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to information in the Condition list resource -->
+        <entry>
+            <reference value="urn:uuid:0a46351b-bfe1-4085-956e-15d3b172e36f" />
+        </entry>
+    </section>
+    <!-- Discharge details -->
+    <section>
+        <title value="Discharge details" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="discharge-details" />
+                <display value="Discharge details" />
+            </coding>
+        </code>
+        <text>
+            <status value="extensions" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Discharge status</th><td>Streamed from emergency department to urgent care service following initial assessment</td></tr><tr><th>Date/time of discharge</th><td>12-Feb-2015 08:00</td></tr><tr><th>Discharge destination</th><td>NHS other Hospital Provider - Ward for general Patients or the younger physically disabled</td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to the Encounter entry as the source of information for this section -->
+        <entry>
+            <reference value="urn:uuid:9a20cb92-354a-4015-82ec-ab0252efc5b9" />
+        </entry>
+    </section>
+    <!--  GP Practice -->
+    <section>
+        <title value="GP practice" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="general-practitioner-practice" />
+                <display value="General practitioner practice" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>GP name</th><td><p>Prefix: Dr</p><p>Given Name: John</p><p>Family Name: Lorenzo</p></td></tr><tr><th>GP practice details</th><td><p>Name: MGP Medical Centre</p><p>Address:</p><p>Address Line: 1 MGP House, Overtown</p><p>City: Leeds</p><p>Post Code: LS21 7PA</p></td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to the Organisation entry as the source of information for this section -->
+        <entry>
+            <reference value="urn:uuid:e4058bb2-bf1a-47a4-ab10-1471161380a1" />
+        </entry>
+    </section>
+    <!--  Information and advice given -->
+    <section>
+        <title value="Information and advice given" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="information-and-advice-given" />
+                <display value="Information and advice given" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Information and advice given</th><td>Patient advised to be admitted to ward for further tests after ECG results showed inferior ischaemic changes.</td></tr></tbody></table></div>
+        </text>
+    </section>
+    <!-- Medications and medical devices -->
+    <section>
+        <title value="Medications and medical devices" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="medications-and-medical-devices" />
+                <display value="Medications and medical devices" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Medication name</th><td>Ramipril 2.5mg tablets (A A H Pharmaceuticals Ltd)</td></tr><tr><th>Form</th><td>Tablet</td></tr><tr><th>Route</th><td>Oral</td></tr><tr><th>Dose directions description</th><td>One 2.5mg tablet once a day.</td></tr><tr><th>Status</th><td>Continued</td></tr></tbody></table><table width="100%"><tbody><tr><th>Medication name</th><td>Aspirin 75mg tablets (Sigma Pharmaceuticals Plc)</td></tr><tr><th>Form</th><td>Tablet</td></tr><tr><th>Route</th><td>Oral</td></tr><tr><th>Dose directions description</th><td>Take one 75mg tablet once a day.</td></tr><tr><th>Status</th><td>Continued</td></tr></tbody></table><table width="100%"><tbody><tr><th>Medication name</th><td>Simvastatin 40mg tablets (Brown &amp; Burk UK Ltd)</td></tr><tr><th>Form</th><td>Tablet</td></tr><tr><th>Route</th><td>Oral</td></tr><tr><th>Dose directions description</th><td>Take one 40mg tablet once a day.</td></tr><tr><th>Status</th><td>Continued</td></tr></tbody></table><table width="100%"><tbody><tr><th>Medication name</th><td>Bisoprolol 5mg tablets (A A H Pharmaceuticals Ltd)</td></tr><tr><th>Form</th><td>Tablet</td></tr><tr><th>Route</th><td>Oral</td></tr><tr><th>Dose directions description</th><td>Take one 5mg tablet daily.</td></tr><tr><th>Comment/recommendation</th><td>Recommend Uptitrate according to BP and HR</td></tr><tr><th>Status</th><td>Continued</td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to medication list -->
+        <entry>
+            <reference value="urn:uuid:e3c8b45f-22d4-4ce6-970c-10a959831dca" />
+        </entry>
+    </section>
+    <!--  Patient demographics -->
+    <section>
+        <title value="Patient demographics" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="patient-demographics" />
+                <display value="Patient demographics" />
+            </coding>
+        </code>
+        <text>
+            <status value="generated" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Patient name</th><td><p>Prefix: Mr</p><p>Given Name: Richard</p><p>Family Name: Smith</p></td></tr><tr><th>Date of birth</th><td>1 January 1957</td></tr><tr><th>Gender</th><td>Male</td></tr><tr><th>NHS number</th><td>1352465790</td></tr><tr><th>Patient address</th><td><p>Address Line: 21, Grove Street, Overtown</p><p>City: Leeds</p><p>Post Code: LS21 1PF</p></td></tr></tbody></table></div>
+        </text>
+        <!-- reference to further information carried in the patient resource -->
+        <entry>
+            <reference value="urn:uuid:c8225cc8-8026-466f-80f8-fc2832a4b9d5" />
+        </entry>
+    </section>
+    <!-- Person completing record -->
+    <section>
+        <title value="Person completing record" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="person-completing-record" />
+                <display value="Person completing record" />
+            </coding>
+        </code>
+        <text>
+            <status value="generated" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Name</th><td><p>Prefix: Dr</p><p>Given Name: Paul</p><p>Family Name: Rastall</p></td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to the practitioner entry as the source of information for this section -->
+        <entry>
+            <reference value="urn:uuid:369d88a8-9f6b-407f-8560-6ee9d7ccc8bb" />
+        </entry>
+    </section>
+    <!-- Plan and requested actions -->
+    <section>
+        <title value="Plan and requested actions" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="plan-and-requested-actions" />
+                <display value="Plan and requested actions" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Action</th><td><p>Patient has agreed to be admitted to Cramer ward for further tests to investigate causes of his chest pain on 12 February 2015.</p><p>Person responsible: Dr. Paul Rastall (Accident and Emergency Consultant, St. James's University Hospital Accident and Emergency Department)</p><p>Status: Completed</p><p>Outcome: Patient expects to find out the more information about the reasons for his chest pain when tests are carried out after admission.</p></td></tr></tbody></table></div>
+        </text>
+    </section>
+    <!-- Presenting complaints or issues -->
+    <section>
+        <title value="Presenting complaints or issues" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="presenting-complaints-or-issues" />
+                <display value="Presenting complaints or issues" />
+            </coding>
+        </code>
+        <text>
+            <status value="generated" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Presenting complaints or issue</th><td>Chest pain</td></tr></tbody></table></div>
+        </text>
+        <!-- Reference to information in the Condition list resource -->
+        <entry>
+            <reference value="urn:uuid:0a46351b-bfe1-4085-956e-15d3b172e36f" />
+        </entry>
+    </section>
+    <!-- Procedures -->
+    <section>
+        <title value="Procedures" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="procedures" />
+                <display value="Procedures" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table><tbody><tr><th>Procedure name</th><td>Electrocardiographic monitoring</td></tr><tr><th>Comment</th><td>ECGs showed inferior ischaemic changes.</td></tr></tbody></table></div>
+        </text>
+        <!-- reference to further information carried in the procedure list resource -->
+        <entry>
+            <reference value="urn:uuid:1e04ce96-6e52-4f82-bc26-93c89c5836a1" />
+        </entry>
+    </section>
+    <!-- Referrer details -->
+    <section>
+        <title value="Referrer details" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="referrer-details" />
+                <display value="Referrer details" />
+            </coding>
+        </code>
+        <text>
+            <status value="additional" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Referrer details</th><td>Self-referral to accident and emergency department</td></tr></tbody></table></div>
+        </text>
+    </section>
+    <!-- Senior reviewing clinician -->
+    <section>
+        <title value="Senior reviewing clinician" />
+        <code>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings" />
+                <code value="senior-reviewing-clinician" />
+                <display value="Senior reviewing clinician" />
+            </coding>
+        </code>
+        <text>
+            <status value="generated" />
+            <div xmlns="http://www.w3.org/1999/xhtml"><table width="100%"><tbody><tr><th>Name</th><td><p>Prefix: Mr</p><p>Family Name: Abacus</p></td></tr></tbody></table></div>
+        </text>
+        <!-- reference to further information carried in the practitioner resource -->
+        <entry>
+            <reference value="urn:uuid:d25fd1c6-2658-4db7-9af0-86c5f95e8ec9" />
+        </entry>
+    </section>
 </Composition>

--- a/examples/UKCore-Composition-Discharge-Example.xml
+++ b/examples/UKCore-Composition-Discharge-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Composition-Discharge-Example" />
     <text>
         <status value="additional" />
-        --- We have skipped the narrative for better readability of the resource ---
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a composition containing a discharge summary</div>
     </text>
     <!--  Extension to carry details of the Correspondence Care Setting Type.  -->
     <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CareSettingType">

--- a/examples/UKCore-Extension-ConditionEpisode-Example.xml
+++ b/examples/UKCore-Extension-ConditionEpisode-Example.xml
@@ -6,17 +6,17 @@
   </text>
   <!--  **************extension start**************  -->
   <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ConditionEpisode">
-    <valueCode value="new" />
-    <valueCodeableConcept>
-      <coding>
-        <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity" />
-        <code value="new" />
-        <display value="New" />
-      </coding>
-    </valueCodeableConcept>
-  </extension>
-  <!--  **************extension end**************  -->
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
+        <valueCode value="new" />
+        <valueCodeableConcept>
+            <coding>
+                <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity" />
+                <code value="new" />
+                <display value="New" />
+            </coding>
+        </valueCodeableConcept>
+    </extension>
+    <!--   **************extension end**************   -->
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
 </Condition>

--- a/examples/UKCore-Extension-DeviceReference-Example.xml
+++ b/examples/UKCore-Extension-DeviceReference-Example.xml
@@ -5,40 +5,40 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a device performing a diagnostic report</div>
   </text>
   <status value="final" />
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="721981007" />
-      <display value="Diagnostic studies report" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <performer>
-    <display value="Software as a medical device" />
-    <!-- ***************extension start*************** -->
-    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference">
-      <valueReference>
-        <reference value="Device/UKCore-Device-SoftwareAsAMedicalDevice-Example" />
-      </valueReference>
-    </extension>
-    <!-- ***************extension end*************** -->
-  </performer>
-  <resultsInterpreter>
-    <display value="Software as a medical device" />
-    <!-- ***************extension start*************** -->
-    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference">
-      <valueReference>
-        <reference value="Device/UKCore-Device-SoftwareAsAMedicalDevice-Example" />
-      </valueReference>
-    </extension>
-    <!-- ***************extension end*************** -->
-  </resultsInterpreter>
-  <specimen>
-    <reference value="Specimen/UKCore-Specimen-BloodSpecimen-Example" />
-  </specimen>
-  <result>
-    <reference value="Observation/UKCore-Observation-WhiteCellCount-Example" />
-  </result>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="721981007" />
+            <display value="Diagnostic studies report" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <performer>
+        <!--  ***************extension start***************  -->
+        <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference">
+            <valueReference>
+                <reference value="Device/UKCore-Device-SoftwareAsAMedicalDevice-Example" />
+            </valueReference>
+        </extension>
+        <display value="Software as a medical device" />
+        <!--  ***************extension end***************  -->
+    </performer>
+    <resultsInterpreter>
+        <!--  ***************extension start***************  -->
+        <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference">
+            <valueReference>
+                <reference value="Device/UKCore-Device-SoftwareAsAMedicalDevice-Example" />
+            </valueReference>
+        </extension>
+        <display value="Software as a medical device" />
+        <!--  ***************extension end***************  -->
+    </resultsInterpreter>
+    <specimen>
+        <reference value="Specimen/UKCore-Specimen-BloodSpecimen-Example" />
+    </specimen>
+    <result>
+        <reference value="Observation/UKCore-Observation-WhiteCellCount-Example" />
+    </result>
 </DiagnosticReport>

--- a/examples/UKCore-Extension-PriorityReason-Example.xml
+++ b/examples/UKCore-Extension-PriorityReason-Example.xml
@@ -4,25 +4,25 @@
     <status value="additional" />
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate sending a priority reason for an urgent ServiceRequest, using a SNOMED CT concept</div>
   </text>
-  <priority value="urgent">
-    <!-- ***************extension start*************** -->
-    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason">
-      <valueCodeableConcept>
-        <coding>
-          <system value="http://snomed.info/sct" />
-          <code value="1321851000000109" />
-          <display value="Provision of advice, assessment or treatment delayed due to COVID-19 pandemic" />
-        </coding>
-      </valueCodeableConcept>
-    </extension>
-    <!-- **************extension end ****************** -->
-  </priority>
   <status value="active" />
   <intent value="order" />
+  <priority value="urgent">
+      <!--  ***************extension start***************  -->
+      <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason">
+          <valueCodeableConcept>
+              <coding>
+                  <system value="http://snomed.info/sct" />
+                  <code value="1321851000000109" />
+                  <display value="Provision of advice, assessment or treatment delayed due to COVID-19 pandemic" />
+              </coding>
+          </valueCodeableConcept>
+      </extension>
+      <!--  **************extension end ******************  -->
+  </priority>
   <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+      <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
   </subject>
   <requester>
-    <reference value="Practitioner/UKCore-Practitioner-DoctorPaulRastall-Example" />
+      <reference value="Practitioner/UKCore-Practitioner-DoctorPaulRastall-Example" />
   </requester>
 </ServiceRequest>

--- a/examples/UKCore-Extension-PriorityReason-SendingAsText-Example.xml
+++ b/examples/UKCore-Extension-PriorityReason-SendingAsText-Example.xml
@@ -4,21 +4,21 @@
     <status value="additional" />
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate sending a priority reason for an urgent ServiceRequest, using plain text</div>
   </text>
-  <priority value="urgent">
-    <!-- ***************extension start*************** -->
-    <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason">
-      <valueCodeableConcept>
-        <text value="Original assessment was delayed due to COVID-19 pandemic" />
-      </valueCodeableConcept>
-    </extension>
-    <!-- **************extension end ****************** -->
-  </priority>
   <status value="active" />
   <intent value="order" />
+  <priority value="urgent">
+      <!--  ***************extension start***************  -->
+      <extension url="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason">
+          <valueCodeableConcept>
+              <text value="Original assessment was delayed due to COVID-19 pandemic" />
+          </valueCodeableConcept>
+      </extension>
+      <!--  **************extension end ******************  -->
+  </priority>
   <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+      <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
   </subject>
   <requester>
-    <reference value="Practitioner/UKCore-Practitioner-DoctorPaulRastall-Example" />
+      <reference value="Practitioner/UKCore-Practitioner-DoctorPaulRastall-Example" />
   </requester>
 </ServiceRequest>

--- a/examples/UKCore-Extension-TriggeredBy-Example.xml
+++ b/examples/UKCore-Extension-TriggeredBy-Example.xml
@@ -6,45 +6,45 @@
   </text>
   <!-- ***************extension start*************** -->
   <extension url="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy">
-    <extension url="observation">
-      <valueReference>
-        <reference value="Observation/UKCore-Observation-DrugUse-Example" />
-      </valueReference>
+        <extension url="observation">
+            <valueReference>
+                <reference value="Observation/UKCore-Observation-DrugUse-Example" />
+            </valueReference>
+        </extension>
+        <extension url="type">
+            <valueCode value="reflex" />
+        </extension>
+        <extension url="reason">
+            <valueString value="Patient admitted to recreational drug use." />
+        </extension>
     </extension>
-    <extension url="type">
-      <valueCode value="reflex" />
-    </extension>
-    <extension url="reason">
-      <valueString value="Patient admitted to recreational drug use." />
-    </extension>
-  </extension>
-  <!-- ***************extension end*************** -->
-  <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="293a6418-9dcf-4d42-b97a-b119afd200ba" />
-  </identifier>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="laboratory" />
-      <display value="Laboratory" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="1014801000000101" />
-      <display value="Urine tricyclic drug screen" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <specimen>
-    <reference value="Specimen/UKCore-Specimen-UrineSpecimen-Example" />
-  </specimen>
+    <!--  ***************extension end***************  -->
+    <identifier>
+        <system value="https://tools.ietf.org/html/rfc4122" />
+        <value value="293a6418-9dcf-4d42-b97a-b119afd200ba" />
+    </identifier>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="laboratory" />
+            <display value="Laboratory" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="1014801000000101" />
+            <display value="Urine tricyclic drug screen" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <specimen>
+        <reference value="Specimen/UKCore-Specimen-UrineSpecimen-Example" />
+    </specimen>
 </Observation>

--- a/examples/UKCore-Observation-24HourBloodPressure-Example.xml
+++ b/examples/UKCore-Observation-24HourBloodPressure-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Observation-24HourBloodPressure-Example" />
     <text>
         <status value="additional" />
-        --- We have skipped the narrative for better readability of the resource ---
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate an average blood pressure over 24 hours</div>
     </text>
     <status value="final" />
     <category>

--- a/examples/UKCore-Observation-24HourBloodPressure-Example.xml
+++ b/examples/UKCore-Observation-24HourBloodPressure-Example.xml
@@ -1,61 +1,61 @@
-<Observation>
-  <id value="UKCore-Observation-24HourBloodPressure-Example" />
-  <text>
-    <status value="additional" />
-    <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate an average blood pressure over 24 hours</div>
-  </text>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="vital-signs" />
-      <display value="Vital Signs" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="314463006" />
-      <display value="24 hour blood pressure" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-03-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <component>
+<Observation xmlns="http://hl7.org/fhir">
+    <id value="UKCore-Observation-24HourBloodPressure-Example" />
+    <text>
+        <status value="additional" />
+        --- We have skipped the narrative for better readability of the resource ---
+    </text>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="vital-signs" />
+            <display value="Vital Signs" />
+        </coding>
+    </category>
     <code>
-      <coding>
-        <system value="http://snomed.info/sct" />
-        <code value="314464000" />
-        <display value="24 hour systolic blood pressure" />
-      </coding>
-      <text value="Systolic blood pressure" />
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="314463006" />
+            <display value="24 hour blood pressure" />
+        </coding>
     </code>
-    <valueQuantity>
-      <value value="102" />
-      <unit value="millimeter of mercury" />
-      <system value="http://unitsofmeasure.org" />
-      <code value="mm[Hg]" />
-    </valueQuantity>
-  </component>
-  <component>
-    <code>
-      <coding>
-        <system value="http://snomed.info/sct" />
-        <code value="314465004" />
-        <display value="24 hour diastolic blood pressure" />
-      </coding>
-      <text value="Diastolic blood pressure" />
-    </code>
-    <valueQuantity>
-      <value value="84" />
-      <unit value="millimeter of mercury" />
-      <system value="http://unitsofmeasure.org" />
-      <code value="mm[Hg]" />
-    </valueQuantity>
-  </component>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-03-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <component>
+        <code>
+            <coding>
+                <system value="http://snomed.info/sct" />
+                <code value="314464000" />
+                <display value="24 hour systolic blood pressure" />
+            </coding>
+            <text value="Systolic blood pressure" />
+        </code>
+        <valueQuantity>
+            <value value="102" />
+            <unit value="millimeter of mercury" />
+            <system value="http://unitsofmeasure.org" />
+            <code value="mm[Hg]" />
+        </valueQuantity>
+    </component>
+    <component>
+        <code>
+            <coding>
+                <system value="http://snomed.info/sct" />
+                <code value="314465004" />
+                <display value="24 hour diastolic blood pressure" />
+            </coding>
+            <text value="Diastolic blood pressure" />
+        </code>
+        <valueQuantity>
+            <value value="84" />
+            <unit value="millimeter of mercury" />
+            <system value="http://unitsofmeasure.org" />
+            <code value="mm[Hg]" />
+        </valueQuantity>
+    </component>
 </Observation>

--- a/examples/UKCore-Observation-BreathingNormally-Example.xml
+++ b/examples/UKCore-Observation-BreathingNormally-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Observation-BreathingNormally-Example" />
     <text>
         <status value="additional" />
-        --- We have skipped the narrative for better readability of the resource ---
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate an observation of a patient breathing room air</div>
     </text>
     <status value="final" />
     <category>

--- a/examples/UKCore-Observation-BreathingNormally-Example.xml
+++ b/examples/UKCore-Observation-BreathingNormally-Example.xml
@@ -1,29 +1,29 @@
-<Observation>
-  <id value="UKCore-Observation-BreathingNormally-Example" />
-  <text>
-    <status value="additional" />
-    <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate an observation of a patient breathing room air</div>
-  </text>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="exam" />
-      <display value="Exam" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="722742002" />
-      <display value="Breathing room air" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-08-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
+<Observation xmlns="http://hl7.org/fhir">
+    <id value="UKCore-Observation-BreathingNormally-Example" />
+    <text>
+        <status value="additional" />
+        --- We have skipped the narrative for better readability of the resource ---
+    </text>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="exam" />
+            <display value="Exam" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="722742002" />
+            <display value="Breathing room air" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
 </Observation>

--- a/examples/UKCore-Observation-DrugUse-Example.xml
+++ b/examples/UKCore-Observation-DrugUse-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Observation-DrugUse-Example" />
     <text>
         <status value="additional" />
-        --- We have skipped the narrative for better readability of the resource ---
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate n observation of the patient's drug use</div>
     </text>
     <identifier>
         <system value="https://tools.ietf.org/html/rfc4122" />

--- a/examples/UKCore-Observation-DrugUse-Example.xml
+++ b/examples/UKCore-Observation-DrugUse-Example.xml
@@ -1,32 +1,32 @@
-<Observation>
-  <id value="UKCore-Observation-DrugUse-Example" />
-  <text>
-    <status value="additional" />
-    <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate n observation of the patient's drug use</div>
-  </text>
-  <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="2af46949-4938-4c57-bad4-c4363e1965d5" />
-  </identifier>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="social-history" />
-      <display value="Social History" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="307052004" />
-      <display value="Illicit drug use" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
+<Observation xmlns="http://hl7.org/fhir">
+    <id value="UKCore-Observation-DrugUse-Example" />
+    <text>
+        <status value="additional" />
+        --- We have skipped the narrative for better readability of the resource ---
+    </text>
+    <identifier>
+        <system value="https://tools.ietf.org/html/rfc4122" />
+        <value value="2af46949-4938-4c57-bad4-c4363e1965d5" />
+    </identifier>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="social-history" />
+            <display value="Social History" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="307052004" />
+            <display value="Illicit drug use" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
 </Observation>

--- a/examples/UKCore-Observation-FastingTest-Example.xml
+++ b/examples/UKCore-Observation-FastingTest-Example.xml
@@ -1,35 +1,35 @@
-<Observation>
-  <id value="UKCore-Observation-FastingTest-Example" />
-  <text>
-    <status value="additional" />
-    <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a blood glucose reading after fasting</div>
-  </text>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="exam" />
-      <display value="Exam" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="997681000000108" />
-      <display value="Fasting blood glucose level" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-08-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <valueQuantity>
-    <value value="3.9" />
-    <code value="mmol/L" />
-    <system value="http://unitsofmeasure.org" />
-    <unit value="millimoles per litre" />
-  </valueQuantity>
+<Observation xmlns="http://hl7.org/fhir">
+    <id value="UKCore-Observation-FastingTest-Example" />
+    <text>
+        <status value="additional" />
+        --- We have skipped the narrative for better readability of the resource ---
+    </text>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="exam" />
+            <display value="Exam" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="997681000000108" />
+            <display value="Fasting blood glucose level" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueQuantity>
+        <value value="3.9" />
+        <unit value="millimoles per litre" />
+        <system value="http://unitsofmeasure.org" />
+        <code value="mmol/L" />
+    </valueQuantity>
 </Observation>

--- a/examples/UKCore-Observation-FastingTest-Example.xml
+++ b/examples/UKCore-Observation-FastingTest-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Observation-FastingTest-Example" />
     <text>
         <status value="additional" />
-        --- We have skipped the narrative for better readability of the resource ---
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a blood glucose reading after fasting</div>
     </text>
     <status value="final" />
     <category>

--- a/examples/UKCore-Observation-FingerJointInflamed-Example.xml
+++ b/examples/UKCore-Observation-FingerJointInflamed-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Observation-FingerJointInflamed-Example" />
     <text>
         <status value="additional" />
-        --- We have skipped the narrative for better readability of the resource ---
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a finger joint inflammation observation</div>
     </text>
     <identifier>
         <system value="https://tools.ietf.org/html/rfc4122" />

--- a/examples/UKCore-Observation-FingerJointInflamed-Example.xml
+++ b/examples/UKCore-Observation-FingerJointInflamed-Example.xml
@@ -1,29 +1,29 @@
-<Observation>
-  <id value="UKCore-Observation-FingerJointInflamed-Example" />
-  <text>
-    <status value="additional" />
-    <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a finger joint inflammation observation</div>
-  </text>
-  <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="0733b27a-377b-4688-90be-eb7b9f462b91" />
-  </identifier>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="exam" />
-      <display value="Exam" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="298167002" />
-      <display value="Finger joint inflamed" />
-    </coding>
-  </code>
-  <performer>
-    <reference value="Practitioner/UKCore-Practitioner-PharmacistJimmyChuck-Example" />
-  </performer>
+<Observation xmlns="http://hl7.org/fhir">
+    <id value="UKCore-Observation-FingerJointInflamed-Example" />
+    <text>
+        <status value="additional" />
+        --- We have skipped the narrative for better readability of the resource ---
+    </text>
+    <identifier>
+        <system value="https://tools.ietf.org/html/rfc4122" />
+        <value value="0733b27a-377b-4688-90be-eb7b9f462b91" />
+    </identifier>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="exam" />
+            <display value="Exam" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="298167002" />
+            <display value="Finger joint inflamed" />
+        </coding>
+    </code>
+    <performer>
+        <reference value="Practitioner/UKCore-Practitioner-PharmacistJimmyChuck-Example" />
+    </performer>
 </Observation>

--- a/examples/UKCore-Observation-Group-FullBloodCount-Example.xml
+++ b/examples/UKCore-Observation-Group-FullBloodCount-Example.xml
@@ -5,31 +5,31 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a full blood count using multiple lab observation references</div>
   </text>
   <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="53dd97da-082c-450d-a47d-3ffa44941a68" />
+      <system value="https://tools.ietf.org/html/rfc4122" />
+      <value value="53dd97da-082c-450d-a47d-3ffa44941a68" />
   </identifier>
   <status value="final" />
   <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="laboratory" />
-      <display value="Laboratory" />
-    </coding>
+      <coding>
+          <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+          <code value="laboratory" />
+          <display value="Laboratory" />
+      </coding>
   </category>
   <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="26604007" />
-      <display value="Full blood count" />
-    </coding>
+      <coding>
+          <system value="http://snomed.info/sct" />
+          <code value="26604007" />
+          <display value="Full blood count" />
+      </coding>
   </code>
   <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+      <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
   </subject>
   <hasMember>
-    <reference value="Observation/UKCore-Observation-Lab-WhiteCellCount-Example" />
+      <reference value="Observation/UKCore-Observation-Lab-WhiteCellCount-Example" />
   </hasMember>
   <hasMember>
-    <reference value="Observation/UKCore-Observation-Lab-RedCellCount-Example" />
+      <reference value="Observation/UKCore-Observation-Lab-RedCellCount-Example" />
   </hasMember>
 </Observation>

--- a/examples/UKCore-Observation-HeavyDrinker-Example.xml
+++ b/examples/UKCore-Observation-HeavyDrinker-Example.xml
@@ -5,31 +5,31 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a patient who is a heavy drinker</div>
   </text>
   <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="social-history" />
-      <display value="Social History" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="1082631000000102" />
-      <display value="Alcohol units consumed per day" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-08-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <valueQuantity>
-    <value value="20" />
-    <code value="/d" />
-    <system value="http://unitsofmeasure.org" />
-    <unit value="per day" />
-  </valueQuantity>
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="social-history" />
+            <display value="Social History" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="1082631000000102" />
+            <display value="Alcohol units consumed per day" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueQuantity>
+        <value value="20" />
+        <unit value="per day" />
+        <system value="http://unitsofmeasure.org" />
+        <code value="/d" />
+    </valueQuantity>
 </Observation>

--- a/examples/UKCore-Observation-Lab-RedCellCount-Example.xml
+++ b/examples/UKCore-Observation-Lab-RedCellCount-Example.xml
@@ -5,44 +5,44 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate the observation of a red cell count for a blood specimen</div>
   </text>
   <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="fcd8af5a-18a0-4d0b-8c79-5b6bdf55fb32" />
-  </identifier>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="laboratory" />
-      <display value="Laboratory" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="58571000237106" />
-      <display value="Nucleated red blood cell count in blood" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <valueQuantity>
-    <value value="3.9" />
-    <unit value="10*12/L" />
-    <system value="http://unitsofmeasure.org" />
-  </valueQuantity>
-  <specimen>
-    <reference value="Specimen/UKCore-Specimen-BloodSpecimen-Example" />
-  </specimen>
-  <referenceRange>
-    <low>
-      <value value="4.0" />
-    </low>
-    <high>
-      <value value="5.9" />
-    </high>
-  </referenceRange>
+        <system value="https://tools.ietf.org/html/rfc4122" />
+        <value value="fcd8af5a-18a0-4d0b-8c79-5b6bdf55fb32" />
+    </identifier>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="laboratory" />
+            <display value="Laboratory" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="58571000237106" />
+            <display value="Nucleated red blood cell count in blood" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueQuantity>
+        <value value="3.9" />
+        <unit value="10*12/L" />
+        <system value="http://unitsofmeasure.org" />
+    </valueQuantity>
+    <specimen>
+        <reference value="Specimen/UKCore-Specimen-BloodSpecimen-Example" />
+    </specimen>
+    <referenceRange>
+        <low>
+            <value value="4.0" />
+        </low>
+        <high>
+            <value value="5.9" />
+        </high>
+    </referenceRange>
 </Observation>

--- a/examples/UKCore-Observation-Lab-WhiteCellCount-Example.xml
+++ b/examples/UKCore-Observation-Lab-WhiteCellCount-Example.xml
@@ -5,44 +5,44 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate the observation of a white cell count for a blood specimen</div>
   </text>
   <identifier>
-    <system value="https://tools.ietf.org/html/rfc4122" />
-    <value value="3b809516-a294-4de9-a4ce-0c24c7b5f796" />
-  </identifier>
-  <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="laboratory" />
-      <display value="Laboratory" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="16181000237107" />
-      <display value="White blood cell count in fluid" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <valueQuantity>
-    <value value="11.2" />
-    <unit value="10*9/L" />
-    <system value="http://unitsofmeasure.org" />
-  </valueQuantity>
-  <specimen>
-    <reference value="Specimen/UKCore-Specimen-BloodSpecimen-Example" />
-  </specimen>
-  <referenceRange>
-    <low>
-      <value value="4.0" />
-    </low>
-    <high>
-      <value value="17.0" />
-    </high>
-  </referenceRange>
+        <system value="https://tools.ietf.org/html/rfc4122" />
+        <value value="3b809516-a294-4de9-a4ce-0c24c7b5f796" />
+    </identifier>
+    <status value="final" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="laboratory" />
+            <display value="Laboratory" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="16181000237107" />
+            <display value="White blood cell count in fluid" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueQuantity>
+        <value value="11.2" />
+        <unit value="10*9/L" />
+        <system value="http://unitsofmeasure.org" />
+    </valueQuantity>
+    <specimen>
+        <reference value="Specimen/UKCore-Specimen-BloodSpecimen-Example" />
+    </specimen>
+    <referenceRange>
+        <low>
+            <value value="4.0" />
+        </low>
+        <high>
+            <value value="17.0" />
+        </high>
+    </referenceRange>
 </Observation>

--- a/examples/UKCore-Observation-OxygenTherapy-Example.xml
+++ b/examples/UKCore-Observation-OxygenTherapy-Example.xml
@@ -5,27 +5,27 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate an observation of a patient being assisted by oxygen therapy</div>
   </text>
   <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="therapy" />
-      <display value="Therapy" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="371825009" />
-      <display value="Patient on oxygen" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <effectiveDateTime value="2023-08-10" />
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="therapy" />
+            <display value="Therapy" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="371825009" />
+            <display value="Patient on oxygen" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
     <valueQuantity>
         <value value="2" />
         <unit value="litre per minute" />

--- a/examples/UKCore-Observation-PatientConsciousness-Example.xml
+++ b/examples/UKCore-Observation-PatientConsciousness-Example.xml
@@ -5,32 +5,32 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a patient's consciousness level</div>
   </text>
   <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="survey" />
-      <display value="Survey" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="1104441000000107" />
-      <display value="Alert Confusion Voice Pain Unresponsive scale score" />
-    </coding>
-  </code>
-  <valueCodeableConcept>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="300202002" />
-      <display value="Responds to voice" />
-    </coding>
-  </valueCodeableConcept>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-08-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="survey" />
+            <display value="Survey" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="1104441000000107" />
+            <display value="Alert Confusion Voice Pain Unresponsive scale score" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueCodeableConcept>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="300202002" />
+            <display value="Responds to voice" />
+        </coding>
+    </valueCodeableConcept>
 </Observation>

--- a/examples/UKCore-Observation-PipeSmoker-Example.xml
+++ b/examples/UKCore-Observation-PipeSmoker-Example.xml
@@ -5,31 +5,31 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate the observation of a patient who smokes a pipe</div>
   </text>
   <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="social-history" />
-      <display value="Social History" />
-    </coding>
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="230058003" />
-      <display value="Pipe tobacco consumption" />
-    </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-08-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <valueQuantity>
-    <value value="5" />
-    <code value="/d" />
-    <system value="http://unitsofmeasure.org" />
-    <unit value="per day" />
-  </valueQuantity>
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="social-history" />
+            <display value="Social History" />
+        </coding>
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="230058003" />
+            <display value="Pipe tobacco consumption" />
+        </coding>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueQuantity>
+        <value value="5" />
+        <unit value="per day" />
+        <system value="http://unitsofmeasure.org" />
+        <code value="/d" />
+    </valueQuantity>
 </Observation>

--- a/examples/UKCore-Observation-VitalSigns-HeartRate-Example.xml
+++ b/examples/UKCore-Observation-VitalSigns-HeartRate-Example.xml
@@ -5,37 +5,37 @@
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate a heart rate vital sign</div>
   </text>
   <status value="final" />
-  <category>
-    <coding>
-      <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-      <code value="vital-signs" />
-      <display value="Vital Signs" />
-    </coding>
-    <text value="Vital Signs" />
-  </category>
-  <code>
-    <coding>
-      <system value="http://snomed.info/sct" />
-      <code value="444981005" />
-      <display value="Resting heart rate" />
-    </coding>
+    <category>
+        <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+            <code value="vital-signs" />
+            <display value="Vital Signs" />
+        </coding>
+        <text value="Vital Signs" />
+    </category>
+    <code>
+        <coding>
+            <system value="http://snomed.info/sct" />
+            <code value="444981005" />
+            <display value="Resting heart rate" />
+        </coding>
         <coding>
             <system value="http://loinc.org" />
             <code value="8867-4" />
             <display value="Heart rate" />
         </coding>
-  </code>
-  <subject>
-    <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-  </subject>
-  <effectiveDateTime value="2023-08-10" />
-  <performer>
-    <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-  </performer>
-  <valueQuantity>
-    <value value="104" />
-    <code value="/min" />
-    <system value="http://unitsofmeasure.org" />
-    <unit value="per minute" />
-  </valueQuantity>
+    </code>
+    <subject>
+        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+    </subject>
+    <effectiveDateTime value="2023-08-10" />
+    <performer>
+        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+    </performer>
+    <valueQuantity>
+        <value value="104" />
+        <unit value="per minute" />
+        <system value="http://unitsofmeasure.org" />
+        <code value="/min" />
+    </valueQuantity>
 </Observation>

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -1,174 +1,173 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-DiagnosticReport-Lab" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
-  <version value="2.0.0" />
-  <name value="UKCoreDiagnosticReportLab" />
-  <title value="UK Core Diagnostic Report Lab" />
-  <status value="active" />
-  <date value="2024-07-11" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [DiagnosticReport](https://hl7.org/fhir/R4/DiagnosticReport.html), to provide laboratory specific support for test results." />
-  <purpose value="To provide implementers with additional support when implementing test result data and to provide a consistent structure to how the data is presented." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="DiagnosticReport" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="DiagnosticReport">
-      <path value="DiagnosticReport" />
-      <constraint>
-        <key value="ukcore-diag-lab-001" />
-        <severity value="warning" />
-        <human value="An issued time SHOULD be present if status = partial, preliminary, final, amended, corrected or appended" />
-        <expression value="issued.exists() or (issued.empty() and (status in ('partial' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'appended')).not())" />
-      </constraint>
-    </element>
-    <element id="DiagnosticReport.extension:compositionReferenceR5">
-      <path value="DiagnosticReport.extension" />
-      <sliceName value="compositionReferenceR5" />
-      <short value="A Composition reference for a DiagnosticReport. This is a R5 backport." />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="DiagnosticReport.extension:compositionReferenceR5.value[x]">
-      <path value="DiagnosticReport.extension.value[x]" />
-      <short value="Reference to a Composition resource." />
-      <definition value="Reference to a Composition resource instance that provides structure for organizing the contents of the DiagnosticReport." />
-    </element>
-    <element id="DiagnosticReport.extension:noteR5">
-      <path value="DiagnosticReport.extension" />
-      <sliceName value="noteR5" />
-      <short value="Comments about the diagnostic report. This is a R5 backport." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.note" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="DiagnosticReport.extension:noteR5.value[x]">
-      <path value="DiagnosticReport.extension.value[x]" />
-      <definition value="May include general statements about the diagnostic report, or statements about significant, unexpected or unreliable results values contained within the diagnostic report, or information about its source when relevant to its interpretation." />
-    </element>
-    <element id="DiagnosticReport.extension:supportingInfoR5">
-      <path value="DiagnosticReport.extension" />
-      <sliceName value="supportingInfoR5" />
-      <short value="Additional info supporting the diagnostic report. This is a R5 backport." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.supportingInfo" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="DiagnosticReport.extension:supportingInfoR5.extension">
-      <path value="DiagnosticReport.extension.extension" />
-      <min value="2" />
-    </element>
-    <element id="DiagnosticReport.status">
-      <path value="DiagnosticReport.status" />
-      <short value="The status of the diagnostic report." />
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.category">
-      <path value="DiagnosticReport.category" />
-      <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="coding.code" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <min value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.category:laboratory">
-      <path value="DiagnosticReport.category" />
-      <sliceName value="laboratory" />
-      <short value="A mandatory slice that states this resource is categorized as laboratory related content." />
-      <min value="1" />
-      <max value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.category:laboratory.coding.system">
-      <path value="DiagnosticReport.category.coding.system" />
-      <fixedUri value="http://terminology.hl7.org/CodeSystem/v2-0074" />
-    </element>
-    <element id="DiagnosticReport.category:laboratory.coding.code">
-      <path value="DiagnosticReport.category.coding.code" />
-      <fixedCode value="LAB" />
-    </element>
-    <element id="DiagnosticReport.code">
-      <path value="DiagnosticReport.code" />
-      <short value="A code or name that describes this diagnostic report." />
-      <mustSupport value="true" />
-      <binding>
-        <strength value="preferred" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode" />
-      </binding>
-    </element>
-    <element id="DiagnosticReport.subject">
-      <path value="DiagnosticReport.subject" />
-      <short value="The patient that is the subject of the report." />
-      <min value="1" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-      </type>
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.issued">
-      <path value="DiagnosticReport.issued" />
-      <short value="Clinically relevant time / time-period for report." />
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.performer.extension:deviceReference">
-      <path value="DiagnosticReport.performer.extension" />
-      <sliceName value="deviceReference" />
-      <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="DiagnosticReport.resultsInterpreter.extension:deviceReference">
-      <path value="DiagnosticReport.resultsInterpreter.extension" />
-      <sliceName value="deviceReference" />
-      <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="DiagnosticReport.result">
-      <path value="DiagnosticReport.result" />
-      <short value="Lab related Observations that are part of this diagnostic report." />
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.conclusionCode">
-      <path value="DiagnosticReport.conclusionCode" />
-      <binding>
-        <strength value="preferred" />
-      </binding>
-    </element>
-  </differential>
+    <id value="UKCore-DiagnosticReport-Lab" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab" />
+    <version value="2.0.1" />
+    <name value="UKCoreDiagnosticReportLab" />
+    <title value="UK Core Diagnostic Report Lab" />
+    <status value="active" />
+    <date value="2024-07-23" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="This profile defines the UK constraints and extensions on the International FHIR resource [DiagnosticReport](https://hl7.org/fhir/R4/DiagnosticReport.html), to provide laboratory specific support for test results." />
+    <purpose value="To provide implementers with additional support when implementing test result data and to provide a consistent structure to how the data is presented." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="DiagnosticReport" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="DiagnosticReport">
+            <path value="DiagnosticReport" />
+            <constraint>
+                <key value="ukcore-diag-lab-001" />
+                <severity value="warning" />
+                <human value="An issued time SHOULD be present if status = partial, preliminary, final, amended, corrected or appended" />
+                <expression value="issued.exists() or (issued.empty() and (status in (&#39;partial&#39; | &#39;preliminary&#39; | &#39;final&#39; | &#39;amended&#39; | &#39;corrected&#39; | &#39;appended&#39;)).not())" />
+            </constraint>
+        </element>
+        <element id="DiagnosticReport.extension:compositionReferenceR5">
+            <path value="DiagnosticReport.extension" />
+            <sliceName value="compositionReferenceR5" />
+            <short value="A Composition reference for a DiagnosticReport. This is a R5 backport." />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="DiagnosticReport.extension:compositionReferenceR5.value[x]">
+            <path value="DiagnosticReport.extension.value[x]" />
+            <short value="Reference to a Composition resource." />
+            <definition value="Reference to a Composition resource instance that provides structure for organizing the contents of the DiagnosticReport." />
+        </element>
+        <element id="DiagnosticReport.extension:noteR5">
+            <path value="DiagnosticReport.extension" />
+            <sliceName value="noteR5" />
+            <short value="Comments about the diagnostic report. This is a R5 backport." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.note" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="DiagnosticReport.extension:noteR5.value[x]">
+            <path value="DiagnosticReport.extension.value[x]" />
+            <definition value="May include general statements about the diagnostic report, or statements about significant, unexpected or unreliable results values contained within the diagnostic report, or information about its source when relevant to its interpretation." />
+        </element>
+        <element id="DiagnosticReport.extension:supportingInfoR5">
+            <path value="DiagnosticReport.extension" />
+            <sliceName value="supportingInfoR5" />
+            <short value="Additional info supporting the diagnostic report. This is a R5 backport." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.supportingInfo" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="DiagnosticReport.extension:supportingInfoR5.extension">
+            <path value="DiagnosticReport.extension.extension" />
+            <min value="2" />
+        </element>
+        <element id="DiagnosticReport.status">
+            <path value="DiagnosticReport.status" />
+            <short value="The status of the diagnostic report." />
+            <mustSupport value="true" />
+        </element>
+        <element id="DiagnosticReport.category">
+            <path value="DiagnosticReport.category" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="coding.code" />
+                </discriminator>
+                <rules value="open" />
+            </slicing>
+            <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
+            <min value="1" />
+            <mustSupport value="true" />
+        </element>
+        <element id="DiagnosticReport.category:laboratory">
+            <path value="DiagnosticReport.category" />
+            <sliceName value="laboratory" />
+            <short value="A mandatory slice that states this resource is categorized as laboratory related content." />
+            <min value="1" />
+            <max value="1" />
+            <mustSupport value="true" />
+        </element>
+        <element id="DiagnosticReport.category:laboratory.coding.system">
+            <path value="DiagnosticReport.category.coding.system" />
+            <fixedUri value="http://terminology.hl7.org/CodeSystem/v2-0074" />
+        </element>
+        <element id="DiagnosticReport.category:laboratory.coding.code">
+            <path value="DiagnosticReport.category.coding.code" />
+            <fixedCode value="LAB" />
+        </element>
+        <element id="DiagnosticReport.code">
+            <path value="DiagnosticReport.code" />
+            <short value="A code or name that describes this diagnostic report." />
+            <mustSupport value="true" />
+            <binding>
+                <strength value="preferred" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode" />
+            </binding>
+        </element>
+        <element id="DiagnosticReport.subject">
+            <path value="DiagnosticReport.subject" />
+            <short value="The patient that is the subject of the report." />
+            <min value="1" />
+            <type>
+                <code value="Reference" />
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+            </type>
+            <mustSupport value="true" />
+        </element>
+        <element id="DiagnosticReport.issued">
+            <path value="DiagnosticReport.issued" />
+            <short value="Clinically relevant time / time-period for report." />
+            <mustSupport value="true" />
+        </element>
+        <element id="DiagnosticReport.performer.extension:deviceReference">
+            <path value="DiagnosticReport.performer.extension" />
+            <sliceName value="deviceReference" />
+            <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="DiagnosticReport.resultsInterpreter.extension:deviceReference">
+            <path value="DiagnosticReport.resultsInterpreter.extension" />
+            <sliceName value="deviceReference" />
+            <short value="A reference to a Device which interprets / performs the results of the DiagnosticReport." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="DiagnosticReport.result">
+            <path value="DiagnosticReport.result" />
+            <short value="Lab related Observations that are part of this diagnostic report." />
+            <mustSupport value="true" />
+        </element>
+        <element id="DiagnosticReport.conclusionCode">
+            <path value="DiagnosticReport.conclusionCode" />
+            <binding>
+                <strength value="preferred" />
+            </binding>
+        </element>
+    </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-Group-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Group-Lab.xml
@@ -1,152 +1,151 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Observation-Group-Lab" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Group-Lab" />
-  <version value="2.0.0" />
-  <name value="UKCoreObservationGroupLab" />
-  <title value="UK Core Observation Group Lab" />
-  <status value="active" />
-  <date value="2023-12-12" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Observation](https://hl7.org/fhir/R4/Observation.html), in order to allow the grouping of multiple UKCore-Observation-Lab tests to be referenced within the DiagnosticReport as a single display, e.g. Full Blood Count." />
-  <purpose value="This profile allows the creation of a report for results borne from a single request panel, or profile, e.g. Full Blood Count, Lipid Profile, etc. allowing the results to be logically ordered according to the given profile and/or best practice guidelines." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Observation" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Observation">
-      <path value="Observation" />
-      <constraint>
-        <key value="ukcore-obs-grplab-001" />
-        <severity value="warning" />
-        <human value="`value[x]` SHOULD NOT be used within this Profile" />
-        <expression value="value.empty()" />
-      </constraint>
-    </element>
-    <element id="Observation.extension:triggeredByR5">
-      <path value="Observation.extension" />
-      <sliceName value="triggeredByR5" />
-      <short value="Triggering observation(s). This is a R5 backport." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy" />
-      </type>
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:observation">
-      <path value="Observation.extension.extension" />
-      <sliceName value="observation" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:observation.value[x]">
-      <path value="Observation.extension.extension.value[x]" />
-      <short value="Triggering observation." />
-      <definition value="A reference to the triggering observation." />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:type">
-      <path value="Observation.extension.extension" />
-      <sliceName value="type" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:type.value[x]">
-      <path value="Observation.extension.extension.value[x]" />
-      <short value="The type of trigger. Reflex | Repeat | Re-run" />
-      <definition value="The type of trigger. Reflex | Repeat | Re-run" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:reason">
-      <path value="Observation.extension.extension" />
-      <sliceName value="reason" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:reason.value[x]">
-      <path value="Observation.extension.extension.value[x]" />
-      <short value="Reason that the observation was triggered." />
-      <definition value="Provides the reason why this observation was performed as a result of the observation referenced." />
-    </element>
-    <element id="Observation.extension:bodyStructureR5">
-      <path value="Observation.extension" />
-      <sliceName value="bodyStructureR5" />
-      <short value="Observed body structure. This is a R5 backport." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure" />
-      </type>
-    </element>
-    <element id="Observation.status">
-      <path value="Observation.status" />
-      <short value="The status of the result value." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.category">
-      <path value="Observation.category" />
-      <short value="A code that classifies the general type of observation being made." />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="coding.code" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <min value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.category:laboratory">
-      <path value="Observation.category" />
-      <sliceName value="laboratory" />
-      <short value="A mandatory code, to identify this observation as being Lab related." />
-      <min value="1" />
-      <max value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.category:laboratory.coding.system">
-      <path value="Observation.category.coding.system" />
-      <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
-    </element>
-    <element id="Observation.category:laboratory.coding.code">
-      <path value="Observation.category.coding.code" />
-      <fixedCode value="laboratory" />
-    </element>
-    <element id="Observation.code">
-      <path value="Observation.code" />
-      <short value="The type of observation (code / type)." />
-      <mustSupport value="true" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system regarding laboratory medicine test requests and test group results" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
-      </binding>
-    </element>
-    <element id="Observation.subject">
-      <path value="Observation.subject" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-      </type>
-    </element>
-    <element id="Observation.bodySite">
-      <path value="Observation.bodySite" />
-      <binding>
-        <strength value="preferred" />
-      </binding>
-    </element>
-    <element id="Observation.method">
-      <path value="Observation.method" />
-      <binding>
-        <strength value="preferred" />
-      </binding>
-    </element>
-    <element id="Observation.referenceRange">
-      <path value="Observation.referenceRange" />
-      <max value="0" />
-    </element>
-  </differential>
+    <id value="UKCore-Observation-Group-Lab" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Group-Lab" />
+    <version value="2.0.0" />
+    <name value="UKCoreObservationGroupLab" />
+    <title value="UK Core Observation Group Lab" />
+    <status value="active" />
+    <date value="2023-12-12" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Observation](https://hl7.org/fhir/R4/Observation.html), in order to allow the grouping of multiple UKCore-Observation-Lab tests to be referenced within the DiagnosticReport as a single display, e.g. Full Blood Count." />
+    <purpose value="This profile allows the creation of a report for results borne from a single request panel, or profile, e.g. Full Blood Count, Lipid Profile, etc. allowing the results to be logically ordered according to the given profile and/or best practice guidelines." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="Observation" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="Observation">
+            <path value="Observation" />
+            <constraint>
+                <key value="ukcore-obs-grplab-001" />
+                <severity value="warning" />
+                <human value="`value[x]` SHOULD NOT be used within this Profile" />
+                <expression value="value.empty()" />
+            </constraint>
+        </element>
+        <element id="Observation.extension:triggeredByR5">
+            <path value="Observation.extension" />
+            <sliceName value="triggeredByR5" />
+            <short value="Triggering observation(s). This is a R5 backport." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy" />
+            </type>
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:observation">
+            <path value="Observation.extension.extension" />
+            <sliceName value="observation" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:observation.value[x]">
+            <path value="Observation.extension.extension.value[x]" />
+            <short value="Triggering observation." />
+            <definition value="A reference to the triggering observation." />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:type">
+            <path value="Observation.extension.extension" />
+            <sliceName value="type" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:type.value[x]">
+            <path value="Observation.extension.extension.value[x]" />
+            <short value="The type of trigger. Reflex | Repeat | Re-run" />
+            <definition value="The type of trigger. Reflex | Repeat | Re-run" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:reason">
+            <path value="Observation.extension.extension" />
+            <sliceName value="reason" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:reason.value[x]">
+            <path value="Observation.extension.extension.value[x]" />
+            <short value="Reason that the observation was triggered." />
+            <definition value="Provides the reason why this observation was performed as a result of the observation referenced." />
+        </element>
+        <element id="Observation.extension:bodyStructureR5">
+            <path value="Observation.extension" />
+            <sliceName value="bodyStructureR5" />
+            <short value="Observed body structure. This is a R5 backport." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure" />
+            </type>
+        </element>
+        <element id="Observation.status">
+            <path value="Observation.status" />
+            <short value="The status of the result value." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Observation.category">
+            <path value="Observation.category" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="coding.code" />
+                </discriminator>
+                <rules value="open" />
+            </slicing>
+            <short value="A code that classifies the general type of observation being made." />
+            <min value="1" />
+            <mustSupport value="true" />
+        </element>
+        <element id="Observation.category:laboratory">
+            <path value="Observation.category" />
+            <sliceName value="laboratory" />
+            <short value="A mandatory code, to identify this observation as being Lab related." />
+            <min value="1" />
+            <max value="1" />
+            <mustSupport value="true" />
+        </element>
+        <element id="Observation.category:laboratory.coding.system">
+            <path value="Observation.category.coding.system" />
+            <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
+        </element>
+        <element id="Observation.category:laboratory.coding.code">
+            <path value="Observation.category.coding.code" />
+            <fixedCode value="laboratory" />
+        </element>
+        <element id="Observation.code">
+            <path value="Observation.code" />
+            <short value="The type of observation (code / type)." />
+            <mustSupport value="true" />
+            <binding>
+                <strength value="preferred" />
+                <description value="A code from the SNOMED Clinical Terminology UK coding system regarding laboratory medicine test requests and test group results" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
+            </binding>
+        </element>
+        <element id="Observation.subject">
+            <path value="Observation.subject" />
+            <type>
+                <code value="Reference" />
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+            </type>
+        </element>
+        <element id="Observation.bodySite">
+            <path value="Observation.bodySite" />
+            <binding>
+                <strength value="preferred" />
+            </binding>
+        </element>
+        <element id="Observation.method">
+            <path value="Observation.method" />
+            <binding>
+                <strength value="preferred" />
+            </binding>
+        </element>
+        <element id="Observation.referenceRange">
+            <path value="Observation.referenceRange" />
+            <max value="0" />
+        </element>
+    </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-Group-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Group-Lab.xml
@@ -1,11 +1,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
     <id value="UKCore-Observation-Group-Lab" />
     <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Group-Lab" />
-    <version value="2.0.0" />
+    <version value="2.0.1" />
     <name value="UKCoreObservationGroupLab" />
     <title value="UK Core Observation Group Lab" />
     <status value="active" />
-    <date value="2023-12-12" />
+    <date value="2024-07-23" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -1,148 +1,147 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Observation-Lab" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />
-  <version value="2.0.0" />
-  <name value="UKCoreObservationLab" />
-  <title value="UK Core Observation Lab" />
-  <status value="active" />
-  <date value="2023-12-12" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Observation](https://hl7.org/fhir/R4/Observation.html), in order to represent an individual laboratory test and result value. These tests can be grouped together using the UKCore-Observation-Group-Lab profile." />
-  <purpose value="To provide the minimum expectations for each individual laboratory test." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Observation" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Observation">
-      <path value="Observation" />
-      <constraint>
-        <key value="ukcore-obs-lab-001" />
-        <severity value="warning" />
-        <human value="Either `value`, `dataAbsentReason` or `note` SHOULD be populated" />
-        <expression value="value.exists() or dataAbsentReason.exists() or note.exists()" />
-      </constraint>
-    </element>
-    <element id="Observation.extension:triggeredByR5">
-      <path value="Observation.extension" />
-      <sliceName value="triggeredByR5" />
-      <short value="Triggering observation(s). This is a R5 backport." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy" />
-      </type>
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:observation">
-      <path value="Observation.extension.extension" />
-      <sliceName value="observation" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:observation.value[x]">
-      <path value="Observation.extension.extension.value[x]" />
-      <short value="Triggering observation." />
-      <definition value="A reference to the triggering observation." />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:type">
-      <path value="Observation.extension.extension" />
-      <sliceName value="type" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:type.value[x]">
-      <path value="Observation.extension.extension.value[x]" />
-      <short value="The type of trigger. Reflex | Repeat | Re-run" />
-      <definition value="The type of trigger. Reflex | Repeat | Re-run" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:reason">
-      <path value="Observation.extension.extension" />
-      <sliceName value="reason" />
-    </element>
-    <element id="Observation.extension:triggeredByR5.extension:reason.value[x]">
-      <path value="Observation.extension.extension.value[x]" />
-      <short value="Reason that the observation was triggered." />
-      <definition value="Provides the reason why this observation was performed as a result of the observation referenced." />
-    </element>
-    <element id="Observation.extension:bodyStructureR5">
-      <path value="Observation.extension" />
-      <sliceName value="bodyStructureR5" />
-      <short value="Observed body structure. This is a R5 backport." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure" />
-      </type>
-    </element>
-    <element id="Observation.status">
-      <path value="Observation.status" />
-      <short value="The status of the result value." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.category">
-      <path value="Observation.category" />
-      <short value="A code that classifies the general type of observation being made." />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="coding.code" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <min value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.category:laboratory">
-      <path value="Observation.category" />
-      <sliceName value="laboratory" />
-      <short value="A mandatory code, to identify this observation as being Lab related." />
-      <min value="1" />
-      <max value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="Observation.category:laboratory.coding.system">
-      <path value="Observation.category.coding.system" />
-      <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
-    </element>
-    <element id="Observation.category:laboratory.coding.code">
-      <path value="Observation.category.coding.code" />
-      <fixedCode value="laboratory" />
-    </element>
-    <element id="Observation.code">
-      <path value="Observation.code" />
-      <short value="The type of lab related observation (code / type)." />
-      <mustSupport value="true" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system regarding laboratory medicine test results" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables" />
-      </binding>
-    </element>
-    <element id="Observation.subject">
-      <path value="Observation.subject" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-      </type>
-    </element>
-    <element id="Observation.bodySite">
-      <path value="Observation.bodySite" />
-      <binding>
-        <strength value="preferred" />
-      </binding>
-    </element>
-    <element id="Observation.method">
-      <path value="Observation.method" />
-      <binding>
-        <strength value="preferred" />
-      </binding>
-    </element>
-  </differential>
+    <id value="UKCore-Observation-Lab" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />
+    <version value="2.0.0" />
+    <name value="UKCoreObservationLab" />
+    <title value="UK Core Observation Lab" />
+    <status value="active" />
+    <date value="2023-12-12" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Observation](https://hl7.org/fhir/R4/Observation.html), in order to represent an individual laboratory test and result value. These tests can be grouped together using the UKCore-Observation-Group-Lab profile." />
+    <purpose value="To provide the minimum expectations for each individual laboratory test." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="Observation" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="Observation">
+            <path value="Observation" />
+            <constraint>
+                <key value="ukcore-obs-lab-001" />
+                <severity value="warning" />
+                <human value="Either `value`, `dataAbsentReason` or `note` SHOULD be populated" />
+                <expression value="value.exists() or dataAbsentReason.exists() or note.exists()" />
+            </constraint>
+        </element>
+        <element id="Observation.extension:triggeredByR5">
+            <path value="Observation.extension" />
+            <sliceName value="triggeredByR5" />
+            <short value="Triggering observation(s). This is a R5 backport." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy" />
+            </type>
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:observation">
+            <path value="Observation.extension.extension" />
+            <sliceName value="observation" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:observation.value[x]">
+            <path value="Observation.extension.extension.value[x]" />
+            <short value="Triggering observation." />
+            <definition value="A reference to the triggering observation." />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:type">
+            <path value="Observation.extension.extension" />
+            <sliceName value="type" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:type.value[x]">
+            <path value="Observation.extension.extension.value[x]" />
+            <short value="The type of trigger. Reflex | Repeat | Re-run" />
+            <definition value="The type of trigger. Reflex | Repeat | Re-run" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:reason">
+            <path value="Observation.extension.extension" />
+            <sliceName value="reason" />
+        </element>
+        <element id="Observation.extension:triggeredByR5.extension:reason.value[x]">
+            <path value="Observation.extension.extension.value[x]" />
+            <short value="Reason that the observation was triggered." />
+            <definition value="Provides the reason why this observation was performed as a result of the observation referenced." />
+        </element>
+        <element id="Observation.extension:bodyStructureR5">
+            <path value="Observation.extension" />
+            <sliceName value="bodyStructureR5" />
+            <short value="Observed body structure. This is a R5 backport." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure" />
+            </type>
+        </element>
+        <element id="Observation.status">
+            <path value="Observation.status" />
+            <short value="The status of the result value." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Observation.category">
+            <path value="Observation.category" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="coding.code" />
+                </discriminator>
+                <rules value="open" />
+            </slicing>
+            <short value="A code that classifies the general type of observation being made." />
+            <min value="1" />
+            <mustSupport value="true" />
+        </element>
+        <element id="Observation.category:laboratory">
+            <path value="Observation.category" />
+            <sliceName value="laboratory" />
+            <short value="A mandatory code, to identify this observation as being Lab related." />
+            <min value="1" />
+            <max value="1" />
+            <mustSupport value="true" />
+        </element>
+        <element id="Observation.category:laboratory.coding.system">
+            <path value="Observation.category.coding.system" />
+            <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
+        </element>
+        <element id="Observation.category:laboratory.coding.code">
+            <path value="Observation.category.coding.code" />
+            <fixedCode value="laboratory" />
+        </element>
+        <element id="Observation.code">
+            <path value="Observation.code" />
+            <short value="The type of lab related observation (code / type)." />
+            <mustSupport value="true" />
+            <binding>
+                <strength value="preferred" />
+                <description value="A code from the SNOMED Clinical Terminology UK coding system regarding laboratory medicine test results" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables" />
+            </binding>
+        </element>
+        <element id="Observation.subject">
+            <path value="Observation.subject" />
+            <type>
+                <code value="Reference" />
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+            </type>
+        </element>
+        <element id="Observation.bodySite">
+            <path value="Observation.bodySite" />
+            <binding>
+                <strength value="preferred" />
+            </binding>
+        </element>
+        <element id="Observation.method">
+            <path value="Observation.method" />
+            <binding>
+                <strength value="preferred" />
+            </binding>
+        </element>
+    </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -1,11 +1,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
     <id value="UKCore-Observation-Lab" />
     <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab" />
-    <version value="2.0.0" />
+    <version value="2.0.1" />
     <name value="UKCoreObservationLab" />
     <title value="UK Core Observation Lab" />
     <status value="active" />
-    <date value="2023-12-12" />
+    <date value="2024-07-23" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -1,142 +1,141 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Observation-VitalSigns" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
-  <version value="1.1.0" />
-  <name value="UKCoreObservationVitalSigns" />
-  <title value="UK Core Observation Vital Signs" />
-  <status value="active" />
-  <date value="2023-12-12" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="Defines the observation constraints and extensions on the UK Core Observation resource for the minimal set of data to query and retrieve clinical observation vital signs information." />
-  <purpose value="This profile allows exchange of internationally FHIR compliant vital signs information based on measurements and simple assertions made about an individual. Where a more constrained derived profile exists, it should be used instead of this profile." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Observation">
-      <path value="Observation" />
-      <constraint>
-        <key value="ukcore-obs-vs-001" />
-        <severity value="error" />
-        <human value="`code.coding` SHALL include a LOINC &quot;magic code&quot;" />
-        <expression value="code.coding.where(system='http://loinc.org').exists()" />
-      </constraint>
-    </element>
-    <element id="Observation.extension:bodyPosition">
-      <path value="Observation.extension" />
-      <sliceName value="bodyPosition" />
-      <short value="The patients body position when the vital signs observation was recorded." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="Observation.extension:bodyPosition.value[x]">
-      <path value="Observation.extension.value[x]" />
-      <binding>
-        <strength value="preferred" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyPosition" />
-      </binding>
-    </element>
-    <element id="Observation.extension:recordingSetting">
-      <path value="Observation.extension" />
-      <sliceName value="recordingSetting" />
-      <short value="Records whether the vital signs observation was performed in a clinical or non clinical setting." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="Observation.status">
-      <path value="Observation.status" />
-      <fixedCode value="final" />
-      <short value="A status of `final` SHALL be present." />
-    </element>
-    <element id="Observation.category">
-      <path value="Observation.category" />
-      <short value="A category of `vital-signs` SHALL be present." />
-      <min value="1" />
-      <max value="1" />
-    </element>
-    <element id="Observation.category.coding.system">
-      <path value="Observation.category.coding.system" />
-      <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
-    </element>
-    <element id="Observation.category.coding.code">
-      <path value="Observation.category.coding.code" />
-      <fixedCode value="vital-signs" />
-    </element>
-    <element id="Observation.code">
-      <path value="Observation.code" />
-      <short value="The type of vital signs observation (code / type)." />
-      <min value="1" />
-      <max value="1" />
-    </element>
-    <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-      <short value="A LOINC &quot;magic code&quot; describing the type of observation SHALL be present." />
-      <min value="1" />
-      <max value="1" />
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult" />
-      </binding>
-    </element>
-    <element id="Observation.code.coding:loinc.system">
-      <path value="Observation.code.coding.system" />
-      <fixedUri value="http://loinc.org" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <short value="A SNOMED CT concept describing the type of observation SHALL be present." />
-      <min value="1" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
-      </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
-    <element id="Observation.subject">
-      <path value="Observation.subject" />
-      <short value="Who or what the observation relates to SHALL be present." />
-      <min value="1" />
-    </element>
-    <element id="Observation.effective[x]">
-      <path value="Observation.effective[x]" />
-      <short value="A clinically relevant time / time-period for observation SHALL be present." />
-      <min value="1" />
-    </element>
-  </differential>
+    <id value="UKCore-Observation-VitalSigns" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+    <version value="1.1.1" />
+    <name value="UKCoreObservationVitalSigns" />
+    <title value="UK Core Observation Vital Signs" />
+    <status value="active" />
+    <date value="2024-07-23" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="Defines the observation constraints and extensions on the UK Core Observation resource for the minimal set of data to query and retrieve clinical observation vital signs information." />
+    <purpose value="This profile allows exchange of internationally FHIR compliant vital signs information based on measurements and simple assertions made about an individual. Where a more constrained derived profile exists, it should be used instead of this profile." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="Observation" />
+    <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="Observation">
+            <path value="Observation" />
+            <constraint>
+                <key value="ukcore-obs-vs-001" />
+                <severity value="error" />
+                <human value="`code.coding` SHALL include a LOINC &quot;magic code&quot;" />
+                <expression value="code.coding.where(system=&#39;http://loinc.org&#39;).exists()" />
+            </constraint>
+        </element>
+        <element id="Observation.extension:bodyPosition">
+            <path value="Observation.extension" />
+            <sliceName value="bodyPosition" />
+            <short value="The patients body position when the vital signs observation was recorded." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="Observation.extension:bodyPosition.value[x]">
+            <path value="Observation.extension.value[x]" />
+            <binding>
+                <strength value="preferred" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyPosition" />
+            </binding>
+        </element>
+        <element id="Observation.extension:recordingSetting">
+            <path value="Observation.extension" />
+            <sliceName value="recordingSetting" />
+            <short value="Records whether the vital signs observation was performed in a clinical or non clinical setting." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="Observation.status">
+            <path value="Observation.status" />
+            <short value="A status of `final` SHALL be present." />
+            <fixedCode value="final" />
+        </element>
+        <element id="Observation.category">
+            <path value="Observation.category" />
+            <short value="A category of `vital-signs` SHALL be present." />
+            <min value="1" />
+            <max value="1" />
+        </element>
+        <element id="Observation.category.coding.system">
+            <path value="Observation.category.coding.system" />
+            <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
+        </element>
+        <element id="Observation.category.coding.code">
+            <path value="Observation.category.coding.code" />
+            <fixedCode value="vital-signs" />
+        </element>
+        <element id="Observation.code">
+            <path value="Observation.code" />
+            <short value="The type of vital signs observation (code / type)." />
+            <min value="1" />
+            <max value="1" />
+        </element>
+        <element id="Observation.code.coding">
+            <path value="Observation.code.coding" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="system" />
+                </discriminator>
+                <rules value="open" />
+            </slicing>
+        </element>
+        <element id="Observation.code.coding:loinc">
+            <path value="Observation.code.coding" />
+            <sliceName value="loinc" />
+            <short value="A LOINC &quot;magic code&quot; describing the type of observation SHALL be present." />
+            <min value="1" />
+            <max value="1" />
+            <binding>
+                <strength value="extensible" />
+                <valueSet value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult" />
+            </binding>
+        </element>
+        <element id="Observation.code.coding:loinc.system">
+            <path value="Observation.code.coding.system" />
+            <fixedUri value="http://loinc.org" />
+        </element>
+        <element id="Observation.code.coding:snomedCT">
+            <path value="Observation.code.coding" />
+            <sliceName value="snomedCT" />
+            <short value="A SNOMED CT concept describing the type of observation SHALL be present." />
+            <min value="1" />
+            <binding>
+                <strength value="preferred" />
+                <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
+            </binding>
+        </element>
+        <element id="Observation.code.coding:snomedCT.system">
+            <path value="Observation.code.coding.system" />
+            <fixedUri value="http://snomed.info/sct" />
+        </element>
+        <element id="Observation.subject">
+            <path value="Observation.subject" />
+            <short value="Who or what the observation relates to SHALL be present." />
+            <min value="1" />
+        </element>
+        <element id="Observation.effective[x]">
+            <path value="Observation.effective[x]" />
+            <short value="A clinically relevant time / time-period for observation SHALL be present." />
+            <min value="1" />
+        </element>
+    </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Organization.xml
+++ b/structuredefinitions/UKCore-Organization.xml
@@ -1,129 +1,128 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Organization" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
-  <version value="2.5.0" />
-  <name value="UKCoreOrganization" />
-  <title value="UK Core Organization" />
-  <status value="active" />
-  <date value="2023-12-12" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Organization](https://hl7.org/fhir/R4/Organization.html)." />
-  <purpose value="This profile allows exchange of a formally or informally recognised grouping of people or organisations formed for the purpose of achieving some form of collective action. Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, etc." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Organization" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Organization" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Organization.extension:mainLocation">
-      <path value="Organization.extension" />
-      <sliceName value="mainLocation" />
-      <short value="The main location of the organisation." />
-      <definition value="The main location of the organisation." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MainLocation" />
-      </type>
-    </element>
-    <element id="Organization.extension:organizationPeriod">
-      <path value="Organization.extension" />
-      <sliceName value="organizationPeriod" />
-      <short value="The date range that this organization SHOULD be considered available." />
-      <definition value="The date range that this organization SHOULD be considered available." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/organization-period" />
-      </type>
-    </element>
-    <element id="Organization.extension:organizationPeriod.value[x]">
-      <path value="Organization.extension.value[x]" />
-      <short value="The date range that this organization SHOULD be considered available." />
-      <definition value="The date range that this organization SHOULD be considered available." />
-    </element>
-    <element id="Organization.identifier">
-      <path value="Organization.identifier" />
-      <short value="Identifies this organization across multiple systems." />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <ordered value="false" />
-        <rules value="open" />
-      </slicing>
-      <mustSupport value="true" />
-    </element>
-    <element id="Organization.identifier:odsOrganisationCode">
-      <path value="Organization.identifier" />
-      <sliceName value="odsOrganisationCode" />
-      <short value="Organisation Data Service code" />
-      <definition value="Identifier code supplier by the Organisation Data Service." />
-      <max value="1" />
-    </element>
-    <element id="Organization.identifier:odsOrganisationCode.system">
-      <path value="Organization.identifier.system" />
-      <min value="1" />
-      <fixedUri value="https://fhir.nhs.uk/Id/ods-organization-code" />
-    </element>
-    <element id="Organization.identifier:odsOrganisationCode.value">
-      <path value="Organization.identifier.value" />
-      <min value="1" />
-    </element>
-    <element id="Organization.identifier:odsSiteCode">
-      <path value="Organization.identifier" />
-      <sliceName value="odsSiteCode" />
-      <short value="ODS Site code to identify the organisation at site level" />
-      <definition value="ODS Site code to identify the organisation at site level." />
-      <max value="1" />
-    </element>
-    <element id="Organization.identifier:odsSiteCode.system">
-      <path value="Organization.identifier.system" />
-      <min value="1" />
-      <fixedUri value="https://fhir.nhs.uk/Id/ods-site-code" />
-    </element>
-    <element id="Organization.identifier:odsSiteCode.value">
-      <path value="Organization.identifier.value" />
-      <min value="1" />
-    </element>
-    <element id="Organization.active">
-      <path value="Organization.active" />
-      <short value="Identifies this organization across multiple systems." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Organization.type">
-      <path value="Organization.type" />
-      <binding>
-        <strength value="extensible" />
-        <description value="A set of concepts indicating the organisation type, derived from the base CodeSystem, and Genomics specific concepts" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-OrganizationType" />
-      </binding>
-    </element>
-    <element id="Organization.name">
-      <path value="Organization.name" />
-      <short value="A name associated with the organization." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Organization.telecom">
-      <path value="Organization.telecom" />
-      <short value="Contact details for the organization." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Organization.address">
-      <path value="Organization.address" />
-      <short value="An address for the organization." />
-      <mustSupport value="true" />
-    </element>
-  </differential>
+    <id value="UKCore-Organization" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization" />
+    <version value="2.5.1" />
+    <name value="UKCoreOrganization" />
+    <title value="UK Core Organization" />
+    <status value="active" />
+    <date value="2024-07-23" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Organization](https://hl7.org/fhir/R4/Organization.html)." />
+    <purpose value="This profile allows exchange of a formally or informally recognised grouping of people or organisations formed for the purpose of achieving some form of collective action. Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, etc." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="Organization" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Organization" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="Organization.extension:mainLocation">
+            <path value="Organization.extension" />
+            <sliceName value="mainLocation" />
+            <short value="The main location of the organisation." />
+            <definition value="The main location of the organisation." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MainLocation" />
+            </type>
+        </element>
+        <element id="Organization.extension:organizationPeriod">
+            <path value="Organization.extension" />
+            <sliceName value="organizationPeriod" />
+            <short value="The date range that this organization SHOULD be considered available." />
+            <definition value="The date range that this organization SHOULD be considered available." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/organization-period" />
+            </type>
+        </element>
+        <element id="Organization.extension:organizationPeriod.value[x]">
+            <path value="Organization.extension.value[x]" />
+            <short value="The date range that this organization SHOULD be considered available." />
+            <definition value="The date range that this organization SHOULD be considered available." />
+        </element>
+        <element id="Organization.identifier">
+            <path value="Organization.identifier" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="system" />
+                </discriminator>
+                <ordered value="false" />
+                <rules value="open" />
+            </slicing>
+            <short value="Identifies this organization across multiple systems." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Organization.identifier:odsOrganisationCode">
+            <path value="Organization.identifier" />
+            <sliceName value="odsOrganisationCode" />
+            <short value="Organisation Data Service code" />
+            <definition value="Identifier code supplier by the Organisation Data Service." />
+            <max value="1" />
+        </element>
+        <element id="Organization.identifier:odsOrganisationCode.system">
+            <path value="Organization.identifier.system" />
+            <min value="1" />
+            <fixedUri value="https://fhir.nhs.uk/Id/ods-organization-code" />
+        </element>
+        <element id="Organization.identifier:odsOrganisationCode.value">
+            <path value="Organization.identifier.value" />
+            <min value="1" />
+        </element>
+        <element id="Organization.identifier:odsSiteCode">
+            <path value="Organization.identifier" />
+            <sliceName value="odsSiteCode" />
+            <short value="ODS Site code to identify the organisation at site level" />
+            <definition value="ODS Site code to identify the organisation at site level." />
+            <max value="1" />
+        </element>
+        <element id="Organization.identifier:odsSiteCode.system">
+            <path value="Organization.identifier.system" />
+            <min value="1" />
+            <fixedUri value="https://fhir.nhs.uk/Id/ods-site-code" />
+        </element>
+        <element id="Organization.identifier:odsSiteCode.value">
+            <path value="Organization.identifier.value" />
+            <min value="1" />
+        </element>
+        <element id="Organization.active">
+            <path value="Organization.active" />
+            <short value="Identifies this organization across multiple systems." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Organization.type">
+            <path value="Organization.type" />
+            <binding>
+                <strength value="extensible" />
+                <description value="A set of concepts indicating the organisation type, derived from the base CodeSystem, and Genomics specific concepts" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-OrganizationType" />
+            </binding>
+        </element>
+        <element id="Organization.name">
+            <path value="Organization.name" />
+            <short value="A name associated with the organization." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Organization.telecom">
+            <path value="Organization.telecom" />
+            <short value="Contact details for the organization." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Organization.address">
+            <path value="Organization.address" />
+            <short value="An address for the organization." />
+            <mustSupport value="true" />
+        </element>
+    </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Patient.xml
+++ b/structuredefinitions/UKCore-Patient.xml
@@ -1,321 +1,320 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-Patient" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
-  <version value="2.6.0" />
-  <name value="UKCorePatient" />
-  <title value="UK Core Patient" />
-  <status value="active" />
-  <date value="2024-03-28" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Patient](https://hl7.org/fhir/R4/Patient.html)." />
-  <purpose value="This profile allows exchange of demographics and other administrative information about an individual receiving care or other health-related services." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="Patient" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Patient" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Patient.extension:birthPlace">
-      <path value="Patient.extension" />
-      <sliceName value="birthPlace" />
-      <short value="The registered place of birth of the patient." />
-      <definition value="The registered place of birth of the patient." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthPlace" />
-      </type>
-    </element>
-    <element id="Patient.extension:birthPlace.value[x]">
-      <path value="Patient.extension.value[x]" />
-      <short value="The registered place of birth of the patient." />
-    </element>
-    <element id="Patient.extension:birthSex">
-      <path value="Patient.extension" />
-      <sliceName value="birthSex" />
-      <short value="The patient's phenotypic sex at birth." />
-      <definition value="The patient's phenotypic sex at birth." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex" />
-      </type>
-    </element>
-    <element id="Patient.extension:cadavericDonor">
-      <path value="Patient.extension" />
-      <sliceName value="cadavericDonor" />
-      <short value="Post-mortem donor status." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/patient-cadavericDonor" />
-      </type>
-    </element>
-    <element id="Patient.extension:cadavericDonor.value[x]">
-      <path value="Patient.extension.value[x]" />
-      <short value="Post-mortem donor status." />
-      <definition value="Flag indicating whether the patient authorized the donation of body parts after death." />
-    </element>
-    <element id="Patient.extension:contactPreference">
-      <path value="Patient.extension" />
-      <sliceName value="contactPreference" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference" />
-      </type>
-    </element>
-    <element id="Patient.extension:deathNotificationStatus">
-      <path value="Patient.extension" />
-      <sliceName value="deathNotificationStatus" />
-      <short value="The patient's death notification status." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeathNotificationStatus" />
-      </type>
-    </element>
-    <element id="Patient.extension:deathNotificationStatus.extension">
-      <path value="Patient.extension.extension" />
-      <min value="1" />
-    </element>
-    <element id="Patient.extension:ethnicCategory">
-      <path value="Patient.extension" />
-      <sliceName value="ethnicCategory" />
-      <short value="The ethnicity of the subject." />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory" />
-      </type>
-    </element>
-    <element id="Patient.extension:residentialStatus">
-      <path value="Patient.extension" />
-      <sliceName value="residentialStatus" />
-      <short value="The residential status of the patient." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ResidentialStatus" />
-      </type>
-    </element>
-    <element id="Patient.extension:patientInterpreterRequired">
-      <path value="Patient.extension" />
-      <sliceName value="patientInterpreterRequired" />
-      <short value="Indicator showing whether the patient needs an interpreter." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired" />
-      </type>
-    </element>
-    <element id="Patient.extension:patientInterpreterRequired.value[x]">
-      <path value="Patient.extension.value[x]" />
-      <short value="Indicator showing whether the patient needs an interpreter" />
-      <definition value="Indicator showing if this Patient requires an interpreter to communicate healthcare information to the practitioner." />
-    </element>
-    <element id="Patient.extension:nhsNumberUnavailableReason">
-      <path value="Patient.extension" />
-      <sliceName value="nhsNumberUnavailableReason" />
-      <short value="Reason why this Patient does not include an NHS Number identifier." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberUnavailableReason" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="Patient.identifier">
-      <path value="Patient.identifier" />
-      <short value="An identifier for this patient." />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <ordered value="false" />
-        <rules value="open" />
-      </slicing>
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.identifier:nhsNumber">
-      <path value="Patient.identifier" />
-      <sliceName value="nhsNumber" />
-      <short value="The patient's NHS number." />
-      <max value="1" />
-      <mustSupport value="false" />
-    </element>
-    <element id="Patient.identifier:nhsNumber.extension:nhsNumberVerificationStatus">
-      <path value="Patient.identifier.extension" />
-      <sliceName value="nhsNumberVerificationStatus" />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus" />
-      </type>
-      <mustSupport value="false" />
-    </element>
-    <element id="Patient.identifier:nhsNumber.system">
-      <path value="Patient.identifier.system" />
-      <min value="1" />
-      <fixedUri value="https://fhir.nhs.uk/Id/nhs-number" />
-    </element>
-    <element id="Patient.identifier:nhsNumber.value">
-      <path value="Patient.identifier.value" />
-      <min value="1" />
-    </element>
-    <element id="Patient.active">
-      <path value="Patient.active" />
-      <short value="Whether this patient's record is in active use." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.name">
-      <path value="Patient.name" />
-      <short value="A name associated with the patient." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.telecom">
-      <path value="Patient.telecom" />
-      <short value="A contact detail for the individual." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.telecom.system.extension:otherContactSystem">
-      <path value="Patient.telecom.system.extension" />
-      <sliceName value="otherContactSystem" />
-      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
-      </type>
-    </element>
-    <element id="Patient.gender">
-      <path value="Patient.gender" />
-      <short value="The gender that the patient is considered to have for administration and record keeping purposes." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.birthDate">
-      <path value="Patient.birthDate" />
-      <short value="The date of birth for the individual." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.birthDate.extension:birthTime">
-      <path value="Patient.birthDate.extension" />
-      <sliceName value="birthTime" />
-      <short value="The time of day that the patient was born. This SHOULD be included when the birth time is relevant." />
-      <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthTime" />
-      </type>
-    </element>
-    <element id="Patient.birthDate.extension:birthTime.value[x]">
-      <path value="Patient.birthDate.extension.value[x]" />
-      <short value="Time of day of birth." />
-      <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
-    </element>
-    <element id="Patient.address">
-      <path value="Patient.address" />
-      <definition value="An address for the individual." />
-      <mustSupport value="true" />
-    </element>
-    <element id="Patient.address.extension:addressKey">
-      <path value="Patient.address.extension" />
-      <sliceName value="addressKey" />
-      <short value="A patient's address key and type" />
-      <definition value="A patient's address key and type." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey" />
-      </type>
-      <mustSupport value="false" />
-    </element>
-    <element id="Patient.maritalStatus">
-      <path value="Patient.maritalStatus" />
-      <binding>
-        <strength value="extensible" />
-        <description value="An indicator to identify the legal marital status of a person" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonMaritalStatusCode" />
-      </binding>
-    </element>
-    <element id="Patient.contact.extension:contactRank">
-      <path value="Patient.contact.extension" />
-      <sliceName value="contactRank" />
-      <short value="The preferred ranking or order of contact applied to a contact on a Patient's contact list." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactRank" />
-      </type>
-    </element>
-    <element id="Patient.contact.extension:copyCorrespondenceIndicator">
-      <path value="Patient.contact.extension" />
-      <sliceName value="copyCorrespondenceIndicator" />
-      <short value="Indicates that a must be copied in to all related correspondence." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CopyCorrespondenceIndicator" />
-      </type>
-    </element>
-    <element id="Patient.contact.relationship">
-      <path value="Patient.contact.relationship" />
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonRelationshipType" />
-      </binding>
-    </element>
-    <element id="Patient.contact.telecom.system.extension:otherContactSystem">
-      <path value="Patient.contact.telecom.system.extension" />
-      <sliceName value="otherContactSystem" />
-      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
-      </type>
-    </element>
-    <element id="Patient.communication.extension:proficiency">
-      <path value="Patient.communication.extension" />
-      <sliceName value="proficiency" />
-      <short value="The patient's proficiency level of the communication method." />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/StructureDefinition/patient-proficiency" />
-      </type>
-    </element>
-    <element id="Patient.communication.extension:proficiency.extension:level">
-      <path value="Patient.communication.extension.extension" />
-      <sliceName value="level" />
-    </element>
-    <element id="Patient.communication.extension:proficiency.extension:level.value[x]">
-      <path value="Patient.communication.extension.extension.value[x]" />
-      <short value="The proficiency level for the communication" />
-      <definition value="The proficiency level for the communication." />
-    </element>
-    <element id="Patient.communication.extension:proficiency.extension:type">
-      <path value="Patient.communication.extension.extension" />
-      <sliceName value="type" />
-    </element>
-    <element id="Patient.communication.extension:proficiency.extension:type.value[x]">
-      <path value="Patient.communication.extension.extension.value[x]" />
-      <short value="The proficiency type for the communication" />
-      <definition value="The proficiency type for the communication." />
-    </element>
-    <element id="Patient.communication.language">
-      <path value="Patient.communication.language" />
-      <short value="A ValueSet that identifies the language used by a person." />
-      <definition value="A ValueSet that identifies the language used by a person." />
-      <binding>
-        <strength value="required" />
-        <description value="A ValueSet that identifies the language used by a person." />
-        <valueSet value="http://hl7.org/fhir/ValueSet/all-languages" />
-      </binding>
-    </element>
-    <element id="Patient.managingOrganization">
-      <path value="Patient.managingOrganization" />
-      <mustSupport value="true" />
-    </element>
-  </differential>
+    <id value="UKCore-Patient" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" />
+    <version value="2.6.1" />
+    <name value="UKCorePatient" />
+    <title value="UK Core Patient" />
+    <status value="active" />
+    <date value="2024-07-23" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Patient](https://hl7.org/fhir/R4/Patient.html)." />
+    <purpose value="This profile allows exchange of demographics and other administrative information about an individual receiving care or other health-related services." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="Patient" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Patient" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="Patient.extension:birthPlace">
+            <path value="Patient.extension" />
+            <sliceName value="birthPlace" />
+            <short value="The registered place of birth of the patient." />
+            <definition value="The registered place of birth of the patient." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthPlace" />
+            </type>
+        </element>
+        <element id="Patient.extension:birthPlace.value[x]">
+            <path value="Patient.extension.value[x]" />
+            <short value="The registered place of birth of the patient." />
+        </element>
+        <element id="Patient.extension:birthSex">
+            <path value="Patient.extension" />
+            <sliceName value="birthSex" />
+            <short value="The patient&#39;s phenotypic sex at birth." />
+            <definition value="The patient&#39;s phenotypic sex at birth." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex" />
+            </type>
+        </element>
+        <element id="Patient.extension:cadavericDonor">
+            <path value="Patient.extension" />
+            <sliceName value="cadavericDonor" />
+            <short value="Post-mortem donor status." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/patient-cadavericDonor" />
+            </type>
+        </element>
+        <element id="Patient.extension:cadavericDonor.value[x]">
+            <path value="Patient.extension.value[x]" />
+            <short value="Post-mortem donor status." />
+            <definition value="Flag indicating whether the patient authorized the donation of body parts after death." />
+        </element>
+        <element id="Patient.extension:contactPreference">
+            <path value="Patient.extension" />
+            <sliceName value="contactPreference" />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference" />
+            </type>
+        </element>
+        <element id="Patient.extension:deathNotificationStatus">
+            <path value="Patient.extension" />
+            <sliceName value="deathNotificationStatus" />
+            <short value="The patient&#39;s death notification status." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeathNotificationStatus" />
+            </type>
+        </element>
+        <element id="Patient.extension:deathNotificationStatus.extension">
+            <path value="Patient.extension.extension" />
+            <min value="1" />
+        </element>
+        <element id="Patient.extension:ethnicCategory">
+            <path value="Patient.extension" />
+            <sliceName value="ethnicCategory" />
+            <short value="The ethnicity of the subject." />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory" />
+            </type>
+        </element>
+        <element id="Patient.extension:residentialStatus">
+            <path value="Patient.extension" />
+            <sliceName value="residentialStatus" />
+            <short value="The residential status of the patient." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ResidentialStatus" />
+            </type>
+        </element>
+        <element id="Patient.extension:patientInterpreterRequired">
+            <path value="Patient.extension" />
+            <sliceName value="patientInterpreterRequired" />
+            <short value="Indicator showing whether the patient needs an interpreter." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired" />
+            </type>
+        </element>
+        <element id="Patient.extension:patientInterpreterRequired.value[x]">
+            <path value="Patient.extension.value[x]" />
+            <short value="Indicator showing whether the patient needs an interpreter" />
+            <definition value="Indicator showing if this Patient requires an interpreter to communicate healthcare information to the practitioner." />
+        </element>
+        <element id="Patient.extension:nhsNumberUnavailableReason">
+            <path value="Patient.extension" />
+            <sliceName value="nhsNumberUnavailableReason" />
+            <short value="Reason why this Patient does not include an NHS Number identifier." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberUnavailableReason" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="Patient.identifier">
+            <path value="Patient.identifier" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="system" />
+                </discriminator>
+                <ordered value="false" />
+                <rules value="open" />
+            </slicing>
+            <short value="An identifier for this patient." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.identifier:nhsNumber">
+            <path value="Patient.identifier" />
+            <sliceName value="nhsNumber" />
+            <short value="The patient&#39;s NHS number." />
+            <max value="1" />
+            <mustSupport value="false" />
+        </element>
+        <element id="Patient.identifier:nhsNumber.extension:nhsNumberVerificationStatus">
+            <path value="Patient.identifier.extension" />
+            <sliceName value="nhsNumberVerificationStatus" />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus" />
+            </type>
+            <mustSupport value="false" />
+        </element>
+        <element id="Patient.identifier:nhsNumber.system">
+            <path value="Patient.identifier.system" />
+            <min value="1" />
+            <fixedUri value="https://fhir.nhs.uk/Id/nhs-number" />
+        </element>
+        <element id="Patient.identifier:nhsNumber.value">
+            <path value="Patient.identifier.value" />
+            <min value="1" />
+        </element>
+        <element id="Patient.active">
+            <path value="Patient.active" />
+            <short value="Whether this patient&#39;s record is in active use." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.name">
+            <path value="Patient.name" />
+            <short value="A name associated with the patient." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.telecom">
+            <path value="Patient.telecom" />
+            <short value="A contact detail for the individual." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.telecom.system.extension:otherContactSystem">
+            <path value="Patient.telecom.system.extension" />
+            <sliceName value="otherContactSystem" />
+            <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
+            </type>
+        </element>
+        <element id="Patient.gender">
+            <path value="Patient.gender" />
+            <short value="The gender that the patient is considered to have for administration and record keeping purposes." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.birthDate">
+            <path value="Patient.birthDate" />
+            <short value="The date of birth for the individual." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.birthDate.extension:birthTime">
+            <path value="Patient.birthDate.extension" />
+            <sliceName value="birthTime" />
+            <short value="The time of day that the patient was born. This SHOULD be included when the birth time is relevant." />
+            <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthTime" />
+            </type>
+        </element>
+        <element id="Patient.birthDate.extension:birthTime.value[x]">
+            <path value="Patient.birthDate.extension.value[x]" />
+            <short value="Time of day of birth." />
+            <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
+        </element>
+        <element id="Patient.address">
+            <path value="Patient.address" />
+            <definition value="An address for the individual." />
+            <mustSupport value="true" />
+        </element>
+        <element id="Patient.address.extension:addressKey">
+            <path value="Patient.address.extension" />
+            <sliceName value="addressKey" />
+            <short value="A patient&#39;s address key and type" />
+            <definition value="A patient&#39;s address key and type." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey" />
+            </type>
+            <mustSupport value="false" />
+        </element>
+        <element id="Patient.maritalStatus">
+            <path value="Patient.maritalStatus" />
+            <binding>
+                <strength value="extensible" />
+                <description value="An indicator to identify the legal marital status of a person" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonMaritalStatusCode" />
+            </binding>
+        </element>
+        <element id="Patient.contact.extension:contactRank">
+            <path value="Patient.contact.extension" />
+            <sliceName value="contactRank" />
+            <short value="The preferred ranking or order of contact applied to a contact on a Patient&#39;s contact list." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactRank" />
+            </type>
+        </element>
+        <element id="Patient.contact.extension:copyCorrespondenceIndicator">
+            <path value="Patient.contact.extension" />
+            <sliceName value="copyCorrespondenceIndicator" />
+            <short value="Indicates that a must be copied in to all related correspondence." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CopyCorrespondenceIndicator" />
+            </type>
+        </element>
+        <element id="Patient.contact.relationship">
+            <path value="Patient.contact.relationship" />
+            <binding>
+                <strength value="extensible" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonRelationshipType" />
+            </binding>
+        </element>
+        <element id="Patient.contact.telecom.system.extension:otherContactSystem">
+            <path value="Patient.contact.telecom.system.extension" />
+            <sliceName value="otherContactSystem" />
+            <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
+            </type>
+        </element>
+        <element id="Patient.communication.extension:proficiency">
+            <path value="Patient.communication.extension" />
+            <sliceName value="proficiency" />
+            <short value="The patient&#39;s proficiency level of the communication method." />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="http://hl7.org/fhir/StructureDefinition/patient-proficiency" />
+            </type>
+        </element>
+        <element id="Patient.communication.extension:proficiency.extension:level">
+            <path value="Patient.communication.extension.extension" />
+            <sliceName value="level" />
+        </element>
+        <element id="Patient.communication.extension:proficiency.extension:level.value[x]">
+            <path value="Patient.communication.extension.extension.value[x]" />
+            <short value="The proficiency level for the communication" />
+            <definition value="The proficiency level for the communication." />
+        </element>
+        <element id="Patient.communication.extension:proficiency.extension:type">
+            <path value="Patient.communication.extension.extension" />
+            <sliceName value="type" />
+        </element>
+        <element id="Patient.communication.extension:proficiency.extension:type.value[x]">
+            <path value="Patient.communication.extension.extension.value[x]" />
+            <short value="The proficiency type for the communication" />
+            <definition value="The proficiency type for the communication." />
+        </element>
+        <element id="Patient.communication.language">
+            <path value="Patient.communication.language" />
+            <short value="A ValueSet that identifies the language used by a person." />
+            <definition value="A ValueSet that identifies the language used by a person." />
+            <binding>
+                <strength value="required" />
+                <description value="A ValueSet that identifies the language used by a person." />
+                <valueSet value="http://hl7.org/fhir/ValueSet/all-languages" />
+            </binding>
+        </element>
+        <element id="Patient.managingOrganization">
+            <path value="Patient.managingOrganization" />
+            <mustSupport value="true" />
+        </element>
+    </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-ServiceRequest.xml
+++ b/structuredefinitions/UKCore-ServiceRequest.xml
@@ -1,165 +1,164 @@
-<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="UKCore-ServiceRequest" />
-  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
-  <version value="2.5.0" />
-  <name value="UKCoreServiceRequest" />
-  <title value="UK Core Service Request" />
-  <status value="active" />
-  <date value="2024-07-11" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [ServiceRequest](https://hl7.org/fhir/R4/ServiceRequest.html)." />
-  <purpose value="This profile is a record of a request for a procedure or diagnostic or other service to be planned, proposed, or performed, as distinguished by the ServiceRequest.intent field value, with or on a patient." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <fhirVersion value="4.0.1" />
-  <kind value="resource" />
-  <abstract value="false" />
-  <type value="ServiceRequest" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ServiceRequest" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="ServiceRequest.extension:sourceOfServiceRequest">
-      <path value="ServiceRequest.extension" />
-      <sliceName value="sourceOfServiceRequest" />
-      <short value="Describes the source of the Service Request." />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SourceOfServiceRequest" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="ServiceRequest.extension:additionalContact">
-      <path value="ServiceRequest.extension" />
-      <sliceName value="additionalContact" />
-      <short value="Supports recording of additional contacts, who should be contacted regarding questions arising from the service request. This differs from the requester and responsibleClinician." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="ServiceRequest.extension:coverage">
-      <path value="ServiceRequest.extension" />
-      <sliceName value="coverage" />
-      <short value="Supports the exchange of information describing the method of funding for the Service Request." />
-      <max value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="ServiceRequest.basedOn">
-      <path value="ServiceRequest.basedOn" />
-      <short value="What the service request fulfils." />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.status">
-      <path value="ServiceRequest.status" />
-      <short value="The status of the order." />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.intent">
-      <path value="ServiceRequest.intent" />
-      <short value="Whether the request is a proposal, plan, an original order or a reflex order." />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.category">
-      <path value="ServiceRequest.category" />
-      <short value="A code that classifies the service for searching, sorting and display purposes." />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="coding.system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.category:genomicsWholeCaseSequencing">
-      <path value="ServiceRequest.category" />
-      <sliceName value="genomicsWholeCaseSequencing" />
-      <short value="Classification of Genomics service" />
-      <definition value="A code that classifies the service for Genomics, whether it is a Whole Case Genome Sequencing or non-Whole Genome Sequencing for cancer or rare diseases" />
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-GenomeSequencingCategory" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.category:genomicsWholeCaseSequencing.coding.system">
-      <path value="ServiceRequest.category.coding.system" />
-      <fixedUri value="https://fhir.hl7.org.uk/CodeSystem/UKCore-GenomeSequencingCategory" />
-    </element>
-    <element id="ServiceRequest.priority">
-      <path value="ServiceRequest.priority" />
-      <short value="Indicates how quickly the ServiceRequest should be addressed with respect to other requests." />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.priority.extension:priorityReason">
-      <path value="ServiceRequest.priority.extension" />
-      <sliceName value="priorityReason" />
-      <short value="Supports the underlying reason why a Service Request is urgent." />
-      <type>
-        <code value="Extension" />
-        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="ServiceRequest.code">
-      <path value="ServiceRequest.code" />
-      <short value="What is being requested/ordered." />
-      <mustSupport value="true" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.orderDetail">
-      <path value="ServiceRequest.orderDetail" />
-      <binding>
-        <strength value="preferred" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.subject">
-      <path value="ServiceRequest.subject" />
-      <short value="The individual or entity the service is ordered for." />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.authoredOn">
-      <path value="ServiceRequest.authoredOn" />
-      <short value="The date the request was signed." />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.requester">
-      <path value="ServiceRequest.requester" />
-      <short value="Who / what is requesting the service" />
-      <mustSupport value="true" />
-    </element>
-    <element id="ServiceRequest.reasonCode">
-      <path value="ServiceRequest.reasonCode" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A set of codes that define a reason for a service request." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode" />
-      </binding>
-    </element>
-    <element id="ServiceRequest.bodySite">
-      <path value="ServiceRequest.bodySite" />
-      <binding>
-        <strength value="preferred" />
-      </binding>
-    </element>
-  </differential>
+    <id value="UKCore-ServiceRequest" />
+    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest" />
+    <version value="2.5.1" />
+    <name value="UKCoreServiceRequest" />
+    <title value="UK Core Service Request" />
+    <status value="active" />
+    <date value="2024-07-23" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="This profile defines the UK constraints and extensions on the International FHIR resource [ServiceRequest](https://hl7.org/fhir/R4/ServiceRequest.html)." />
+    <purpose value="This profile is a record of a request for a procedure or diagnostic or other service to be planned, proposed, or performed, as distinguished by the ServiceRequest.intent field value, with or on a patient." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <fhirVersion value="4.0.1" />
+    <kind value="resource" />
+    <abstract value="false" />
+    <type value="ServiceRequest" />
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ServiceRequest" />
+    <derivation value="constraint" />
+    <differential>
+        <element id="ServiceRequest.extension:sourceOfServiceRequest">
+            <path value="ServiceRequest.extension" />
+            <sliceName value="sourceOfServiceRequest" />
+            <short value="Describes the source of the Service Request." />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SourceOfServiceRequest" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="ServiceRequest.extension:additionalContact">
+            <path value="ServiceRequest.extension" />
+            <sliceName value="additionalContact" />
+            <short value="Supports recording of additional contacts, who should be contacted regarding questions arising from the service request. This differs from the requester and responsibleClinician." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="ServiceRequest.extension:coverage">
+            <path value="ServiceRequest.extension" />
+            <sliceName value="coverage" />
+            <short value="Supports the exchange of information describing the method of funding for the Service Request." />
+            <max value="1" />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="ServiceRequest.basedOn">
+            <path value="ServiceRequest.basedOn" />
+            <short value="What the service request fulfils." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.status">
+            <path value="ServiceRequest.status" />
+            <short value="The status of the order." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.intent">
+            <path value="ServiceRequest.intent" />
+            <short value="Whether the request is a proposal, plan, an original order or a reflex order." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.category">
+            <path value="ServiceRequest.category" />
+            <slicing>
+                <discriminator>
+                    <type value="value" />
+                    <path value="coding.system" />
+                </discriminator>
+                <rules value="open" />
+            </slicing>
+            <short value="A code that classifies the service for searching, sorting and display purposes." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.category:genomicsWholeCaseSequencing">
+            <path value="ServiceRequest.category" />
+            <sliceName value="genomicsWholeCaseSequencing" />
+            <short value="Classification of Genomics service" />
+            <definition value="A code that classifies the service for Genomics, whether it is a Whole Case Genome Sequencing or non-Whole Genome Sequencing for cancer or rare diseases" />
+            <binding>
+                <strength value="extensible" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-GenomeSequencingCategory" />
+            </binding>
+        </element>
+        <element id="ServiceRequest.category:genomicsWholeCaseSequencing.coding.system">
+            <path value="ServiceRequest.category.coding.system" />
+            <fixedUri value="https://fhir.hl7.org.uk/CodeSystem/UKCore-GenomeSequencingCategory" />
+        </element>
+        <element id="ServiceRequest.priority">
+            <path value="ServiceRequest.priority" />
+            <short value="Indicates how quickly the ServiceRequest should be addressed with respect to other requests." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.priority.extension:priorityReason">
+            <path value="ServiceRequest.priority.extension" />
+            <sliceName value="priorityReason" />
+            <short value="Supports the underlying reason why a Service Request is urgent." />
+            <type>
+                <code value="Extension" />
+                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason" />
+            </type>
+            <isModifier value="false" />
+        </element>
+        <element id="ServiceRequest.code">
+            <path value="ServiceRequest.code" />
+            <short value="What is being requested/ordered." />
+            <mustSupport value="true" />
+            <binding>
+                <strength value="preferred" />
+                <description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system." />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
+            </binding>
+        </element>
+        <element id="ServiceRequest.orderDetail">
+            <path value="ServiceRequest.orderDetail" />
+            <binding>
+                <strength value="preferred" />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
+            </binding>
+        </element>
+        <element id="ServiceRequest.subject">
+            <path value="ServiceRequest.subject" />
+            <short value="The individual or entity the service is ordered for." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.authoredOn">
+            <path value="ServiceRequest.authoredOn" />
+            <short value="The date the request was signed." />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.requester">
+            <path value="ServiceRequest.requester" />
+            <short value="Who / what is requesting the service" />
+            <mustSupport value="true" />
+        </element>
+        <element id="ServiceRequest.reasonCode">
+            <path value="ServiceRequest.reasonCode" />
+            <binding>
+                <strength value="preferred" />
+                <description value="A set of codes that define a reason for a service request." />
+                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode" />
+            </binding>
+        </element>
+        <element id="ServiceRequest.bodySite">
+            <path value="ServiceRequest.bodySite" />
+            <binding>
+                <strength value="preferred" />
+            </binding>
+        </element>
+    </differential>
 </StructureDefinition>

--- a/valuesets/ValueSet-UKCore-MedicationRequestCategory.xml
+++ b/valuesets/ValueSet-UKCore-MedicationRequestCategory.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="UKCore-MedicationRequestCategory" />
     <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationRequestCategory" />
-    <version value="1.1.1" />
+    <version value="1.1.2" />
     <name value="UKCoreMedicationRequestCategory" />
     <title value="UK Core Medication Request Category" />
     <status value="active" />
-    <date value="2023-10-06" />
+    <date value="2024-07-23" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-MedicationRequestCategory.xml
+++ b/valuesets/ValueSet-UKCore-MedicationRequestCategory.xml
@@ -1,66 +1,66 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="UKCore-MedicationRequestCategory" />
-  <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationRequestCategory" />
-  <version value="1.1.1" />
-  <name value="UKCoreMedicationRequestCategory" />
-  <title value="UK Core Medication Request Category" />
-  <status value="active" />
-  <date value="2023-10-06" />
-  <publisher value="HL7 UK" />
-  <contact>
-    <name value="HL7 UK" />
-    <telecom>
-      <system value="email" />
-      <value value="ukcore@hl7.org.uk" />
-      <use value="work" />
-      <rank value="1" />
-    </telecom>
-  </contact>
-  <description value="A set of codes to define a category for a medication request." />
-  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-  <compose>
-    <include>
-      <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
-    </include>
-    <include>
-      <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory" />
-    </include>
-  </compose>
-  <expansion>
-    <identifier value="242c10eb-0ecc-47b2-9f97-78e80577a16e" />
-    <timestamp value="2023-10-06T13:57:59+00:00" />
-    <total value="6" />
-    <offset value="0" />
-    <contains>
-      <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
-      <code value="inpatient" />
-      <display value="Inpatient" />
-    </contains>
-    <contains>
-      <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
-      <code value="outpatient" />
-      <display value="Outpatient" />
-    </contains>
-    <contains>
-      <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
-      <code value="community" />
-      <display value="Community" />
-    </contains>
-    <contains>
-      <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
-      <code value="discharge" />
-      <display value="Discharge" />
-    </contains>
-    <contains>
-      <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory" />
-      <code value="leave" />
-      <display value="Leave" />
-    </contains>
-    <contains>
-      <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory" />
-      <code value="primarycare" />
-      <display value="Primary Care" />
-      <inactive value="true" />
-    </contains>
-  </expansion>
+    <id value="UKCore-MedicationRequestCategory" />
+    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationRequestCategory" />
+    <version value="1.1.1" />
+    <name value="UKCoreMedicationRequestCategory" />
+    <title value="UK Core Medication Request Category" />
+    <status value="active" />
+    <date value="2023-10-06" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="A set of codes to define a category for a medication request." />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+    <compose>
+        <include>
+            <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
+        </include>
+        <include>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory" />
+        </include>
+    </compose>
+    <expansion>
+        <identifier value="242c10eb-0ecc-47b2-9f97-78e80577a16e" />
+        <timestamp value="2023-10-06T13:57:59+00:00" />
+        <total value="6" />
+        <offset value="0" />
+        <contains>
+            <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
+            <code value="inpatient" />
+            <display value="Inpatient" />
+        </contains>
+        <contains>
+            <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
+            <code value="outpatient" />
+            <display value="Outpatient" />
+        </contains>
+        <contains>
+            <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
+            <code value="community" />
+            <display value="Community" />
+        </contains>
+        <contains>
+            <system value="http://terminology.hl7.org/CodeSystem/medicationrequest-category" />
+            <code value="discharge" />
+            <display value="Discharge" />
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory" />
+            <code value="leave" />
+            <display value="Leave" />
+        </contains>
+        <contains>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory" />
+            <inactive value="true" />
+            <code value="primarycare" />
+            <display value="Primary Care" />
+        </contains>
+    </expansion>
 </ValueSet>


### PR DESCRIPTION
All Assets and examples checked for JSON rendering errors. This is due to new updates in Simplifier which will show an error in the JSON render if the XML has elements out of order. The XML render is actually reordered correctly so can just be copied from there rather than having to work out the order manually.

Note: The Simplifier QC Checker does not pick these up. This will be fixed later this year, but I have added a check in our own QC Checker to pick these up.

All assets have had their version patch number updated and date updated
