### PR TITLE
add new sct descendant to ValueSet-UKCore-BodySite.xml

### DIFF
--- a/valuesets/ValueSet-UKCore-BodySite.xml
+++ b/valuesets/ValueSet-UKCore-BodySite.xml
@@ -19,7 +19,7 @@
     </contact>
     <description value="A set of codes that define an anatomical or acquired body structure site. Selected from the SNOMED CT UK coding system:
         &#13; - DescendantOf 442083009 | Anatomical or acquired body structure (body structure) 
-        &#13; - DescendantOf 278001007 |  Nonspecific site (body structure)" />
+        &#13; - DescendantOf 278001007 | Nonspecific site (body structure)" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-BodySite.xml
+++ b/valuesets/ValueSet-UKCore-BodySite.xml
@@ -2,11 +2,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="UKCore-BodySite" />
     <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite" />
-    <version value="2.1.0" />
+    <version value="2.2.0" />
     <name value="UKCoreBodySite" />
     <title value="UK Core Body Site" />
     <status value="active" />
-    <date value="2021-09-10" />
+    <date value="2025-02-11" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BodySite.xml
+++ b/valuesets/ValueSet-UKCore-BodySite.xml
@@ -17,7 +17,9 @@
             <rank value="1" />
         </telecom>
     </contact>
-    <description value="A set of codes that define an anatomical or acquired body structure site. Selected from the SNOMED CT UK coding system." />
+    <description value="A set of codes that define an anatomical or acquired body structure site. Selected from the SNOMED CT UK coding system:
+        &#13; - DescendantOf 442083009 | Anatomical or acquired body structure (body structure) 
+        &#13; - DescendantOf 278001007 |  Nonspecific site (body structure)" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>
@@ -25,7 +27,7 @@
             <filter>
                 <property value="constraint" />
                 <op value="=" />
-                <value value="descendantOf 442083009" />
+                <value value="descendantOf 442083009 OR descendantOf 278001007" />
             </filter>
         </include>
     </compose>


### PR DESCRIPTION
From https://simplifier.net/hl7fhirukcorer4/~issues/3350

We have identified that binding against MedicationRequest.dosingInstructions.site could do with additional information. We would like the binding to include all descendants of the SNOMED hierarchy 278001007 | Nonspecific site |.

This would allow for the user case when a clinician is prescribing a cutanious cream or similar to an affected area of the skin. Rather than the clinician having to select all the areas of the body that are affected they can just select the code 22201000087104 | Affected area |.


