### PR TITLE
Cardinality Issues with Extension-DiagnosticReport.media.link

### DIFF
--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
@@ -66,7 +66,7 @@
     <element id="Extension.extension:link">
       <path value="Extension.extension" />
       <sliceName value="link" />
-      <short value="Reference to the image or data source" />
+      <short value="Reference to the image or data source." />
       <definition value="Reference to the image or data source." />
       <min value="1" />
     </element>

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-DiagnosticReportMedia" />
   <url value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media" />
-  <version value="0.0.2" />
+  <version value="0.0.3" />
   <name value="ExtensionUKCoreDiagnosticReportMedia" />
   <title value="Extension UK Core Diagnostic Report Media" />
   <status value="draft" />
-  <date value="2024-12-12" />
+  <date value="2024-12-16" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -38,7 +38,8 @@
   <differential>
     <element id="Extension">
       <path value="Extension" />
-      <short value="Reference to a  DocumentReference resource." />
+      <short value="Key images or data associated with this report" />
+      <definition value="A list of key images or data associated with this report. The images or data are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest)." />
     </element>
     <element id="Extension.extension">
       <path value="Extension.extension" />
@@ -47,6 +48,9 @@
     <element id="Extension.extension:comment">
       <path value="Extension.extension" />
       <sliceName value="comment" />
+      <short value="Comment about the image or data (e.g. explanation)" />
+      <definition value="A comment about the image or data. Typically, this is used to provide an explanation for why the image or data is included, or to draw the viewer's attention to important features." />
+      <comment value="The comment should be displayed with the image or data. It would be common for the report to include additional discussion of the image or data contents or in other sections such as the conclusion." />
     </element>
     <element id="Extension.extension:comment.url">
       <path value="Extension.extension.url" />
@@ -62,7 +66,8 @@
     <element id="Extension.extension:link">
       <path value="Extension.extension" />
       <sliceName value="link" />
-      <short value="Reference to a DocuentReference resource instance that provides structure for organizing the contents of the DiagnosticReport." />
+      <short value="Reference to the image or data source" />
+      <definition value="Reference to the image or data source." />
       <min value="1" />
     </element>
     <element id="Extension.extension:link.url">

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
@@ -62,6 +62,7 @@
     <element id="Extension.extension:link">
       <path value="Extension.extension" />
       <sliceName value="link" />
+      <short value="Reference to a DocuentReference resource instance that provides structure for organizing the contents of the DiagnosticReport." />
       <min value="1" />
     </element>
     <element id="Extension.extension:link.url">

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMedia.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="Extension-UKCore-DiagnosticReportMediaLink" />
-  <url value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
-  <version value="0.0.1" />
-  <name value="ExtensionUKCoreDiagnosticReportMediaLink" />
-  <title value="Extension UK Core Diagnostic Report Media Link" />
+  <id value="Extension-UKCore-DiagnosticReportMedia" />
+  <url value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media" />
+  <version value="0.0.2" />
+  <name value="ExtensionUKCoreDiagnosticReportMedia" />
+  <title value="Extension UK Core Diagnostic Report Media" />
   <status value="draft" />
-  <date value="2024-06-07" />
+  <date value="2024-12-12" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -78,7 +78,7 @@
     </element>
     <element id="Extension.url">
       <path value="Extension.url" />
-      <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
+      <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media" />
     </element>
     <element id="Extension.value[x]">
       <path value="Extension.value[x]" />

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-DiagnosticReportMediaLink" />
   <url value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
-  <version value="0.0.1" />
+  <version value="0.0.2" />
   <name value="ExtensionUKCoreDiagnosticReportMediaLink" />
   <title value="Extension UK Core Diagnostic Report Media Link" />
   <status value="draft" />
-  <date value="2024-06-07" />
+  <date value="2024-12-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -39,11 +39,6 @@
     <element id="Extension">
       <path value="Extension" />
       <short value="Reference to a  DocumentReference resource." />
-      <min value="1" />
-    </element>
-    <element id="Extension.extension">
-      <path value="Extension.extension" />
-      <min value="1" />
     </element>
     <element id="Extension.extension:comment">
       <path value="Extension.extension" />
@@ -63,7 +58,6 @@
     <element id="Extension.extension:link">
       <path value="Extension.extension" />
       <sliceName value="link" />
-      <min value="1" />
     </element>
     <element id="Extension.extension:link.url">
       <path value="Extension.extension.url" />

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
@@ -17,9 +17,12 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="An extension to replicate the changes within R5 to support adding a reference to image or data source(DocumentReference)." />
-  <purpose value="This is a Genomics use case to support the backporting of R5 functionality to support adding a reference to image or data source(DocumentReference)." />
-  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <description
+    value="An extension to replicate the changes within R5 to support adding a reference to image or data source(DocumentReference)." />
+  <purpose
+    value="This is a Genomics use case to support the backporting of R5 functionality to support adding a reference to image or data source(DocumentReference)." />
+  <copyright
+    value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -30,54 +33,25 @@
   <abstract value="false" />
   <context>
     <type value="element" />
-    <expression value="DiagnosticReport" />
+    <expression value="DiagnosticReport.media" />
   </context>
   <type value="Extension" />
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />
   <differential>
-    <element id="Extension">
-      <path value="Extension" />
-      <short value="Reference to a  DocumentReference resource." />
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri
+        value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
     </element>
-    <element id="Extension.extension:comment">
-      <path value="Extension.extension" />
-      <sliceName value="comment" />
-    </element>
-    <element id="Extension.extension:comment.url">
-      <path value="Extension.extension.url" />
-      <fixedUri value="comment" />
-    </element>
-    <element id="Extension.extension:comment.value[x]">
-      <path value="Extension.extension.value[x]" />
-      <min value="1" />
-      <type>
-        <code value="string" />
-      </type>
-    </element>
-    <element id="Extension.extension:link">
-      <path value="Extension.extension" />
-      <sliceName value="link" />
-    </element>
-    <element id="Extension.extension:link.url">
-      <path value="Extension.extension.url" />
-      <fixedUri value="link" />
-    </element>
-    <element id="Extension.extension:link.value[x]">
-      <path value="Extension.extension.value[x]" />
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
       <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
       </type>
-    </element>
-    <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
-    </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]" />
-      <max value="0" />
+      <isSummary value="true" /> 
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
@@ -51,7 +51,6 @@
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
       </type>
-      <isSummary value="true" /> 
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportMediaLink.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-DiagnosticReportMediaLink" />
   <url value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
-  <version value="0.0.2" />
+  <version value="0.0.1" />
   <name value="ExtensionUKCoreDiagnosticReportMediaLink" />
   <title value="Extension UK Core Diagnostic Report Media Link" />
   <status value="draft" />
-  <date value="2024-12-05" />
+  <date value="2024-06-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -17,12 +17,9 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description
-    value="An extension to replicate the changes within R5 to support adding a reference to image or data source(DocumentReference)." />
-  <purpose
-    value="This is a Genomics use case to support the backporting of R5 functionality to support adding a reference to image or data source(DocumentReference)." />
-  <copyright
-    value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <description value="An extension to replicate the changes within R5 to support adding a reference to image or data source(DocumentReference)." />
+  <purpose value="This is a Genomics use case to support the backporting of R5 functionality to support adding a reference to image or data source(DocumentReference)." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -33,24 +30,59 @@
   <abstract value="false" />
   <context>
     <type value="element" />
-    <expression value="DiagnosticReport.media" />
+    <expression value="DiagnosticReport" />
   </context>
   <type value="Extension" />
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />
   <differential>
-    <element id="Extension.url">
-      <path value="Extension.url" />
-      <fixedUri
-        value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
+    <element id="Extension">
+      <path value="Extension" />
+      <short value="Reference to a  DocumentReference resource." />
     </element>
-    <element id="Extension.value[x]">
-      <path value="Extension.value[x]" />
+    <element id="Extension.extension">
+      <path value="Extension.extension" />
+      <min value="1" />
+    </element>
+    <element id="Extension.extension:comment">
+      <path value="Extension.extension" />
+      <sliceName value="comment" />
+    </element>
+    <element id="Extension.extension:comment.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="comment" />
+    </element>
+    <element id="Extension.extension:comment.value[x]">
+      <path value="Extension.extension.value[x]" />
+      <min value="1" />
+      <type>
+        <code value="string" />
+      </type>
+    </element>
+    <element id="Extension.extension:link">
+      <path value="Extension.extension" />
+      <sliceName value="link" />
+      <min value="1" />
+    </element>
+    <element id="Extension.extension:link.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="link" />
+    </element>
+    <element id="Extension.extension:link.value[x]">
+      <path value="Extension.extension.value[x]" />
       <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DocumentReference" />
       </type>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <max value="0" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="media.link.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
+        <expression value="media.link.empty() xor extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="media.link.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
+          value="media.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="media.link.empty() XAND extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
+        <expression value="not(media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -27,6 +27,15 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
   <derivation value="constraint" />
   <differential>
+    <element id="DiagnosticReport">
+      <path value="DiagnosticReport" />
+      <constraint>
+        <key value="ukcore-diag-lab-002" />
+        <severity value="error" />
+        <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
+        <expression value="media.link.exists() xor extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
+      </constraint>
+    </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">
       <path value="DiagnosticReport.extension" />
       <sliceName value="compositionReferenceR5" />
@@ -42,6 +51,16 @@
       <path value="DiagnosticReport.extension.value[x]" />
       <short value="Reference to a Composition resource." />
       <definition value="Reference to a Composition resource instance that provides structure for organizing the contents of the DiagnosticReport." />
+    </element>
+    <element id="DiagnosticReport.extension:mediaLinkR5">
+      <path value="DiagnosticReport.extension" />
+      <sliceName value="mediaLinkR5" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
+      </type>
+      <isModifier value="false" />
+      <isSummary value='true' />
     </element>
     <element id="DiagnosticReport.extension:noteR5">
       <path value="DiagnosticReport.extension" />
@@ -130,26 +149,6 @@
       <path value="DiagnosticReport.result" />
       <short value="Observations that are part of this diagnostic report." />
       <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.media">
-      <path value="DiagnosticReport.media" />
-      <constraint>
-        <key value="ukcore-diag-lab-002" />
-        <severity value="error" />
-        <human
-          value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be used at a time." />
-        <expression
-          value="link.exists() xor extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
-      </constraint>
-    </element>
-    <element id="DiagnosticReport.media.extension:mediaLinkR5">
-      <path value="DiagnosticReport.media.extension" />
-      <sliceName value="mediaLinkR5" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
-      </type>
-      <isModifier value="false" />
     </element>
     <element id="DiagnosticReport.conclusionCode">
       <path value="DiagnosticReport.conclusionCode" />

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="not media.link.exist() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
+          value="media.link.exist() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-DiagnosticReport" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport" />
-  <version value="2.5.0" />
+  <version value="2.6.0" />
   <name value="UKCoreDiagnosticReport" />
   <title value="UK Core Diagnostic Report" />
   <status value="active" />
-  <date value="2024-06-07" />
+  <date value="2024-12-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -51,15 +51,6 @@
         <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
       </type>
       <isModifier value="false" />
-    </element>
-    <element id="DiagnosticReport.extension:mediaR5.extension">
-      <path value="DiagnosticReport.extension.extension" />
-      <min value="1" />
-    </element>
-    <element id="DiagnosticReport.extension:mediaR5.extension:link">
-      <path value="DiagnosticReport.extension.extension" />
-      <sliceName value="link" />
-      <min value="1" />
     </element>
     <element id="DiagnosticReport.extension:noteR5">
       <path value="DiagnosticReport.extension" />

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -43,15 +43,6 @@
       <short value="Reference to a Composition resource." />
       <definition value="Reference to a Composition resource instance that provides structure for organizing the contents of the DiagnosticReport." />
     </element>
-    <element id="DiagnosticReport.extension:mediaR5">
-      <path value="DiagnosticReport.extension" />
-      <sliceName value="mediaR5" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
-      </type>
-      <isModifier value="false" />
-    </element>
     <element id="DiagnosticReport.extension:noteR5">
       <path value="DiagnosticReport.extension" />
       <sliceName value="noteR5" />
@@ -139,6 +130,25 @@
       <path value="DiagnosticReport.result" />
       <short value="Observations that are part of this diagnostic report." />
       <mustSupport value="true" />
+    </element>
+    <element id="DiagnosticReport.media">
+      <path value="DiagnosticReport.media" />
+      <constraint>
+        <key value="ukcore-diag-lab-002" />
+        <severity value="error" />
+        <human
+          value="Only one of DiagnosticReport.media.link or DiagnosticReport.media:mediaLinkR5 can be used at a time." />
+        <expression value="media.where(sliceName.exists()).count() = 0 or media.link.exists() = false" />
+      </constraint>
+    </element>
+    <element id="DiagnosticReport.media.extension:mediaLinkR5">
+      <path value="DiagnosticReport.media.extension" />
+      <sliceName value="mediaLinkR5" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
+      </type>
+      <isModifier value="false" />
     </element>
     <element id="DiagnosticReport.conclusionCode">
       <path value="DiagnosticReport.conclusionCode" />

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="not (media.exists() and media.link.exists()) and not (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
+        <expression value="not media.exists() or not media.link.exists() and not (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -52,15 +52,15 @@
       <short value="Reference to a Composition resource." />
       <definition value="Reference to a Composition resource instance that provides structure for organizing the contents of the DiagnosticReport." />
     </element>
-    <element id="DiagnosticReport.extension:mediaLinkR5">
+    <element id="DiagnosticReport.extension:mediaR5">
       <path value="DiagnosticReport.extension" />
-      <sliceName value="mediaLinkR5" />
+      <sliceName value="mediaR5" />
+      <short value="Reference to a DocuentReference resource instance that provides structure for organizing the contents of the DiagnosticReport." />
       <type>
         <code value="Extension" />
-        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media" />
       </type>
       <isModifier value="false" />
-      <isSummary value="true" />
     </element>
     <element id="DiagnosticReport.extension:noteR5">
       <path value="DiagnosticReport.extension" />

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,10 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="( (media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.mediaLink').exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.mediaLink').exists()) )" />
+          value="( (media.link.exists() and not extension(http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link
+).exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link
+').exists()) )
+" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="media.link.exist() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
+          value="( (media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.mediaLink').exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.mediaLink').exists()) )" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,9 +34,9 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="( (media.link.exists() and not extension(http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link
+          value="(media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link'
 ).exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link
-').exists()) )
+').exists()) 
 " />
       </constraint>
     </element>

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="media.link.exist() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
+        <expression value="media.link.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="not(media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
+        <expression value="not media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,8 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression
-          value="media.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
+        <expression value="media.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="media.link.empty() xor extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
+        <expression value="media.link.empty() XAND extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="not media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()" />
+        <expression value="not (media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="not media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()" />
+        <expression value="not (media.exists() and media.link.exists()) and not (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value=" (media.link.exists() and not (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())) or (not media.link.exists() and (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()))" />
+          value="media.link.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -32,8 +32,9 @@
       <constraint>
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
-        <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="media.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').empty()" />
+        <human
+          value="Only one of DiagnosticReport.media or DiagnosticReport.extension:mediaR5 can be populated at a time." />
+        <expression value="media.empty() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media').empty()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="not (media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
+        <expression value="not media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,8 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="not media.exists() or not media.link.exists() and not (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()" />
+        <expression
+          value="not media.link.exist() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="(media.link.exists() and not DiagnosticReport.extension:mediaLinkR5('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()) or (not media.link.exists() and DiagnosticReport.extension:mediaLinkR5('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
+          value=" (media.link.exists() and not (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())) or (not media.link.exists() and (extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()))" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -33,7 +33,7 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
-        <expression value="media.link.exists() xor extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
+        <expression value="media.link.exist() or extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">
@@ -60,7 +60,7 @@
         <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link" />
       </type>
       <isModifier value="false" />
-      <isSummary value='true' />
+      <isSummary value="true" />
     </element>
     <element id="DiagnosticReport.extension:noteR5">
       <path value="DiagnosticReport.extension" />

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,10 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="(media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link'
-).exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link
-').exists()) 
-" />
+          value="(media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -34,7 +34,7 @@
         <severity value="error" />
         <human value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be populated at a time." />
         <expression
-          value="(media.link.exists() and not extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()) or (not media.link.exists() and extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
+          value="(media.link.exists() and not DiagnosticReport.extension:mediaLinkR5('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists()) or (not media.link.exists() and DiagnosticReport.extension:mediaLinkR5('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exists())" />
       </constraint>
     </element>
     <element id="DiagnosticReport.extension:compositionReferenceR5">

--- a/structuredefinitions/UKCore-DiagnosticReport.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport.xml
@@ -137,8 +137,9 @@
         <key value="ukcore-diag-lab-002" />
         <severity value="error" />
         <human
-          value="Only one of DiagnosticReport.media.link or DiagnosticReport.media:mediaLinkR5 can be used at a time." />
-        <expression value="media.where(sliceName.exists()).count() = 0 or media.link.exists() = false" />
+          value="Only one of DiagnosticReport.media.link or DiagnosticReport.media.extension:mediaLinkR5 can be used at a time." />
+        <expression
+          value="link.exists() xor extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link').exist()" />
       </constraint>
     </element>
     <element id="DiagnosticReport.media.extension:mediaLinkR5">


### PR DESCRIPTION
Changing the cardinality of Extension-DiagnosticReport.media.link to 0 to many (0...*) instead of the current 1 to many(1..*)