### PR TITLE
Update Extension-UKCore-DiagnosticReportSupportingInfo.xml

### DIFF
--- a/structuredefinitions/Extension-UKCore-DiagnosticReportSupportingInfo.xml
+++ b/structuredefinitions/Extension-UKCore-DiagnosticReportSupportingInfo.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="Extension-UKCore-DiagnosticReportSupportingInfo" />
   <url value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.supportingInfo" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="ExtensionUKCoreDiagnosticReportSupportingInfo" />
   <title value="Extension UK Core Diagnostic Report Supporting Info" />
   <status value="active" />
-  <date value="2023-12-12" />
+  <date value="2025-02-11" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />


### PR DESCRIPTION
There was an issue with this extension previously where the `Citation` profile was referenced, which is an R5 profile and cannot be referenced in R4. It was fixed in the main branch, but for whatever reason the version and date was not changed. It was not fixed in the STU2 branch either. I have now fixed it in the STU2 branch and upped the version & date, but this profile is now out of sync in the main branch. The updating of metadata fixes that.
This PR updates the extension to align with STU2 branch https://github.com/NHSDigital/FHIR-R4-UKCORE-STAGING-MAIN/pull/584