### PR TITLE
Fix missing namespaces

### DIFF
--- a/examples/UKCore-Extension-TriggeredBy-Example.xml
+++ b/examples/UKCore-Extension-TriggeredBy-Example.xml
@@ -4,47 +4,47 @@
     <status value="additional" />
     <div xmlns="http://www.w3.org/1999/xhtml">An example to illustration observation triggered by another observation</div>
   </text>
-  <!-- ***************extension start*************** -->
+  <!--  ***************extension start***************  -->
   <extension url="http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy">
-        <extension url="observation">
-            <valueReference>
-                <reference value="Observation/UKCore-Observation-DrugUse-Example" />
-            </valueReference>
-        </extension>
-        <extension url="type">
-            <valueCode value="reflex" />
-        </extension>
-        <extension url="reason">
-            <valueString value="Patient admitted to recreational drug use." />
-        </extension>
-    </extension>
-    <!--  ***************extension end***************  -->
-    <identifier>
-        <system value="https://tools.ietf.org/html/rfc4122" />
-        <value value="293a6418-9dcf-4d42-b97a-b119afd200ba" />
-    </identifier>
-    <status value="final" />
-    <category>
-        <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
-            <code value="laboratory" />
-            <display value="Laboratory" />
-        </coding>
-    </category>
-    <code>
-        <coding>
-            <system value="http://snomed.info/sct" />
-            <code value="1014801000000101" />
-            <display value="Urine tricyclic drug screen" />
-        </coding>
-    </code>
-    <subject>
-        <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
-    </subject>
-    <performer>
-        <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
-    </performer>
-    <specimen>
-        <reference value="Specimen/UKCore-Specimen-UrineSpecimen-Example" />
-    </specimen>
+      <extension url="observation">
+          <valueReference>
+              <reference value="Observation/UKCore-Observation-DrugUse-Example" />
+          </valueReference>
+      </extension>
+      <extension url="type">
+          <valueCode value="reflex" />
+      </extension>
+      <extension url="reason">
+          <valueString value="Patient admitted to recreational drug use." />
+      </extension>
+  </extension>
+  <!--   ***************extension end***************   -->
+  <identifier>
+      <system value="https://tools.ietf.org/html/rfc4122" />
+      <value value="293a6418-9dcf-4d42-b97a-b119afd200ba" />
+  </identifier>
+  <status value="final" />
+  <category>
+      <coding>
+          <system value="http://terminology.hl7.org/CodeSystem/observation-category" />
+          <code value="laboratory" />
+          <display value="Laboratory" />
+      </coding>
+  </category>
+  <code>
+      <coding>
+          <system value="http://snomed.info/sct" />
+          <code value="1014801000000101" />
+          <display value="Urine tricyclic drug screen" />
+      </coding>
+  </code>
+  <subject>
+      <reference value="Patient/UKCore-Patient-RichardSmith-Example" />
+  </subject>
+  <performer>
+      <reference value="Organization/UKCore-Organization-LeedsTeachingHospital-Example" />
+  </performer>
+  <specimen>
+      <reference value="Specimen/UKCore-Specimen-UrineSpecimen-Example" />
+  </specimen>
 </Observation>

--- a/examples/UKCore-Extension-TriggeredBy-Example.xml
+++ b/examples/UKCore-Extension-TriggeredBy-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Extension-TriggeredBy-Example" />
   <text>
     <status value="additional" />

--- a/examples/UKCore-Observation-DrugUse-Example.xml
+++ b/examples/UKCore-Observation-DrugUse-Example.xml
@@ -2,7 +2,7 @@
     <id value="UKCore-Observation-DrugUse-Example" />
     <text>
         <status value="additional" />
-        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate n observation of the patient's drug use</div>
+        <div xmlns="http://www.w3.org/1999/xhtml">An example to illustrate an observation of the patient's illicit drug use</div>
     </text>
     <identifier>
         <system value="https://tools.ietf.org/html/rfc4122" />

--- a/examples/UKCore-Observation-Group-FullBloodCount-Example.xml
+++ b/examples/UKCore-Observation-Group-FullBloodCount-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-Group-FullBloodCount-Example" />
   <text>
     <status value="additional" />

--- a/examples/UKCore-Observation-HeavyDrinker-Example.xml
+++ b/examples/UKCore-Observation-HeavyDrinker-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-HeavyDrinker-Example" />
   <text>
     <status value="additional" />

--- a/examples/UKCore-Observation-Lab-RedCellCount-Example.xml
+++ b/examples/UKCore-Observation-Lab-RedCellCount-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-Lab-RedCellCount-Example" />
   <text>
     <status value="additional" />

--- a/examples/UKCore-Observation-Lab-Sn-AbsentData-Example.xml
+++ b/examples/UKCore-Observation-Lab-Sn-AbsentData-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-Lab-Sn-AbsentData-Example" />
   <status value="final" />
   <category>

--- a/examples/UKCore-Observation-Lab-WhiteCellCount-Example.xml
+++ b/examples/UKCore-Observation-Lab-WhiteCellCount-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-Lab-WhiteCellCount-Example" />
   <text>
     <status value="additional" />

--- a/examples/UKCore-Observation-OxygenTherapy-Example.xml
+++ b/examples/UKCore-Observation-OxygenTherapy-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-OxygenTherapy-Example" />
   <text>
     <status value="additional" />

--- a/examples/UKCore-Observation-PipeSmoker-Example.xml
+++ b/examples/UKCore-Observation-PipeSmoker-Example.xml
@@ -1,4 +1,4 @@
-<Observation>
+<Observation xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-PipeSmoker-Example" />
   <text>
     <status value="additional" />


### PR DESCRIPTION
Namespaces are missing in these examples, stopping the rendering of json within simplifier.

plus one fix on example text being incorrect