### PR TITLE
Update Extension-UKCore-DiagnosticReportSupportingInfo.xml

### DIFF
--- a/structuredefinitions/Extension-UKCore-DiagnosticReportSupportingInfo.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportSupportingInfo.xml
@@ -96,7 +96,6 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Procedure" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Observation" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Citation" />
       </type>
     </element>
     <element id="Extension.url">


### PR DESCRIPTION
Citation is a new profile within R5 so cannot be referenced within R4.

This needs removing and a new package and IG created for STU2