### PR TITLE
Remove Duplicate Option

### DIFF
--- a/codesystems/CodeSystem-UKCore-PrimarySampleState.xml
+++ b/codesystems/CodeSystem-UKCore-PrimarySampleState.xml
@@ -34,10 +34,6 @@
     <display value="Fresh" />
   </concept>
   <concept>
-    <code value="frozen" />
-    <display value="Frozen" />
-  </concept>
-  <concept>
     <code value="other" />
     <display value="Other" />
     <definition value="Any other suitable sample condition that is an alternative to concepts provided in this CodeSystem. This should be provided by free text." />

--- a/codesystems/CodeSystem-UKCore-PrimarySampleState.xml
+++ b/codesystems/CodeSystem-UKCore-PrimarySampleState.xml
@@ -1,11 +1,11 @@
 <CodeSystem xmlns="http://hl7.org/fhir">
   <id value="UKCore-PrimarySampleState" />
   <url value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PrimarySampleState" />
-  <version value="1.0.0" />
+  <version value="2.0.0" />
   <name value="UKCorePrimarySampleState" />
   <title value="UK Core Primary Sample State" />
   <status value="active" />
-  <date value="2024-10-07" />
+  <date value="2024-11-08" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />


### PR DESCRIPTION
Remove Frozen state from UKCore as it already exist in another HL7 CodeSystem http://terminology.hl7.org/CodeSystem/v2-0493, within the same ValueSet.