### PR TITLE
changed valueQuantity to valueCodeableConcept to allow for centimetres

### DIFF
--- a/.simplifier/folder.settings.json
+++ b/.simplifier/folder.settings.json
@@ -1,4 +1,0 @@
-{
-  "IncludeSubdirectories": true,
-  "PreferredFormat": "Xml"
-}

--- a/.simplifier/folder.settings.json
+++ b/.simplifier/folder.settings.json
@@ -1,0 +1,4 @@
+{
+  "IncludeSubdirectories": true,
+  "PreferredFormat": "Xml"
+}

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyHeight" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyHeight" />
-  <version value="1.0.0" />
+  <version value="1.1.0" />
   <name value="UKCoreObservationVitalSignsBodyHeight" />
   <title value="UK Core Observation Vital Signs Body Height" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-02-19" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -17,7 +17,7 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="Defines the additional constraints and extensions on the UK Core Observation Vital Signs profile, for recording body height vital signs clinical observations." />
+  <description value="Defines the additional constraints and extensions on the UK Core Observation Vital Signs profile, for recording body height for adults and body length for infants and children . Body height / length is expected to be recorded in meters (m) or centimetres (cm) as per https://www.datadictionary.nhs.uk/nhs_business_definitions/height.html?hl=height." />
   <purpose value="To provide implementers with additional support when implementing length / height measuring and to provide a consistent structure to how the data is presented." />
   <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <fhirVersion value="4.0.1" />
@@ -48,20 +48,13 @@
       <path value="Observation.value[x]" />
       <min value="1" />
       <type>
-        <code value="Quantity" />
+        <code value="CodeableConcept" />
       </type>
-    </element>
-    <element id="Observation.value[x].unit">
-      <path value="Observation.value[x].unit" />
-      <fixedString value="meter" />
-    </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
-      <path value="Observation.value[x].code" />
-      <fixedCode value="m" />
+      <binding>
+        <strength value="required" />
+        <description value="Include codes from http://unitsofmeasure.org where canonical = m" />
+        <valueSet value="http://hl7.org/fhir/ValueSet/all-distance-units" />
+      </binding>
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -1,141 +1,139 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-    <id value="UKCore-Observation-VitalSigns" />
-    <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
-    <version value="1.1.1" />
-    <name value="UKCoreObservationVitalSigns" />
-    <title value="UK Core Observation Vital Signs" />
-    <status value="active" />
-    <date value="2024-07-23" />
-    <publisher value="HL7 UK" />
-    <contact>
-        <name value="HL7 UK" />
-        <telecom>
-            <system value="email" />
-            <value value="ukcore@hl7.org.uk" />
-            <use value="work" />
-            <rank value="1" />
-        </telecom>
-    </contact>
-    <description value="Defines the observation constraints and extensions on the UK Core Observation resource for the minimal set of data to query and retrieve clinical observation vital signs information." />
-    <purpose value="This profile allows exchange of internationally FHIR compliant vital signs information based on measurements and simple assertions made about an individual. Where a more constrained derived profile exists, it should be used instead of this profile." />
-    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
-    <fhirVersion value="4.0.1" />
-    <kind value="resource" />
-    <abstract value="false" />
-    <type value="Observation" />
-    <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
-    <derivation value="constraint" />
-    <differential>
-        <element id="Observation">
-            <path value="Observation" />
-            <constraint>
-                <key value="ukcore-obs-vs-001" />
-                <severity value="error" />
-                <human value="`code.coding` SHALL include a LOINC &quot;magic code&quot;" />
-                <expression value="code.coding.where(system=&#39;http://loinc.org&#39;).exists()" />
-            </constraint>
-        </element>
-        <element id="Observation.extension:bodyPosition">
-            <path value="Observation.extension" />
-            <sliceName value="bodyPosition" />
-            <short value="The patients body position when the vital signs observation was recorded." />
-            <type>
-                <code value="Extension" />
-                <profile value="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition" />
-            </type>
-            <isModifier value="false" />
-        </element>
-        <element id="Observation.extension:bodyPosition.value[x]">
-            <path value="Observation.extension.value[x]" />
-            <binding>
-                <strength value="preferred" />
-                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyPosition" />
-            </binding>
-        </element>
-        <element id="Observation.extension:recordingSetting">
-            <path value="Observation.extension" />
-            <sliceName value="recordingSetting" />
-            <short value="Records whether the vital signs observation was performed in a clinical or non clinical setting." />
-            <type>
-                <code value="Extension" />
-                <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting" />
-            </type>
-            <isModifier value="false" />
-        </element>
-        <element id="Observation.status">
-            <path value="Observation.status" />
-            <short value="A status of `final` SHALL be present." />
-            <fixedCode value="final" />
-        </element>
-        <element id="Observation.category">
-            <path value="Observation.category" />
-            <short value="A category of `vital-signs` SHALL be present." />
-            <min value="1" />
-            <max value="1" />
-        </element>
-        <element id="Observation.category.coding.system">
-            <path value="Observation.category.coding.system" />
-            <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
-        </element>
-        <element id="Observation.category.coding.code">
-            <path value="Observation.category.coding.code" />
-            <fixedCode value="vital-signs" />
-        </element>
-        <element id="Observation.code">
-            <path value="Observation.code" />
-            <short value="The type of vital signs observation (code / type)." />
-            <min value="1" />
-            <max value="1" />
-        </element>
-        <element id="Observation.code.coding">
-            <path value="Observation.code.coding" />
-            <slicing>
-                <discriminator>
-                    <type value="value" />
-                    <path value="system" />
-                </discriminator>
-                <rules value="open" />
-            </slicing>
-        </element>
-        <element id="Observation.code.coding:loinc">
-            <path value="Observation.code.coding" />
-            <sliceName value="loinc" />
-            <short value="A LOINC &quot;magic code&quot; describing the type of observation SHALL be present." />
-            <min value="1" />
-            <max value="1" />
-            <binding>
-                <strength value="extensible" />
-                <valueSet value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult" />
-            </binding>
-        </element>
-        <element id="Observation.code.coding:loinc.system">
-            <path value="Observation.code.coding.system" />
-            <fixedUri value="http://loinc.org" />
-        </element>
-        <element id="Observation.code.coding:snomedCT">
-            <path value="Observation.code.coding" />
-            <sliceName value="snomedCT" />
-            <short value="A SNOMED CT concept describing the type of observation SHALL be present." />
-            <min value="1" />
-            <binding>
-                <strength value="preferred" />
-                <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
-                <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
-            </binding>
-        </element>
-        <element id="Observation.code.coding:snomedCT.system">
-            <path value="Observation.code.coding.system" />
-            <fixedUri value="http://snomed.info/sct" />
-        </element>
-        <element id="Observation.subject">
-            <path value="Observation.subject" />
-            <short value="Who or what the observation relates to SHALL be present." />
-            <min value="1" />
-        </element>
-        <element id="Observation.effective[x]">
-            <path value="Observation.effective[x]" />
-            <short value="A clinically relevant time / time-period for observation SHALL be present." />
-            <min value="1" />
-        </element>
-    </differential>
+  <id value="UKCore-Observation-VitalSigns" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <version value="1.1.1" />
+  <name value="UKCoreObservationVitalSigns" />
+  <title value="UK Core Observation Vital Signs" />
+  <status value="active" />
+  <date value="2024-07-23" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="Defines the observation constraints and extensions on the UK Core Observation resource for the minimal set of data to query and retrieve clinical observation vital signs information." />
+  <purpose value="This profile allows exchange of internationally FHIR compliant vital signs information based on measurements and simple assertions made about an individual. Where a more constrained derived profile exists, it should be used instead of this profile." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Observation" />
+  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Observation">
+      <path value="Observation" />
+      <constraint>
+        <key value="ukcore-obs-vs-001" />
+        <severity value="error" />
+        <human value="`code.coding` SHALL include a LOINC &quot;magic code&quot;" />
+        <expression value="code.coding.where(system='http://loinc.org').exists()" />
+      </constraint>
+    </element>
+    <element id="Observation.extension:bodyPosition">
+      <path value="Observation.extension" />
+      <sliceName value="bodyPosition" />
+      <short value="The patients body position when the vital signs observation was recorded." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Observation.extension:bodyPosition.value[x]">
+      <path value="Observation.extension.value[x]" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyPosition" />
+      </binding>
+    </element>
+    <element id="Observation.extension:recordingSetting">
+      <path value="Observation.extension" />
+      <sliceName value="recordingSetting" />
+      <short value="Records whether the vital signs observation was performed in a clinical or non clinical setting." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Observation.status">
+      <path value="Observation.status" />
+      <short value="A status of `final` SHALL be present." />
+      <fixedCode value="final" />
+    </element>
+    <element id="Observation.category">
+      <path value="Observation.category" />
+      <short value="A category of `vital-signs` SHALL be present." />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Observation.category.coding.system">
+      <path value="Observation.category.coding.system" />
+      <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
+    </element>
+    <element id="Observation.category.coding.code">
+      <path value="Observation.category.coding.code" />
+      <fixedCode value="vital-signs" />
+    </element>
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <short value="The type of vital signs observation (code / type)." />
+    </element>
+    <element id="Observation.code.coding">
+      <path value="Observation.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.code.coding:loinc">
+      <path value="Observation.code.coding" />
+      <sliceName value="loinc" />
+      <short value="A LOINC &quot;magic code&quot; describing the type of observation SHALL be present." />
+      <min value="1" />
+      <max value="1" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult" />
+      </binding>
+    </element>
+    <element id="Observation.code.coding:loinc.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://loinc.org" />
+    </element>
+    <element id="Observation.code.coding:snomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedCT" />
+      <short value="A SNOMED CT concept describing the type of observation SHALL be present." />
+      <min value="1" />
+      <binding>
+        <strength value="preferred" />
+        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
+      </binding>
+    </element>
+    <element id="Observation.code.coding:snomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
+    <element id="Observation.subject">
+      <path value="Observation.subject" />
+      <short value="Who or what the observation relates to SHALL be present." />
+      <min value="1" />
+    </element>
+    <element id="Observation.effective[x]">
+      <path value="Observation.effective[x]" />
+      <short value="A clinically relevant time / time-period for observation SHALL be present." />
+      <min value="1" />
+    </element>
+  </differential>
 </StructureDefinition>


### PR DESCRIPTION
As per https://simplifier.net/hl7fhirukcorer4/ukcore-observation-vitalsigns-bodyheight/~issues/3351
>After reviewing the use of units with clinical experts from different specialties in NHS Wales, it was deemed appropriate to use cm as the primary unit, especially in certain use cases where patients are very young (under 2 years old) and length is recorded instead of height. Length is always recorded as cm.
>
>Ideally, we should allow the use of both meters (m) and centimeters (cm) to accommodate this

Changed valueQuantity to valueCodeableConcept and reused an international valueset that includes all distances that contain (m) so this includes metres and centimetres. Reworded description so that it includes these two values and that body length for babies and infants are in scope.

Changes to VitalSigns are symbols only and automatically done by forge