### PR TITLE
added pipe to beginning and end of snomed description

### DIFF
--- a/valuesets/ValueSet-UKCore-ACVPU.xml
+++ b/valuesets/ValueSet-UKCore-ACVPU.xml
@@ -17,11 +17,11 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
-&#13; - 248234008 | Mentally alert
-&#13; - 300202002 | Responds to voice
-&#13; - 450847001 | Responds to pain
-&#13; - 422768004 | Unresponsive
-&#13; - 130987000 | Acute confusion" />
+&#13; - 248234008 | Mentally alert |
+&#13; - 300202002 | Responds to voice |
+&#13; - 450847001 | Responds to pain |
+&#13; - 422768004 | Unresponsive |
+&#13; - 130987000 | Acute confusion |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-ACVPU.xml
+++ b/valuesets/ValueSet-UKCore-ACVPU.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-ACVPU" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ACVPU" />
-  <version value="2.1.0" />
+  <version value="2.1.1" />
   <name value="UKCoreACVPU" />
   <title value="UK Core ACVPU" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-AlcoholConsumption.xml
+++ b/valuesets/ValueSet-UKCore-AlcoholConsumption.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-AlcoholConsumption" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-AlcoholConsumption" />
-  <version value="0.0.1" />
+  <version value="0.1.1" />
   <name value="UKCoreAlcoholConsumption" />
   <title value="UK Core Alcohol Consumption" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-AlcoholConsumption.xml
+++ b/valuesets/ValueSet-UKCore-AlcoholConsumption.xml
@@ -17,10 +17,10 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
-&#13; - 1082641000000106 | Alcohol units consumed per week (observable entity) 
-&#13; - 1082631000000102 | Alcohol units consumed per day (observable entity)
-&#13; - 442547005 | Number of alcohol units consumed on heaviest drinking day (observable entity)
-&#13; - 443315005 | Number of alcohol units consumed on typical drinking day (observable entity) " />
+&#13; - 1082641000000106 | Alcohol units consumed per week (observable entity) |
+&#13; - 1082631000000102 | Alcohol units consumed per day (observable entity) |
+&#13; - 442547005 | Number of alcohol units consumed on heaviest drinking day (observable entity) |
+&#13; - 443315005 | Number of alcohol units consumed on typical drinking day (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BMI.xml
+++ b/valuesets/ValueSet-UKCore-BMI.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BMI" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BMI" />
-  <version value="1.0.1" />
+  <version value="1.0.2" />
   <name value="UKCoreBMI" />
   <title value="UK Core BMI" />
   <status value="active" />
-  <date value="2024-02-27" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BMI.xml
+++ b/valuesets/ValueSet-UKCore-BMI.xml
@@ -17,16 +17,16 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
-&#13; - DescendantOrSelfOf 60621009 | Body mass index (observable entity)
-&#13; - DescendantOrSelfOf 446974000 |Body mass index centile (observable entity
+&#13; - DescendantOrSelfOf 60621009 | Body mass index (observable entity) |
+&#13; - DescendantOrSelfOf 446974000 |Body mass index centile (observable entity |
 &#13; - MINUS 
-&amp;nbsp;&#13; - 846931000000101 | Baseline body mass index (observable entity)
-&amp;nbsp;&#13; - 852451000000103 | Maximum body mass index (observable entity)
-&amp;nbsp;&#13; - 852461000000100 | Minimum body mass index (observable entity)
-&amp;nbsp;&#13; - 715456008 | Percentage median body mass index for age and sex (observable entity)
-&amp;nbsp;&#13; - 846911000000109 | Baseline body mass index centile (observable entity)
-&amp;nbsp;&#13; - 1153596006 | Body mass index for age z-score (observable entity)
-&amp;nbsp;&#13; - 248358009 | Weight for height (observable entity)" />
+&amp;nbsp;&#13; - 846931000000101 | Baseline body mass index (observable entity) |
+&amp;nbsp;&#13; - 852451000000103 | Maximum body mass index (observable entity) |
+&amp;nbsp;&#13; - 852461000000100 | Minimum body mass index (observable entity) |
+&amp;nbsp;&#13; - 715456008 | Percentage median body mass index for age and sex (observable entity) |
+&amp;nbsp;&#13; - 846911000000109 | Baseline body mass index centile (observable entity) |
+&amp;nbsp;&#13; - 1153596006 | Body mass index for age z-score (observable entity) |
+&amp;nbsp;&#13; - 248358009 | Weight for height (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodGlucose.xml
+++ b/valuesets/ValueSet-UKCore-BloodGlucose.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodGlucose" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodGlucose" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodGlucose" />
   <title value="UK Core Blood Glucose" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodGlucose.xml
+++ b/valuesets/ValueSet-UKCore-BloodGlucose.xml
@@ -17,8 +17,8 @@
     </telecom>
   </contact>
   <description value="A set of codes to record the level of result from a blood glucose test. Selected from the SNOMED CT UK coding system:
-&#13; - DescendantOrSelfOf 997671000000106 | Blood glucose level (observable entity)
-&#13; - DescendantOrSelfOf 434911002 | Plasma glucose concentration (observable entity)" />
+&#13; - DescendantOrSelfOf 997671000000106 | Blood glucose level (observable entity) |
+&#13; - DescendantOrSelfOf 434911002 | Plasma glucose concentration (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-Average.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Average.xml
@@ -17,12 +17,12 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for recording average blood pressure. Selected from the SNOMED CT UK coding system:
-&#13; - 170599006 | 24 hr blood pressure monitoring (regime/therapy) 
-&#13; - 314463006 | 24 hour blood pressure (observable entity)
-&#13; - 723232008 | Average blood pressure (observable entity)
-&#13; - DescendantOrSelfOf 6797001 | Mean blood pressure (observable entity)
+&#13; - 170599006 | 24 hr blood pressure monitoring (regime/therapy) |
+&#13; - 314463006 | 24 hour blood pressure (observable entity) |
+&#13; - 723232008 | Average blood pressure (observable entity) |
+&#13; - DescendantOrSelfOf 6797001 | Mean blood pressure (observable entity) |
 &#13; - MINUS
-&amp;nbsp;&#13; - 852281000000108 | Target mean blood pressure (observable entity)" />
+&amp;nbsp;&#13; - 852281000000108 | Target mean blood pressure (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-Average.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Average.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-Average" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Average" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureAverage" />
   <title value="UK Core Blood Pressure Average" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-AverageDiastolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-AverageDiastolic.xml
@@ -17,12 +17,12 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for the average diastolic blood pressure. Selected from the SNOMED CT UK coding system:
-&#13; - 198091000000104 | Ambulatory diastolic blood pressure (observable entity)
-&#13; - 314465004 | 24 hour diastolic blood pressure (observable entity)
-&#13; - 314462001 | Average 24 hour diastolic blood pressure (observable entity)
-&#13; - 314459004 | Maximum 24 hour diastolic blood pressure (observable entity) 
-&#13; - 314456006 | Minimum 24 hour diastolic blood pressure (observable entity)
-&#13; - DescendantOrSelfOf 314453003 | Average diastolic blood pressure (observable entity)" />
+&#13; - 198091000000104 | Ambulatory diastolic blood pressure (observable entity) |
+&#13; - 314465004 | 24 hour diastolic blood pressure (observable entity) |
+&#13; - 314462001 | Average 24 hour diastolic blood pressure (observable entity) |
+&#13; - 314459004 | Maximum 24 hour diastolic blood pressure (observable entity) |
+&#13; - 314456006 | Minimum 24 hour diastolic blood pressure (observable entity) |
+&#13; - DescendantOrSelfOf 314453003 | Average diastolic blood pressure (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-AverageDiastolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-AverageDiastolic.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-AverageDiastolic" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-AverageDiastolic" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureAverageDiastolic" />
   <title value="UK Core Blood Pressure Average Diastolic" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-AverageSystolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-AverageSystolic.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-AverageSystolic" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-AverageSystolic" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureAverageSystolic" />
   <title value="UK Core Blood Pressure Average Systolic" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-AverageSystolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-AverageSystolic.xml
@@ -17,12 +17,12 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for the systolic blood pressure. Selected from the SNOMED CT UK coding system:
-&#13; - 198081000000101  | Ambulatory systolic blood pressure (observable entity)
-&#13; - 314464000 | 24 hour systolic blood pressure (observable entity)
-&#13; - 314449000 | Average 24 hour systolic blood pressure (observable entity)
-&#13; - 314448008 | Maximum 24 hour systolic blood pressure (observable entity) 
-&#13; - 314447003 | Minimum 24 hour systolic blood pressure (observable entity)
-&#13; - DescendantOrSelfOf 314440001 | Average systolic blood pressure (observable entity)" />
+&#13; - 198081000000101  | Ambulatory systolic blood pressure (observable entity) |
+&#13; - 314464000 | 24 hour systolic blood pressure (observable entity) |
+&#13; - 314449000 | Average 24 hour systolic blood pressure (observable entity) |
+&#13; - 314448008 | Maximum 24 hour systolic blood pressure (observable entity) |
+&#13; - 314447003 | Minimum 24 hour systolic blood pressure (observable entity) |
+&#13; - DescendantOrSelfOf 314440001 | Average systolic blood pressure (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-CuffSize.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-CuffSize.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-CuffSize" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-CuffSize" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureCuffSize" />
   <title value="UK Core Blood Pressure Cuff Size" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-CuffSize.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-CuffSize.xml
@@ -17,7 +17,7 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a sphygmomanometer cuff size used with a device. Selected from the SNOMED CT UK coding system:
-&#13; - DescendantOf 70665002 | Blood pressure cuff, device (physical object)" />
+&#13; - DescendantOf 70665002 | Blood pressure cuff, device (physical object) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-DeviceType.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-DeviceType.xml
@@ -17,10 +17,10 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for the type of device used to measure blood pressure. Selected from the SNOMED CT UK coding system:
-&#13; - 43770009 | Doppler device (physical object)
-&#13; - 469801002 | Invasive blood pressure monitor (physical object)
-&#13; - 258057004 | Non-invasive blood pressure monitor (physical object)
-&#13; - DescendantOrSelfOf 39690000 | Sphygmomanometer, device (physical object)" />
+&#13; - 43770009 | Doppler device (physical object) |
+&#13; - 469801002 | Invasive blood pressure monitor (physical object) |
+&#13; - 258057004 | Non-invasive blood pressure monitor (physical object) |
+&#13; - DescendantOrSelfOf 39690000 | Sphygmomanometer, device (physical object) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-DeviceType.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-DeviceType.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-DeviceType" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-DeviceType" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureDeviceType" />
   <title value="UK Core Blood Pressure Device Type" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-Diastolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Diastolic.xml
@@ -17,13 +17,13 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for the recording of a single diastolic blood pressure reading. Selected from the SNOMED CT UK coding system:
-&#13; - 163031004 | On examination - Diastolic blood pressure reading (finding)
-&#13; - 271650006 | Diastolic blood pressure (observable entity)
-&#13; - 1091811000000102  | Diastolic arterial pressure (observable entity)
-&#13; - 407557002 | Lying diastolic blood pressure (observable entity)
-&#13; - 1162735000 | Self reported diastolic blood pressure (observable entity)
-&#13; - 407555005 | Sitting diastolic blood pressure (observable entity)
-&#13; - 400975005 | Standing diastolic blood pressure (observable entity)" />
+&#13; - 163031004 | On examination - Diastolic blood pressure reading (finding) |
+&#13; - 271650006 | Diastolic blood pressure (observable entity) |
+&#13; - 1091811000000102  | Diastolic arterial pressure (observable entity) |
+&#13; - 407557002 | Lying diastolic blood pressure (observable entity) |
+&#13; - 1162735000 | Self reported diastolic blood pressure (observable entity) |
+&#13; - 407555005 | Sitting diastolic blood pressure (observable entity) |
+&#13; - 400975005 | Standing diastolic blood pressure (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-Diastolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Diastolic.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-Diastolic" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Diastolic" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureDiastolic" />
   <title value="UK Core Blood Pressure Diastolic" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-MeasurementMethod.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-MeasurementMethod.xml
@@ -17,13 +17,13 @@
     </telecom>
   </contact>
   <description value="A code for recording the method in which blood pressure was measured. Selected from the SNOMED CT UK coding system:
-&#13; - 37931006 | Auscultation (procedure)
-&#13; - 810061000000102 | Measurement of blood pressure using manual sphygmomanometer by auscultation over brachial artery (procedure)
-&#13; - 13385008 | Mediate auscultation (procedure)
-&#13; - 765172009 | Doppler ultrasound (procedure)
-&#13; - 113011001 | Palpation (procedure)
-&#13; - 31813000 | Vascular oscillometry (procedure)
-&#13; - descendantOrSelfOf 42826002 | Systemic arterial pressure monitoring (regime/therapy)" />
+&#13; - 37931006 | Auscultation (procedure) |
+&#13; - 810061000000102 | Measurement of blood pressure using manual sphygmomanometer by auscultation over brachial artery (procedure) |
+&#13; - 13385008 | Mediate auscultation (procedure) |
+&#13; - 765172009 | Doppler ultrasound (procedure) |
+&#13; - 113011001 | Palpation (procedure) |
+&#13; - 31813000 | Vascular oscillometry (procedure) |
+&#13; - descendantOrSelfOf 42826002 | Systemic arterial pressure monitoring (regime/therapy) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure-MeasurementMethod.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-MeasurementMethod.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-MeasurementMethod" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-MeasurementMethod" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureMeasurementMethod" />
   <title value="UK Core Blood Pressure Measurement Method" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-Systolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Systolic.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure-Systolic" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Systolic" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBloodPressureSystolic" />
   <title value="UK Core Blood Pressure Systolic" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure-Systolic.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Systolic.xml
@@ -17,13 +17,13 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for the recording of a single systolic blood pressure reading. Selected from the SNOMED CT UK coding system:
-&#13; - 163030003 | On examination - Systolic blood pressure reading (finding)
-&#13; - 271649006 | Systolic blood pressure (observable entity)
-&#13; - 407556006 | Lying systolic blood pressure (observable entity)
-&#13; - 1162737008 | Self reported systolic blood pressure (observable entity)
-&#13; - 407554009 | Sitting systolic blood pressure (observable entity)
-&#13; - 400974009 | Standing systolic blood pressure (observable entity)
-&#13; - 72313002 | Systolic arterial pressure (observable entity)" />
+&#13; - 163030003 | On examination - Systolic blood pressure reading (finding) |
+&#13; - 271649006 | Systolic blood pressure (observable entity) |
+&#13; - 407556006 | Lying systolic blood pressure (observable entity) |
+&#13; - 1162737008 | Self reported systolic blood pressure (observable entity) |
+&#13; - 407554009 | Sitting systolic blood pressure (observable entity) |
+&#13; - 400974009 | Standing systolic blood pressure (observable entity) |
+&#13; - 72313002 | Systolic arterial pressure (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BloodPressure.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
-  <version value="1.0.1" />
+  <version value="1.0.2" />
   <name value="UKCoreBloodPressure" />
   <title value="UK Core Blood Pressure" />
   <status value="active" />
-  <date value="2024-02-27" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BloodPressure.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure.xml
@@ -17,46 +17,46 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for recording and grouping of a single set of blood pressure readings, and excludes specific systolic / diastolic readings. Selected from the SNOMED CT UK coding system:
-&#13; - 163020007 | On examination - blood pressure reading (finding) 
-&#13; - 392570002 | Blood pressure finding (finding)
-&#13; - 392571003 | Finding of arterial pulse pressure (finding)
-&#13; - 301141002 | Finding of pulmonary arterial pressure (finding)
-&#13; - 366161004 | Finding of venous pressure (finding) 
-&#13; - 366162006 | Finding of central venous pressure (finding)
-&#13; - 366163001 | Finding of jugular venous pressure (finding) 
-&#13; - 75367002 | Blood pressure (observable entity) 
-&#13; - 386534000 | Arterial blood pressure (observable entity)
-&#13; - 87179004 | Arterial pulse pressure (observable entity)
-&#13; - 386533006 | Invasive blood pressure (observable entity)
-&#13; - 386532001 | Invasive arterial pressure (observable entity)
-&#13; - 723237002 | Non-invasive blood pressure (observable entity)
-&#13; - 251076008 | Non-invasive arterial pressure (observable entity)
-&#13; - 1036531000000108 | Non-invasive central blood pressure (observable entity)
-&#13; - 335661000000109 | Self measured blood pressure reading (observable entity)
-&#13; - 163033001 | Lying blood pressure (observable entity) 
-&#13; - 163035008 | Sitting blood pressure (observable entity)
-&#13; - 163034007 | Standing blood pressure (observable entity)
-&#13; - 252076005 | Venous pressure (observable entity)
-&#13; - 76882007 | Venous wedge pressure (observable entity) 
-&#13; - 71420008 | Central venous pressure (observable entity)
-&#13; - 37476000 | Jugular venous pressure (observable entity)
-&#13; - 364090009 | Systemic arterial pressure (observable entity)
-&#13; - 386536003 | Systemic blood pressure (observable entity)
-&#13; - 251068006 | Atrial pressure (observable entity)
-&#13; - 276760007 | Left atrial pressure (observable entity)
-&#13; - 276755008 | Right atrial pressure (observable entity)
-&#13; - 165077006 | Intracardiac pressure (observable entity)
-&#13; - 37087001 | Arterial wedge pressure (observable entity)
-&#13; - 371829003 | Pulmonary vein wedge pressure (observable entity)
+&#13; - 163020007 | On examination - blood pressure reading (finding) |
+&#13; - 392570002 | Blood pressure finding (finding) |
+&#13; - 392571003 | Finding of arterial pulse pressure (finding) |
+&#13; - 301141002 | Finding of pulmonary arterial pressure (finding) |
+&#13; - 366161004 | Finding of venous pressure (finding) |
+&#13; - 366162006 | Finding of central venous pressure (finding) |
+&#13; - 366163001 | Finding of jugular venous pressure (finding) |
+&#13; - 75367002 | Blood pressure (observable entity) |
+&#13; - 386534000 | Arterial blood pressure (observable entity) |
+&#13; - 87179004 | Arterial pulse pressure (observable entity) |
+&#13; - 386533006 | Invasive blood pressure (observable entity) |
+&#13; - 386532001 | Invasive arterial pressure (observable entity) |
+&#13; - 723237002 | Non-invasive blood pressure (observable entity) |
+&#13; - 251076008 | Non-invasive arterial pressure (observable entity) |
+&#13; - 1036531000000108 | Non-invasive central blood pressure (observable entity) |
+&#13; - 335661000000109 | Self measured blood pressure reading (observable entity) |
+&#13; - 163033001 | Lying blood pressure (observable entity) |
+&#13; - 163035008 | Sitting blood pressure (observable entity) |
+&#13; - 163034007 | Standing blood pressure (observable entity) |
+&#13; - 252076005 | Venous pressure (observable entity) |
+&#13; - 76882007 | Venous wedge pressure (observable entity) |
+&#13; - 71420008 | Central venous pressure (observable entity) |
+&#13; - 37476000 | Jugular venous pressure (observable entity) |
+&#13; - 364090009 | Systemic arterial pressure (observable entity) |
+&#13; - 386536003 | Systemic blood pressure (observable entity) |
+&#13; - 251068006 | Atrial pressure (observable entity) |
+&#13; - 276760007 | Left atrial pressure (observable entity) |
+&#13; - 276755008 | Right atrial pressure (observable entity) |
+&#13; - 165077006 | Intracardiac pressure (observable entity) |
+&#13; - 37087001 | Arterial wedge pressure (observable entity) |
+&#13; - 371829003 | Pulmonary vein wedge pressure (observable entity) |
 &#13; - MINUS
-&amp;nbsp;&#13; - 170599006 | 24 hr blood pressure monitoring (regime/therapy)
-&amp;nbsp;&#13; - descendantOrSelfOf 371830008 | Pulmonary vein mean wedge pressure (observable entity)
-&amp;nbsp;&#13; - descendantOrSelfOf 6797001 | Mean blood pressure (observable entity)
-&amp;nbsp;&#13; - descendantOrSelfOf 723232008 | Average blood pressure (observable entity)
-&amp;nbsp;&#13; - descendantOf 276769008 | Left ventricular pressure (observable entity)
-&amp;nbsp;&#13; - descendantOf 276756009 | Right ventricular pressure (observable entity)
-&amp;nbsp;&#13; - descendantOf 276760007 | Left atrial pressure (observable entity)
-&amp;nbsp;&#13; - descendantOf 276755008 | Right atrial pressure (observable entity)" />
+&amp;nbsp;&#13; - 170599006 | 24 hr blood pressure monitoring (regime/therapy) |
+&amp;nbsp;&#13; - descendantOrSelfOf 371830008 | Pulmonary vein mean wedge pressure (observable entity) |
+&amp;nbsp;&#13; - descendantOrSelfOf 6797001 | Mean blood pressure (observable entity) |
+&amp;nbsp;&#13; - descendantOrSelfOf 723232008 | Average blood pressure (observable entity) |
+&amp;nbsp;&#13; - descendantOf 276769008 | Left ventricular pressure (observable entity) |
+&amp;nbsp;&#13; - descendantOf 276756009 | Right ventricular pressure (observable entity) |
+&amp;nbsp;&#13; - descendantOf 276760007 | Left atrial pressure (observable entity) |
+&amp;nbsp;&#13; - descendantOf 276755008 | Right atrial pressure (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BodyHeightMeasurements.xml
+++ b/valuesets/ValueSet-UKCore-BodyHeightMeasurements.xml
@@ -17,17 +17,17 @@
     </telecom>
   </contact>
   <description value="A code from the SNOMED CT UK coding system for the measurement of body lengths or heights. Selected from the SNOMED CT UK coding system:
-&#13; - 248337003 | Height from demispan (observable entity)
-&#13; - 1003998008 | Arm demispan (observable entity)
-&#13; - DescendantOrSelfOf 50373000 | Body height measure (observable entity)
+&#13; - 248337003 | Height from demispan (observable entity) |
+&#13; - 1003998008 | Arm demispan (observable entity) |
+&#13; - DescendantOrSelfOf 50373000 | Body height measure (observable entity) |
 &#13; - MINUS 
-&amp;nbsp;&#13; - 925931000000103 | Mid-parental height (observable entity))
-&amp;nbsp;&#13; - 925951000000105 | Predicted adult height (observable entity)
-&amp;nbsp;&#13; - 248336007 | Pubis to ground height (observable entity)
-&amp;nbsp;&#13; - 276350001 | Subischial leg length (observable entity)
-&amp;nbsp;&#13; - 1153591001 | Length for age percentile (observable entity)
-&amp;nbsp;&#13; - 1153604005 | Body height for age z-score (observable entity)
-&amp;nbsp;&#13; - 1153590000 | Length for age z score (observable entity)" />
+&amp;nbsp;&#13; - 925931000000103 | Mid-parental height (observable entity) |
+&amp;nbsp;&#13; - 925951000000105 | Predicted adult height (observable entity) |
+&amp;nbsp;&#13; - 248336007 | Pubis to ground height (observable entity) |
+&amp;nbsp;&#13; - 276350001 | Subischial leg length (observable entity) |
+&amp;nbsp;&#13; - 1153591001 | Length for age percentile (observable entity) |
+&amp;nbsp;&#13; - 1153604005 | Body height for age z-score (observable entity) |
+&amp;nbsp;&#13; - 1153590000 | Length for age z score (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BodyHeightMeasurements.xml
+++ b/valuesets/ValueSet-UKCore-BodyHeightMeasurements.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BodyHeightMeasurements" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements" />
-  <version value="1.0.1" />
+  <version value="1.0.2" />
   <name value="UKCoreBodyHeightMeasurements" />
   <title value="UK Core Body Height Measurements" />
   <status value="active" />
-  <date value="2024-02-27" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BodyPosition.xml
+++ b/valuesets/ValueSet-UKCore-BodyPosition.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BodyPosition" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyPosition" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBodyPosition" />
   <title value="UK Core Body Position" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BodyPosition.xml
+++ b/valuesets/ValueSet-UKCore-BodyPosition.xml
@@ -17,19 +17,19 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a patients body position when a clinical observation was taken. Selected from the SNOMED CT UK coding system:
-&#13; - 30212006 | Fowler's position (finding)
-&#13; - 26527006 | Inverse Trendelenburg position (finding)
-&#13; - 102536004 | Left lateral decubitus position (finding)
-&#13; - 414585002 | Left lateral tilt (finding)
-&#13; - 10904000 | Orthostatic body position (finding)
-&#13; - 1240000 | Prone body position (finding)
-&#13; - 102538003 | Recumbent body position (finding)
-&#13; - 423413008 | Reverse trendelenburg positioning (finding)
-&#13; - 102535000 | Right lateral decubitus position (finding)
-&#13; - 415346000 | Right lateral tilt (finding)
-&#13; - 33586001 | Sitting position (finding)
-&#13; - 40199007 | Supine body position (finding)
-&#13; - 34106002 | Trendelenburg position (finding)" />
+&#13; - 30212006 | Fowler's position (finding) |
+&#13; - 26527006 | Inverse Trendelenburg position (finding) |
+&#13; - 102536004 | Left lateral decubitus position (finding) |
+&#13; - 414585002 | Left lateral tilt (finding) |
+&#13; - 10904000 | Orthostatic body position (finding) |
+&#13; - 1240000 | Prone body position (finding) |
+&#13; - 102538003 | Recumbent body position (finding) |
+&#13; - 423413008 | Reverse trendelenburg positioning (finding) |
+&#13; - 102535000 | Right lateral decubitus position (finding) |
+&#13; - 415346000 | Right lateral tilt (finding) |
+&#13; - 33586001 | Sitting position (finding) |
+&#13; - 40199007 | Supine body position (finding) |
+&#13; - 34106002 | Trendelenburg position (finding) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BodySite.xml
+++ b/valuesets/ValueSet-UKCore-BodySite.xml
@@ -18,8 +18,8 @@
         </telecom>
     </contact>
     <description value="A set of codes that define an anatomical or acquired body structure site. Selected from the SNOMED CT UK coding system:
-        &#13; - DescendantOf 442083009 | Anatomical or acquired body structure (body structure) 
-        &#13; - DescendantOf 278001007 | Nonspecific site (body structure)" />
+        &#13; - DescendantOf 442083009 | Anatomical or acquired body structure (body structure) |
+        &#13; - DescendantOf 278001007 | Nonspecific site (body structure) |" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-BodySite.xml
+++ b/valuesets/ValueSet-UKCore-BodySite.xml
@@ -2,11 +2,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="UKCore-BodySite" />
     <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite" />
-    <version value="2.2.0" />
+    <version value="2.2.1" />
     <name value="UKCoreBodySite" />
     <title value="UK Core Body Site" />
     <status value="active" />
-    <date value="2025-02-11" />
+    <date value="2025-03-05" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BodyTemperature.xml
+++ b/valuesets/ValueSet-UKCore-BodyTemperature.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BodyTemperature" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyTemperature" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBodyTemperature" />
   <title value="UK Core Body Temperature" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BodyTemperature.xml
+++ b/valuesets/ValueSet-UKCore-BodyTemperature.xml
@@ -17,23 +17,23 @@
     </telecom>
   </contact>
   <description value="A set of codes regarding laboratory medicine test requests and results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
-&#13; - DescendantOrSelfOf 386725007 | Body temperature 
+&#13; - DescendantOrSelfOf 386725007 | Body temperature |
 &#13; - MINUS
-&#13; - DescendantOrSelfOf 248458005 | Comparative temperature in limbs 
-&#13; - DescendantOrSelfOf 852591000000107 | Maximum body temperature 
-&amp;nbsp;&#13; - DescendantOrSelfOf 852601000000101 | Minimum body temperature 
-&amp;nbsp;&#13; - DescendantOrSelfOf 852581000000105 | Target body temperature 
-&amp;nbsp;&#13; - DescendantOrSelfOf 364419004 | Temperature of cervical spine 
-&amp;nbsp;&#13; - DescendantOrSelfOf 364424001 | Temperature of thoracic spine 
-&amp;nbsp;&#13; - DescendantOrSelfOf 364429006 | Temperature of lumbar spine
-&amp;nbsp;&#13; - DescendantOrSelfOf 248835004 | Temperature of breast 
-&amp;nbsp;&#13; - DescendantOrSelfOf 250124002 | Temperature of joint 
-&amp;nbsp;&#13; - DescendantOrSelfOf 431197002 | Temperature of digit 
-&amp;nbsp;&#13; - DescendantOrSelfOf 364518005 | Temperature of foot 
-&amp;nbsp;&#13; - DescendantOrSelfOf 363997004 | Temperature of pinna 
-&amp;nbsp;&#13; - DescendantOrSelfOf 364537001 | Temperature of skin 
-&amp;nbsp;&#13; - DescendantOrSelfOf 364246006 | Temperature of vagina 
-&amp;nbsp;&#13; - DescendantOrSelfOf 431598003 | Temperature of oesophagus)" />
+&#13; - DescendantOrSelfOf 248458005 | Comparative temperature in limbs |
+&#13; - DescendantOrSelfOf 852591000000107 | Maximum body temperature |
+&amp;nbsp;&#13; - DescendantOrSelfOf 852601000000101 | Minimum body temperature |
+&amp;nbsp;&#13; - DescendantOrSelfOf 852581000000105 | Target body temperature |
+&amp;nbsp;&#13; - DescendantOrSelfOf 364419004 | Temperature of cervical spine |
+&amp;nbsp;&#13; - DescendantOrSelfOf 364424001 | Temperature of thoracic spine |
+&amp;nbsp;&#13; - DescendantOrSelfOf 364429006 | Temperature of lumbar spine |
+&amp;nbsp;&#13; - DescendantOrSelfOf 248835004 | Temperature of breast |
+&amp;nbsp;&#13; - DescendantOrSelfOf 250124002 | Temperature of joint |
+&amp;nbsp;&#13; - DescendantOrSelfOf 431197002 | Temperature of digit |
+&amp;nbsp;&#13; - DescendantOrSelfOf 364518005 | Temperature of foot |
+&amp;nbsp;&#13; - DescendantOrSelfOf 363997004 | Temperature of pinna |
+&amp;nbsp;&#13; - DescendantOrSelfOf 364537001 | Temperature of skin |
+&amp;nbsp;&#13; - DescendantOrSelfOf 364246006 | Temperature of vagina | 
+&amp;nbsp;&#13; - DescendantOrSelfOf 431598003 | Temperature of oesophagus |)" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BodyWeightMeasurements.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightMeasurements.xml
@@ -19,9 +19,9 @@
   <description value="A code from the SNOMED CT UK coding system for the measurement of body weight. Selected from the SNOMED CT UK coding system:
 &#13; - DescendantOrSelfOf 27113001 | Body weight (observable entity)
 &#13; - MINUS 
-&amp;nbsp;&#13; - DescendantOrSelfOf 301334000 | Birth weight centile (observable entity)
-&amp;nbsp;&#13; - DescendantOrSelfOf 400967004 | Baseline weight (observable entity)
-&amp;nbsp;&#13; - DescendantOrSelfOf 248351003 | Previous well-weight (observable entity)" />
+&amp;nbsp;&#13; - DescendantOrSelfOf 301334000 | Birth weight centile (observable entity) |
+&amp;nbsp;&#13; - DescendantOrSelfOf 400967004 | Baseline weight (observable entity) |
+&amp;nbsp;&#13; - DescendantOrSelfOf 248351003 | Previous well-weight (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-BodyWeightMeasurements.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightMeasurements.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BodyWeightMeasurements" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightMeasurements" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreBodyWeightMeasurements" />
   <title value="UK Core Body Weight Measurements" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-EarlyWarningSubScore.xml
+++ b/valuesets/ValueSet-UKCore-EarlyWarningSubScore.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-EarlyWarningSubScore" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-EarlyWarningSubScore" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreEarlyWarningSubScore" />
   <title value="UK Core Early Warning Sub Score" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-EarlyWarningSubScore.xml
+++ b/valuesets/ValueSet-UKCore-EarlyWarningSubScore.xml
@@ -17,28 +17,28 @@
     </telecom>
   </contact>
   <description value="A set of codes for the recording of Early Warning Score sub scores. Selected from the SNOMED CT UK coding system:
-&#13; - 1104351000000103 | Royal College of Physicians National Early Warning Score 2 - pulse score (observable entity) 
-&#13; - 1104371000000107 | Royal College of Physicians National Early Warning Score 2 - temperature score (observable entity)
-&#13; - 1104331000000105 | Royal College of Physicians National Early Warning Score 2 - air or oxygen score (observable entity)
-&#13; - 1104361000000100 | Royal College of Physicians National Early Warning Score 2 - consciousness score (observable entity)
-&#13; - 1104301000000104 | Royal College of Physicians National Early Warning Score 2 - respiration rate score (observable entity)
-&#13; - 1104341000000101 | Royal College of Physicians National Early Warning Score 2 - systolic blood pressure score (observable entity)
-&#13; - 1104311000000102 | Royal College of Physicians National Early Warning Score 2 - oxygen saturation scale 1 score (observable entity)
-&#13; - 1104321000000108 | Royal College of Physicians National Early Warning Score 2 - oxygen saturation scale 2 score (observable entity)
+&#13; - 1104351000000103 | Royal College of Physicians National Early Warning Score 2 - pulse score (observable entity) |
+&#13; - 1104371000000107 | Royal College of Physicians National Early Warning Score 2 - temperature score (observable entity) |
+&#13; - 1104331000000105 | Royal College of Physicians National Early Warning Score 2 - air or oxygen score (observable entity) |
+&#13; - 1104361000000100 | Royal College of Physicians National Early Warning Score 2 - consciousness score (observable entity) |
+&#13; - 1104301000000104 | Royal College of Physicians National Early Warning Score 2 - respiration rate score (observable entity) |
+&#13; - 1104341000000101 | Royal College of Physicians National Early Warning Score 2 - systolic blood pressure score (observable entity) |
+&#13; - 1104311000000102 | Royal College of Physicians National Early Warning Score 2 - oxygen saturation scale 1 score (observable entity) |
+&#13; - 1104321000000108 | Royal College of Physicians National Early Warning Score 2 - oxygen saturation scale 2 score (observable entity) |
 &#13;
-&#13; - 1364091000000101 | National Paediatric Early Warning Score chart used (observable entity)
-&#13; - 1363331000000103 | National Paediatric Early Warning Score heart rate score (observable entity)
-&#13; - 1363361000000108 | National Paediatric Early Warning Score temperature score (observable entity)
-&#13; - 1363351000000105 | National Paediatric Early Warning Score consciousness score (observable entity)
-&#13; - 1363321000000100 | National Paediatric Early Warning Score inspired oxygen score (observable entity)
-&#13; - 1363271000000106 | National Paediatric Early Warning Score respiration rate score (observable entity)
-&#13; - 1363301000000109 | National Paediatric Early Warning Score respiratory distress score (observable entity)
-&#13; - 1363341000000107 | National Paediatric Early Warning Score capillary refill time score (observable entity)
-&#13; - 1364081000000103 | National Paediatric Early Warning Score level of respiratory distress (observable entity)
-&#13; - 1363291000000105 | National Paediatric Early Warning Score systolic blood pressure score (observable entity)
-&#13; - 1363311000000106 | National Paediatric Early Warning Score peripheral oxygen saturation score (observable entity)
-&#13; - 1364131000000103 | National Paediatric Early Warning Score nursing concern, clinical intuition (observable entity)
-&#13; - 1364121000000100 | National Paediatric Early Warning Score how is your child different since I last saw them? (observable entity)" />
+&#13; - 1364091000000101 | National Paediatric Early Warning Score chart used (observable entity) |
+&#13; - 1363331000000103 | National Paediatric Early Warning Score heart rate score (observable entity) |
+&#13; - 1363361000000108 | National Paediatric Early Warning Score temperature score (observable entity) |
+&#13; - 1363351000000105 | National Paediatric Early Warning Score consciousness score (observable entity) |
+&#13; - 1363321000000100 | National Paediatric Early Warning Score inspired oxygen score (observable entity) |
+&#13; - 1363271000000106 | National Paediatric Early Warning Score respiration rate score (observable entity) |
+&#13; - 1363301000000109 | National Paediatric Early Warning Score respiratory distress score (observable entity) |
+&#13; - 1363341000000107 | National Paediatric Early Warning Score capillary refill time score (observable entity) |
+&#13; - 1364081000000103 | National Paediatric Early Warning Score level of respiratory distress (observable entity) |
+&#13; - 1363291000000105 | National Paediatric Early Warning Score systolic blood pressure score (observable entity) |
+&#13; - 1363311000000106 | National Paediatric Early Warning Score peripheral oxygen saturation score (observable entity) |
+&#13; - 1364131000000103 | National Paediatric Early Warning Score nursing concern, clinical intuition (observable entity) |
+&#13; - 1364121000000100 | National Paediatric Early Warning Score how is your child different since I last saw them? (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-EarlyWarningTotalScore.xml
+++ b/valuesets/ValueSet-UKCore-EarlyWarningTotalScore.xml
@@ -17,8 +17,8 @@
     </telecom>
   </contact>
   <description value="A set of codes for the recording of Early Warning Score systems total scores. Selected from the SNOMED CT UK coding system:
-&#13; - 1104051000000101 | Royal College of Physicians National Early Warning Score 2 total score (observable entity)
-&#13; - 1363261000000104 | National Paediatric Early Warning Score total score (observable entity)" />
+&#13; - 1104051000000101 | Royal College of Physicians National Early Warning Score 2 total score (observable entity) |
+&#13; - 1363261000000104 | National Paediatric Early Warning Score total score (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-EarlyWarningTotalScore.xml
+++ b/valuesets/ValueSet-UKCore-EarlyWarningTotalScore.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-EarlyWarningTotalScore" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-EarlyWarningTotalScore" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreEarlyWarningTotalScore" />
   <title value="UK Core Early Warning Total Score" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-HeadCircumferenceMeasurements.xml
+++ b/valuesets/ValueSet-UKCore-HeadCircumferenceMeasurements.xml
@@ -19,10 +19,10 @@
   <description value="A code from the SNOMED CT UK coding system for the measurement of head circumferences. Selected from the SNOMED CT UK coding system:
 &#13; - DescendantOrSelfOf 363811000 | Head circumference measure (observable entity)
 &#13; - MINUS 
-&amp;nbsp;&#13; - 1153594009 | Head circumference for age z-score (observable entity)
-&amp;nbsp;&#13; - 70751000052109 | Head circumference of biological father (observable entity)
-&amp;nbsp;&#13; - 70761000052107 | Head circumference of biological mother (observable entity) 
-&amp;nbsp;&#13; - DescendantOrSelfOf 170061009 | Child head circumference centile (observable entity)" />
+&amp;nbsp;&#13; - 1153594009 | Head circumference for age z-score (observable entity) |
+&amp;nbsp;&#13; - 70751000052109 | Head circumference of biological father (observable entity) |
+&amp;nbsp;&#13; - 70761000052107 | Head circumference of biological mother (observable entity) |
+&amp;nbsp;&#13; - DescendantOrSelfOf 170061009 | Child head circumference centile (observable entity) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-HeadCircumferenceMeasurements.xml
+++ b/valuesets/ValueSet-UKCore-HeadCircumferenceMeasurements.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-HeadCircumferenceMeasurements" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreHeadCircumferenceMeasurements" />
   <title value="UK Core Head Circumference Measurements" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-HeartRate.xml
+++ b/valuesets/ValueSet-UKCore-HeartRate.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-HeartRate" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeartRate" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreHeartRate" />
   <title value="UK Core Heart Rate" />
   <status value="active" />
-  <date value="2024-07-11" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-HeartRate.xml
+++ b/valuesets/ValueSet-UKCore-HeartRate.xml
@@ -19,12 +19,12 @@
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
 &#13; - DescendantOrSelfOf 364075005 | Heart rate (observable entity)
 &#13; - MINUS 
-&amp;nbsp;&#13; - DescendantOrSelfOf 251670001 | Baseline fetal heart rate
-&amp;nbsp;&#13; - DescendantOrSelfOf 928001000000104 | Baseline heart rate
-&amp;nbsp;&#13; - DescendantOrSelfOf 852341000000107 | Maximum pulse rate
-&amp;nbsp;&#13; - DescendantOrSelfOf 852351000000105 | Minimum pulse rate
-&amp;nbsp;&#13; - DescendantOrSelfOf 428420003 | Target heart rate
-&amp;nbsp;&#13; - DescendantOrSelfOf 852331000000103 | Target pulse rate" />
+&amp;nbsp;&#13; - DescendantOrSelfOf 251670001 | Baseline fetal heart rate |
+&amp;nbsp;&#13; - DescendantOrSelfOf 928001000000104 | Baseline heart rate |
+&amp;nbsp;&#13; - DescendantOrSelfOf 852341000000107 | Maximum pulse rate |
+&amp;nbsp;&#13; - DescendantOrSelfOf 852351000000105 | Minimum pulse rate |
+&amp;nbsp;&#13; - DescendantOrSelfOf 428420003 | Target heart rate |
+&amp;nbsp;&#13; - DescendantOrSelfOf 852331000000103 | Target pulse rate |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-InspiredOxygen.xml
+++ b/valuesets/ValueSet-UKCore-InspiredOxygen.xml
@@ -17,8 +17,8 @@
     </telecom>
   </contact>
    <description value="A code from the SNOMED CT UK coding system which describes whether a patient requires oxygen or is breathing room air. Selected from the SNOMED CT UK coding system:
-&#13; - 722742002 | Breathing room air (finding)
-&#13; - 371825009 | Patient on oxygen (finding)" />
+&#13; - 722742002 | Breathing room air (finding) |
+&#13; - 371825009 | Patient on oxygen (finding) |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
    <compose>
       <include>

--- a/valuesets/ValueSet-UKCore-InspiredOxygen.xml
+++ b/valuesets/ValueSet-UKCore-InspiredOxygen.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
    <id value="UKCore-InspiredOxygen" />
    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-InspiredOxygen" />
-   <version value="2.1.0" />
+   <version value="2.1.1" />
    <name value="UKCoreInspiredOxygen" />
    <title value="UK Core Inspired Oxygen" />
    <status value="active" />
-   <date value="2023-09-12" />
+   <date value="2025-03-05" />
    <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-OxygenSaturation.xml
+++ b/valuesets/ValueSet-UKCore-OxygenSaturation.xml
@@ -19,11 +19,11 @@
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
 &#13; - DescendantOrSelfOf 103228002 | Hemoglobin saturation with oxygen (observable entity)
 &#13; - MINUS 
-&amp;nbsp;&#13; - DescendantOrSelfOf 927981000000106 | Baseline oxygen saturation at periphery
+&amp;nbsp;&#13; - DescendantOrSelfOf 927981000000106 | Baseline oxygen saturation at periphery |
 &amp;nbsp;&#13; - DescendantOrSelfOf 852651000000100 | Maximum peripheral oxygen saturation
-&amp;nbsp;&#13; - DescendantOrSelfOf 852661000000102 | Minimum peripheral oxygen saturation
-&amp;nbsp;&#13; - DescendantOrSelfOf 852641000000103 | Target peripheral oxygen saturation
-&amp;nbsp;&#13; - DescendantOrSelfOf 442349007 | Venous oxygen saturation" />
+&amp;nbsp;&#13; - DescendantOrSelfOf 852661000000102 | Minimum peripheral oxygen saturation |
+&amp;nbsp;&#13; - DescendantOrSelfOf 852641000000103 | Target peripheral oxygen saturation |
+&amp;nbsp;&#13; - DescendantOrSelfOf 442349007 | Venous oxygen saturation |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-OxygenSaturation.xml
+++ b/valuesets/ValueSet-UKCore-OxygenSaturation.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-OxygenSaturation" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreOxygenSaturation" />
   <title value="UK Core Oxygen Saturation" />
   <status value="active" />
-  <date value="2024-07-11" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.xml
@@ -17,8 +17,8 @@
         </telecom>
     </contact>
     <description value="A set of codes regarding laboratory medicine test results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: 
-  &#xD;&#xA; - memberOf 1853551000000106 | Pathology and laboratory medicine observable entity simple reference set
-  &#xD;&#xA; - memberOf 999002881000000100 | Pathology Bounded Code List observables simple reference set" />
+  &#xD;&#xA; - memberOf 1853551000000106 | Pathology and laboratory medicine observable entity simple reference set |
+  &#xD;&#xA; - memberOf 999002881000000100 | Pathology Bounded Code List observables simple reference set |" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="UKCore-PathologyAndLaboratoryMedicineObservables" />
     <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables" />
-    <version value="1.0.0" />
+    <version value="1.0.1" />
     <name value="UKCorePathologyAndLaboratoryMedicineObservables" />
     <title value="UK Core Pathology And Laboratory Medicine Observables" />
     <status value="active" />
-    <date value="2023-11-28" />
+    <date value="2025-03-05" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
@@ -17,7 +17,7 @@
         </telecom>
     </contact>
     <description value="A set of codes regarding laboratory medicine test requests and test group results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
-  - memberOf 1853561000000109 | Pathology and laboratory medicine procedure simple reference set" />
+  - memberOf 1853561000000109 | Pathology and laboratory medicine procedure simple reference set |" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
     <id value="UKCore-PathologyAndLaboratoryMedicineProcedures" />
     <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
-    <version value="1.0.0" />
+    <version value="1.0.1" />
     <name value="UKCorePathologyAndLaboratoryMedicineProcedures" />
     <title value="UK Core Pathology And Laboratory Medicine Procedures" />
     <status value="active" />
-    <date value="2023-11-28" />
+    <date value="2025-03-05" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-ProcedureCode.xml
+++ b/valuesets/ValueSet-UKCore-ProcedureCode.xml
@@ -16,7 +16,9 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system:&#xD;&#xA;- descendantOrSelfOf 71388002 | Procedure&#xD;&#xA;- descendantOrSelfOf 129125009 | Procedure with explicit context" />
+  <description value="A set of codes that define a procedure or a procedure with explicit context. Selected from the SNOMED CT UK coding system:
+  &#xD;&#xA; - descendantOrSelfOf 71388002 | Procedure |
+  &#xD;&#xA;- descendantOrSelfOf 129125009 | Procedure with explicit context |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html. This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-ProcedureCode.xml
+++ b/valuesets/ValueSet-UKCore-ProcedureCode.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-ProcedureCode" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
-  <version value="2.2.0" />
+  <version value="2.2.1" />
   <name value="UKCoreProcedureCode" />
   <title value="UK Core Procedure Code" />
   <status value="active" />
-  <date value="2022-12-16" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-ReportCode.xml
+++ b/valuesets/ValueSet-UKCore-ReportCode.xml
@@ -16,7 +16,8 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="A code from the SNOMED Clinical Terminology UK coding system that describes a diagnostic report. Selected from the following SNOMED CT UK coding system:&#xD;&#xA;- descendantOrSelfOf 371525003 | Clinical procedure report" />
+  <description value="A code from the SNOMED Clinical Terminology UK coding system that describes a diagnostic report. Selected from the following SNOMED CT UK coding system:
+  &#xD;&#xA;- descendantOrSelfOf 371525003 | Clinical procedure report |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-ReportCode.xml
+++ b/valuesets/ValueSet-UKCore-ReportCode.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-ReportCode" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode" />
-  <version value="1.0.0" />
+  <version value="1.0.1" />
   <name value="UKCoreReportCode" />
   <title value="UK Core Report Code" />
   <status value="active" />
-  <date value="2023-04-28" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-RespirationRate.xml
+++ b/valuesets/ValueSet-UKCore-RespirationRate.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-RespirationRate" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-RespirationRate" />
-  <version value="1.1.0" />
+  <version value="1.1.1" />
   <name value="UKCoreRespirationRate" />
   <title value="UK Core Respiration Rate" />
   <status value="active" />
-  <date value="2024-07-11" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-RespirationRate.xml
+++ b/valuesets/ValueSet-UKCore-RespirationRate.xml
@@ -17,9 +17,9 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
-&#13; - DescendantOrSelfOf 86290005 | Respiratory rate
+&#13; - DescendantOrSelfOf 86290005 | Respiratory rate |
 &#13; - MINUS 
-&amp;nbsp;&#13; - DescendantOrSelfOf 927961000000102 | Baseline respiratory rate" />
+&amp;nbsp;&#13; - DescendantOrSelfOf 927961000000102 | Baseline respiratory rate |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
+++ b/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
@@ -16,7 +16,12 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="A set of codes that define a reason for a service request. Selected from the following hierarchies within the SNOMED CT UK coding system: &#13; - descendantOrSelfOf 404684003 | Clinical finding &#13; - descendantOrSelfOf 71388002 | Procedure &#13; - descendantOrSelfOf 272379006 | Event &#13; - descendantOrSelfOf 363787002 | Observable entity &#13; - descendantOrSelfOf 243796009 | Situation with explicit context" />
+  <description value="A set of codes that define a reason for a service request. Selected from the following hierarchies within the SNOMED CT UK coding system:
+  &#13; - descendantOrSelfOf 404684003 | Clinical finding |
+  &#13; - descendantOrSelfOf 71388002 | Procedure |
+  &#13; - descendantOrSelfOf 272379006 | Event |
+  &#13; - descendantOrSelfOf 363787002 | Observable entity |
+  &#13; - descendantOrSelfOf 243796009 | Situation with explicit context |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
+++ b/valuesets/ValueSet-UKCore-ServiceRequestReasonCode.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-ServiceRequestReasonCode" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode" />
-  <version value="1.1.0" />
+  <version value="1.1.1" />
   <name value="UKCoreServiceRequestReasonCode" />
   <title value="UK Core Service Request Reason Code" />
   <status value="active" />
-  <date value="2022-12-16" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
+++ b/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-SourceOfServiceRequest" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SourceOfServiceRequest" />
-  <version value="1.2.0" />
+  <version value="1.2.1" />
   <name value="UKCoreSourceOfServiceRequest" />
   <title value="UK Core Source Of Service Request" />
   <status value="active" />
-  <date value="2024-07-11" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
+++ b/valuesets/ValueSet-UKCore-SourceOfServiceRequest.xml
@@ -16,7 +16,9 @@
       <rank value="1" />
     </telecom>
   </contact>
-  <description value="A set of codes that describe the source of the service request. Selected from the Referred by person and Self-referral hierarchies of the SNOMED CT UK coding system:&#xD;&#xA;- descendantOf 309013001 | Referred by person&#xD;&#xA;- descendantOf 306098008 | Self-referral" />
+  <description value="A set of codes that describe the source of the service request. Selected from the Referred by person and Self-referral hierarchies of the SNOMED CT UK coding system:
+  &#xD;&#xA; - descendantOf 309013001 | Referred by person |
+  &#xD;&#xA; - descendantOf 306098008 | Self-referral |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
@@ -17,8 +17,8 @@
     </telecom>
   </contact>
   <description value="A set of codes to record a specimen body site. Selected from the following SNOMED CT UK coding system:
-&#13; - descendantOf 442083009 | Anatomical or acquired body structure, or
-&#13; - descendantOf 49755003 | Morphologically abnormal structure" />
+&#13; - descendantOf 442083009 | Anatomical or acquired body structure |
+&#13; - descendantOf 49755003 | Morphologically abnormal structure |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenBodySite.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-SpecimenBodySite" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite" />
-  <version value="2.1.0" />
+  <version value="2.1.1" />
   <name value="UKCoreSpecimenBodySite" />
   <title value="UK Core Specimen Body Site" />
   <status value="active" />
-  <date value="2023-04-28" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-SpecimenType.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenType.xml
@@ -17,11 +17,11 @@
     </telecom>
   </contact>
   <description value="A set of codes to record a specimen type. Selected from the following SNOMED CT UK coding system:
-&#13; - descendantOf 49755003 | Morphologically abnormal structure
-&#13; - descendantOf 105590001 | Substance
-&#13; - descendantOf 123037004 | Body structure
-&#13; - descendantOf 123038009 | Specimen
-&#13; - descendantOf 260787004 | Physical object" />
+&#13; - descendantOf 49755003 | Morphologically abnormal structure |
+&#13; - descendantOf 105590001 | Substance |
+&#13; - descendantOf 123037004 | Body structure |
+&#13; - descendantOf 123038009 | Specimen |
+&#13; - descendantOf 260787004 | Physical object |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-SpecimenType.xml
+++ b/valuesets/ValueSet-UKCore-SpecimenType.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-SpecimenType" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenType" />
-  <version value="2.2.0" />
+  <version value="2.2.1" />
   <name value="UKCoreSpecimenType" />
   <title value="UK Core Specimen Type" />
   <status value="active" />
-  <date value="2023-04-28" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-TobaccoConsumption.xml
+++ b/valuesets/ValueSet-UKCore-TobaccoConsumption.xml
@@ -17,13 +17,13 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a patients level of consciousness. Selected from the SNOMED CT UK coding system:
-&#13; - DescendantOrSelfOf 266918002 | Tobacco smoking consumption
-&#13; - 228500003 | Moist tobacco consumption
-&#13; - 228510007 | Chewed tobacco consumption
-&#13; - 228490006 | Snuff consumption
+&#13; - DescendantOrSelfOf 266918002 | Tobacco smoking consumption |
+&#13; - 228500003 | Moist tobacco consumption |
+&#13; - 228510007 | Chewed tobacco consumption |
+&#13; - 228490006 | Snuff consumption |
 &#13; - MINUS
-&#13; - 401201003 | Cigarette pack-years
-&#13; - 782516008 | Number of calculated pack years for cumulative lifetime tobacco exposure" />
+&#13; - 401201003 | Cigarette pack-years |
+&#13; - 782516008 | Number of calculated pack years for cumulative lifetime tobacco exposure |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>

--- a/valuesets/ValueSet-UKCore-TobaccoConsumption.xml
+++ b/valuesets/ValueSet-UKCore-TobaccoConsumption.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-TobaccoConsumption" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-TobaccoConsumption" />
-  <version value="0.0.1" />
+  <version value="0.1.1" />
   <name value="UKCoreTobaccoConsumption" />
   <title value="UK Core Tobacco Consumption" />
   <status value="active" />
-  <date value="2023-09-12" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-UnifiedTestList.xml
+++ b/valuesets/ValueSet-UKCore-UnifiedTestList.xml
@@ -16,8 +16,8 @@
             <rank value="1" />
         </telecom>
     </contact>
-    <description value="A set of codes regarding laboratory medicine test requests and results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
-  - memberOf 44991000237108 | Unified Test List simple reference set" />
+    <description value="A set of codes regarding laboratory medicine test requests and results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: 
+    &#xD;&#xA; - memberOf 44991000237108 | Unified Test List simple reference set |" />
     <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
     <compose>
         <include>

--- a/valuesets/ValueSet-UKCore-VaccinationProcedure.xml
+++ b/valuesets/ValueSet-UKCore-VaccinationProcedure.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-VaccinationProcedure" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-VaccinationProcedure" />
-  <version value="2.1.0" />
+  <version value="2.1.1" />
   <name value="UKCoreVaccinationProcedure" />
   <title value="UK Core Vaccination Procedure" />
   <status value="active" />
-  <date value="2021-09-10" />
+  <date value="2025-03-05" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-VaccinationProcedure.xml
+++ b/valuesets/ValueSet-UKCore-VaccinationProcedure.xml
@@ -17,10 +17,9 @@
     </telecom>
   </contact>
   <description value="A set of codes that define a vaccination procedure. Selected from the following hierarchies within the SNOMED CT UK coding system:
-
-&#13; - Active or passive immunisation;
-&#13; - Seasonal influenza vaccination given by midwife;
-&#13; - Vaccination given. &#13;&#13;" />
+&#13; - 127785005 | Active or passive immunisation |
+&#13; - 1066171000000108 | Seasonal influenza vaccination given by midwife |
+&#13; - 713404003 | Vaccination given |" />
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
   <compose>
     <include>


### PR DESCRIPTION
SNOMED CT should be written as `<code> | <description> |` with the description encased around pipes, as per https://simplifier.net/hl7fhirukcorer4/~issues/3350.

This PR addresses this issue for all SNOMED CT ValueSets.

