### PR TITLE
Fix Blood Pressure ValueSets

### DIFF
--- a/valuesets/ValueSet-UKCore-BloodPressure-Average.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure-Average.xml
@@ -32,91 +32,91 @@
     </include>
   </compose>
   <expansion>
-    <identifier value="urn:uuid:bb77c78a-fe8b-4ad7-a54b-d1f28529a53b"/>
-    <timestamp value="2025-03-31T09:30:40+00:00"/>
-    <total value="15"/>
+    <identifier value="urn:uuid:bb77c78a-fe8b-4ad7-a54b-d1f28529a53b" />
+    <timestamp value="2025-03-31T09:30:40+00:00" />
+    <total value="15" />
     <parameter>
-      <name value="used-codesystem"/>
-      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312"/>
+      <name value="used-codesystem" />
+      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312" />
     </parameter>
     <parameter>
-      <name value="version"/>
-      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312"/>
+      <name value="version" />
+      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312" />
     </parameter>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="2324511000000105"/>
-      <display value="Average 24 hour blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="2324511000000105" />
+      <display value="Average 24 hour blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="314462001"/>
-      <display value="Average 24 hour diastolic blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="314462001" />
+      <display value="Average 24 hour diastolic blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="314449000"/>
-      <display value="Average 24 hour systolic blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="314449000" />
+      <display value="Average 24 hour systolic blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="723232008"/>
-      <display value="Average blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="723232008" />
+      <display value="Average blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="251075007"/>
-      <display value="Invasive mean arterial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="251075007" />
+      <display value="Invasive mean arterial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="852291000000105"/>
-      <display value="Maximum mean blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="852291000000105" />
+      <display value="Maximum mean blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="1285244000"/>
-      <display value="Mean arterial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="1285244000" />
+      <display value="Mean arterial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="6797001"/>
-      <display value="Mean blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="6797001" />
+      <display value="Mean blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="276783005"/>
-      <display value="Mean direct left atrial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="276783005" />
+      <display value="Mean direct left atrial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="276775004"/>
-      <display value="Mean right atrial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="276775004" />
+      <display value="Mean right atrial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="276763009"/>
-      <display value="Mean wedge pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="276763009" />
+      <display value="Mean wedge pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="852301000000109"/>
-      <display value="Minimum mean blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="852301000000109" />
+      <display value="Minimum mean blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="251074006"/>
-      <display value="Non-invasive mean arterial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="251074006" />
+      <display value="Non-invasive mean arterial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="371830008"/>
-      <display value="Pulmonary vein mean wedge pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="371830008" />
+      <display value="Pulmonary vein mean wedge pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="252077001"/>
-      <display value="Venous mean pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="252077001" />
+      <display value="Venous mean pressure" />
     </contains>
   </expansion>
 </ValueSet>

--- a/valuesets/ValueSet-UKCore-BloodPressure.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure.xml
@@ -54,141 +54,141 @@
     </include>
   </compose>
   <expansion>
-    <identifier value="urn:uuid:015a592f-d21e-4879-bc46-041af118671f"/>
-    <timestamp value="2025-03-31T09:34:55+00:00"/>
-    <total value="25"/>
+    <identifier value="urn:uuid:015a592f-d21e-4879-bc46-041af118671f" />
+    <timestamp value="2025-03-31T09:34:55+00:00" />
+    <total value="25" />
     <parameter>
-      <name value="used-codesystem"/>
-      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312"/>
+      <name value="used-codesystem" />
+      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312" />
     </parameter>
     <parameter>
-      <name value="version"/>
-      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312"/>
+      <name value="version" />
+      <valueUri value="http://snomed.info/sct|http://snomed.info/sct/83821000000107/version/20250312" />
     </parameter>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="386534000"/>
-      <display value="Arterial blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="386534000" />
+      <display value="Arterial blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="87179004"/>
-      <display value="Arterial pulse pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="87179004" />
+      <display value="Arterial pulse pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="37087001"/>
-      <display value="Arterial wedge pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="37087001" />
+      <display value="Arterial wedge pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="251068006"/>
-      <display value="Atrial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="251068006" />
+      <display value="Atrial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="75367002"/>
-      <display value="Blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="75367002" />
+      <display value="Blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="71420008"/>
-      <display value="Central venous pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="71420008" />
+      <display value="Central venous pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="165077006"/>
-      <display value="Intracardiac pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="165077006" />
+      <display value="Intracardiac pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="386532001"/>
-      <display value="Invasive arterial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="386532001" />
+      <display value="Invasive arterial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="386533006"/>
-      <display value="Invasive blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="386533006" />
+      <display value="Invasive blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="37476000"/>
-      <display value="Jugular venous pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="37476000" />
+      <display value="Jugular venous pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="276760007"/>
-      <display value="Left atrial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="276760007" />
+      <display value="Left atrial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="163033001"/>
-      <display value="Lying blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="163033001" />
+      <display value="Lying blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="251076008"/>
-      <display value="Non-invasive arterial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="251076008" />
+      <display value="Non-invasive arterial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="723237002"/>
-      <display value="Non-invasive blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="723237002" />
+      <display value="Non-invasive blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="1036531000000108"/>
-      <display value="Non-invasive central blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="1036531000000108" />
+      <display value="Non-invasive central blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="163020007"/>
-      <display value="O/E - blood pressure reading"/>
+      <system value="http://snomed.info/sct" />
+      <code value="163020007" />
+      <display value="O/E - blood pressure reading" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="371829003"/>
-      <display value="Pulmonary vein wedge pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="371829003" />
+      <display value="Pulmonary vein wedge pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="276755008"/>
-      <display value="Right atrial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="276755008" />
+      <display value="Right atrial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="335661000000109"/>
-      <display value="Self measured blood pressure reading"/>
+      <system value="http://snomed.info/sct" />
+      <code value="335661000000109" />
+      <display value="Self measured blood pressure reading" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="163035008"/>
-      <display value="Sitting blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="163035008" />
+      <display value="Sitting blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="163034007"/>
-      <display value="Standing blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="163034007" />
+      <display value="Standing blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="364090009"/>
-      <display value="Systemic arterial pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="364090009" />
+      <display value="Systemic arterial pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="386536003"/>
-      <display value="Systemic blood pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="386536003" />
+      <display value="Systemic blood pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="252076005"/>
-      <display value="Venous pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="252076005" />
+      <display value="Venous pressure" />
     </contains>
     <contains>
-      <system value="http://snomed.info/sct"/>
-      <code value="76882007"/>
-      <display value="Venous wedge pressure"/>
+      <system value="http://snomed.info/sct" />
+      <code value="76882007" />
+      <display value="Venous wedge pressure" />
     </contains>
   </expansion>
 </ValueSet>


### PR DESCRIPTION
This ticket has been created to fix the following:
https://simplifier.net/hl7fhirukcorer4/valueset-ukcore-bloodpressure-average/~issues/3352
https://simplifier.net/hl7fhirukcorer4/valueset-ukcore-bloodpressure/~issues/3353

For ValueSet-UKCore-BloodPressure-Average
- removed 170599006 | 24 hr blood pressure monitoring (regime/therapy) | due to wrong Semantic Tag
- removed - 314463006 | 24 hour blood pressure (observable entity) | as not an average
- added DescendantOrSelfOf 2324511000000105 | Average 24 hour blood pressure (observable entity) |
- fixed MINUS calculation

For ValueSet-UKCore-BloodPressure
- Removed
  - 392570002 | Blood pressure finding (finding) |
  - 392571003 | Finding of arterial pulse pressure (finding) |
  - 301141002 | Finding of pulmonary arterial pressure (finding) |
  - 366161004 | Finding of venous pressure (finding) |
  - 366162006 | Finding of central venous pressure (finding) |
  - 366163001 | Finding of jugular venous pressure (finding) |
 as part of Default Exclusion Filter Reference
- Removed MINUS
  - 170599006 | 24 hr blood pressure monitoring (regime/therapy) |
  - descendantOrSelfOf 371830008 | Pulmonary vein mean wedge pressure (observable entity) |
  - descendantOrSelfOf 6797001 | Mean blood pressure (observable entity) |
  - descendantOrSelfOf 723232008 | Average blood pressure (observable entity) |
  - descendantOf 276769008 | Left ventricular pressure (observable entity) |
  - descendantOf 276756009 | Right ventricular pressure (observable entity) |
  - descendantOf 276760007 | Left atrial pressure (observable entity) |
  - descendantOf 276755008 | Right atrial pressure (observable entity) |" />
 as the codes to be added did not contain any of the minus codes so redundant. I assume this is left over from a previous iteration of this ValueSet 