### PR TITLE
Update CodeSystem-UKCore-FundingCategory.xml

### DIFF
--- a/codesystems/CodeSystem-UKCore-FundingCategory.xml
+++ b/codesystems/CodeSystem-UKCore-FundingCategory.xml
@@ -54,7 +54,7 @@
         </concept>
         <concept>
             <code value="overseas-visitor" />
-            <display value="Overseas visitor" />
+            <display value="Overseas Visitor" />
         </concept>
     </concept>
     <concept>

--- a/codesystems/CodeSystem-UKCore-FundingCategory.xml
+++ b/codesystems/CodeSystem-UKCore-FundingCategory.xml
@@ -1,5 +1,4 @@
-<CodeSystem
-    xmlns="http://hl7.org/fhir">
+<CodeSystem xmlns="http://hl7.org/fhir">
     <id value="UKCore-FundingCategory" />
     <url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />
     <version value="2.0.0" />

--- a/codesystems/CodeSystem-UKCore-FundingCategory.xml
+++ b/codesystems/CodeSystem-UKCore-FundingCategory.xml
@@ -53,8 +53,8 @@
             <display value="Isle of Man" />
         </concept>
         <concept>
-            <code value="oversea-visitor" />
-            <display value="Oversea visitor" />
+            <code value="overseas-visitor" />
+            <display value="Overseas visitor" />
         </concept>
     </concept>
     <concept>

--- a/structuredefinitions/Extension-UKCore-ConditionBodyStructure.xml
+++ b/structuredefinitions/Extension-UKCore-ConditionBodyStructure.xml
@@ -49,7 +49,7 @@
       <min value="1" />
       <type>
         <code value="Reference" />
-        <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/BodyStructure" />
       </type>
     </element>
   </differential>

--- a/valuesets/ValueSet-UKCore-FundingCategory.xml
+++ b/valuesets/ValueSet-UKCore-FundingCategory.xml
@@ -70,7 +70,7 @@
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />
       <code value="overseas-visitor" />
-      <display value="Overseas visitor" />
+      <display value="Overseas Visitor" />
     </contains>
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />

--- a/valuesets/ValueSet-UKCore-FundingCategory.xml
+++ b/valuesets/ValueSet-UKCore-FundingCategory.xml
@@ -69,8 +69,8 @@
     </contains>
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />
-      <code value="oversea-visitor" />
-      <display value="Oversea visitor" />
+      <code value="overseas-visitor" />
+      <display value="Overseas visitor" />
     </contains>
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />

--- a/valuesets/ValueSet-UKCore-FundingCategory.xml
+++ b/valuesets/ValueSet-UKCore-FundingCategory.xml
@@ -14,7 +14,7 @@
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />
       <code value="public" />
-      <display value="Public"/>
+      <display value="Public" />
     </contains>
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" /> 
@@ -29,7 +29,7 @@
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />
       <code value="nhs-wales" />
-      <display value="NHS Wales"/>
+      <display value="NHS Wales" />
     </contains>
     <contains>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />

--- a/valuesets/ValueSet-UKCore-FundingCategory.xml
+++ b/valuesets/ValueSet-UKCore-FundingCategory.xml
@@ -1,7 +1,23 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="45048932" />
+  <id value="UKCore-FundingCategory" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-FundingCategory" />
+  <version value="1.0.0" />
+  <name value="UKCoreFundingCategory" />
+  <title value="UK Core Funding Category" />
   <status value="active" />
+  <date value="2023-04-28" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="A set of codes that define the funding category." />
+  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>
       <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory" />


### PR DESCRIPTION
From https://github.com/NHSDigital/FHIR-R4-UKCORE-STAGING-MAIN/pull/550#issuecomment-2382896845 



>If we are going for a breaking change, I would then prefer Public/Private being the parent concepts with NHS England, NHS Wales, NHS Scotland, HSC Northern Ireland, NHS Isle of Man, Jersey, Guernsey and possibly Overseas Visitor under public. (As this field is meant to represent how the test is being funded, rather than where the test is taking place)
> 
> The current version of the codesystem does not match its intended use. Happy to use the codesystem as is for the purposes of the Genomics Alpha but, if possible, this should be changed in future releases