### PR TITLE
renamed example pages to match id

### DIFF
--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/Index.page.md
@@ -1,0 +1,15 @@
+---
+topic: Library-Examples-Extensions
+---
+
+## Examples
+
+---
+
+## Extension Examples
+
+<div markdown="span" class="alert alert-warning" role="alert"><h4><i class="fa fa-info-circle"></i> Examples Usage</h4>
+Whilst every effort has been made to ensure that the examples are correct and useful, they are not a normative part of the specification.
+</div>
+
+---

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AdditionalContact-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AdditionalContact-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-AdditionalContact-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AddressKey-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AddressKey-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-AddressKey-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AdmissionMethod-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AdmissionMethod-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-AdmissionMethod-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AllergyIntolEnd-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AllergyIntolEnd-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-AllergyIntolEnd-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AssociatedEncounter-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-AssociatedEncounter-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-AssociatedEncounter-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BirthPlace-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BirthPlace-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-BirthPlace-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BirthSex-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BirthSex-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-BirthSex-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BirthTime-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BirthTime-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-BirthTime-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BodySiteReference-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BodySiteReference-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-BodySiteReference-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BookingOrganization-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-BookingOrganization-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-BookingOrganization-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CadavericDonor-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CadavericDonor-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CadavericDonor-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CareSettingType-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CareSettingType-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CareSettingType-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CodingSCTDescId-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CodingSCTDescId-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CodingSCTDescId-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CollectionCollector-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CollectionCollector-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CollectionCollector-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CompositionReference-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CompositionReference-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CompositionReference-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ConditionEpisode-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ConditionEpisode-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-ConditionEpisode-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ContactPreference-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ContactPreference-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-ContactPreference-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ContactRank-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ContactRank-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-ContactRank-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CopyCorrespondenceIndicator-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CopyCorrespondenceIndicator-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CopyCorrespondenceIndicator-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Coverage-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Coverage-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-Coverage-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CuffSize-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-CuffSize-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-CuffSize-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DeathNotificationStatus-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DeathNotificationStatus-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-DeathNotificationStatus-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DeliveryChannel-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DeliveryChannel-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-DeliveryChannel-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DeviceReference-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DeviceReference-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-DeviceReference-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DiagnosticReportMediaLinkR5-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DiagnosticReportMediaLinkR5-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-DiagnosticReportMediaLinkR5-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DischargeMethod-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-DischargeMethod-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-DischargeMethod-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-EmergencyCareDischargeStatus-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-EmergencyCareDischargeStatus-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-EmergencyCareDischargeStatus-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-EthnicCategory-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-EthnicCategory-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-EthnicCategory-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Evidence-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Evidence-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-Evidence-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-InterpreterRequired-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-InterpreterRequired-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-InterpreterRequired-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-LastIssueDate-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-LastIssueDate-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-MedicationStatementLastIssueDate-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-LegalStatus-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-LegalStatus-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-LegalStatus-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ListWarningCode-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ListWarningCode-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-ListWarningCode-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-MainLocation-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-MainLocation-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-MainLocation-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-MedicationPrescribingOrganizationType-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-MedicationPrescribingOrganizationType-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-MedicationPrescribingOrganizationType-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-MedicationTradeFamily-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-MedicationTradeFamily-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-MedicationTradeFamily-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-NHSNumberUnavailableReason-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-NHSNumberUnavailableReason-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-NHSNumberUnavailableReason-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-NHSNumberVerificationStatus-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-NHSNumberVerificationStatus-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-NHSNumberVerificationStatus-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Note-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Note-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-Note-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-OrganizationPeriod-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-OrganizationPeriod-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-Period-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-OtherContactSystem-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-OtherContactSystem-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-OtherContactSystem-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-OutcomeOfAttendance-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-OutcomeOfAttendance-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-OutcomeOfAttendance-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ParentPresent-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ParentPresent-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-ParentPresent-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Participant-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-Participant-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-Participant-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-PharmacistVerifiedIndicator-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-PharmacistVerifiedIndicator-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-PharmacistVerifiedIndicator-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-PriorityReason-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-PriorityReason-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-PriorityReason-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-PriorityReason-SendingAsText-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-PriorityReason-SendingAsText-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-PriorityReason-SendingAsText-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-RecordingSetting-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-RecordingSetting-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-RecordingSetting-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-RepeatInformation-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-RepeatInformation-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-RepeatInformation-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ResidentialStatus-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-ResidentialStatus-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-ResidentialStatus-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SampleCategory-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SampleCategory-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-SampleCategory-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SampleCategory-PheobeSmitham-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SampleCategory-PheobeSmitham-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject:  UKCore-Extension-SampleCategory-PheobeSmitham-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SourceOfServiceRequest-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SourceOfServiceRequest-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-SourceOfServiceRequest-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SpecialHandling-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SpecialHandling-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-SpecialHandling-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SpecimenCollectionCollector-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-SpecimenCollectionCollector-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-SpecimenCollectionCollector-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-TriggeredBy-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-TriggeredBy-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-TriggeredBy-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-VaccinationProcedure-COVID-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-VaccinationProcedure-COVID-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-VaccinationProcedure-COVID-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-VaccinationProcedure-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/UKCore-Extension-VaccinationProcedure-Example.page.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Extension-VaccinationProcedure-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/toc.yaml
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Extension-Examples/toc.yaml
@@ -1,0 +1,118 @@
+- name: Index
+  filename: Index.page.md
+- name: Example UKCore-Extension-AdditionalContact
+  filename: UKCore-Extension-AdditionalContact-Example.page.md
+- name: Example UKCore-Extension-AddressKey
+  filename: UKCore-Extension-AddressKey-Example.page.md
+- name: Example UKCore-Extension-AdmissionMethod
+  filename: UKCore-Extension-AdmissionMethod-Example.page.md
+- name: Example UKCore-Extension-AllergyIntolEnd
+  filename: UKCore-Extension-AllergyIntolEnd-Example.page.md
+- name: Example UKCore-Extension-AssociatedEncounter
+  filename: UKCore-Extension-AssociatedEncounter-Example.page.md
+- name: Example UKCore-Extension-BirthPlace
+  filename: UKCore-Extension-BirthPlace-Example.page.md
+- name: Example UKCore-Extension-BirthSex
+  filename: UKCore-Extension-BirthSex-Example.page.md
+- name: Example UKCore-Extension-BirthTime
+  filename: UKCore-Extension-BirthTime-Example.page.md
+- name: Example UKCore-Extension-BodySiteReference
+  filename: UKCore-Extension-BodySiteReference-Example.page.md
+- name: Example UKCore-Extension-BookingOrganization
+  filename: UKCore-Extension-BookingOrganization-Example.page.md
+- name: Example UKCore-Extension-CadavericDonor
+  filename: UKCore-Extension-CadavericDonor-Example.page.md
+- name: Example UKCore-Extension-CareSettingType
+  filename: UKCore-Extension-CareSettingType-Example.page.md
+- name: Example UKCore-Extension-CodingSCTDescId
+  filename: UKCore-Extension-CodingSCTDescId-Example.page.md
+- name: Example UKCore-Extension-CollectionCollector
+  filename: UKCore-Extension-CollectionCollector-Example.page.md
+- name: Example UKCore-Extension-CompositionReference
+  filename: UKCore-Extension-CompositionReference-Example.page.md
+- name: Example UKCore-Extension-ConditionEpisode
+  filename: UKCore-Extension-ConditionEpisode-Example.page.md
+- name: Example UKCore-Extension-ContactPreference
+  filename: UKCore-Extension-ContactPreference-Example.page.md
+- name: Example UKCore-Extension-ContactRank
+  filename: UKCore-Extension-ContactRank-Example.page.md
+- name: Example UKCore-Extension-CopyCorrespondenceIndicator
+  filename: UKCore-Extension-CopyCorrespondenceIndicator-Example.page.md
+- name: Example UKCore-Extension-Coverage
+  filename: UKCore-Extension-Coverage-Example.page.md
+- name: Example UKCore-Extension-CuffSize
+  filename: UKCore-Extension-CuffSize-Example.page.md
+- name: Example UKCore-Extension-DeathNotificationStatus
+  filename: UKCore-Extension-DeathNotificationStatus-Example.page.md
+- name: Example UKCore-Extension-DeliveryChannel
+  filename: UKCore-Extension-DeliveryChannel-Example.page.md
+- name: Example UKCore-Extension-DeviceReference
+  filename: UKCore-Extension-DeviceReference-Example.page.md
+- name: Example UKCore-Extension-DischargeMethod
+  filename: UKCore-Extension-DischargeMethod-Example.page.md
+- name: Example UKCore-Extension-DiagnosticReportMediaLinkR5
+  filename: UKCore-Extension-DiagnosticReportMediaLinkR5-Example.page.md
+- name: Example UKCore-Extension-EmergencyCareDischargeStatus
+  filename: UKCore-Extension-EmergencyCareDischargeStatus-Example.page.md
+- name: Example UKCore-Extension-EthnicCategory
+  filename: UKCore-Extension-EthnicCategory-Example.page.md
+- name: Example UKCore-Extension-Evidence
+  filename: UKCore-Extension-Evidence-Example.page.md
+- name: Example UKCore-Extension-InterpreterRequired
+  filename: UKCore-Extension-InterpreterRequired-Example.page.md
+- name: Example UKCore-Extension-LegalStatus
+  filename: UKCore-Extension-LegalStatus-Example.page.md
+- name: Example UKCore-Extension-LastIssueDate
+  filename: UKCore-Extension-LastIssueDate-Example.page.md
+- name: Example UKCore-Extension-ListWarningCode
+  filename: UKCore-Extension-ListWarningCode-Example.page.md
+- name: Example UKCore-Extension-MainLocation
+  filename: UKCore-Extension-MainLocation-Example.page.md
+- name: Example UKCore-Extension-MedicationPrescribingOrganizationType
+  filename: UKCore-Extension-MedicationPrescribingOrganizationType-Example.page.md
+- name: Example UKCore-Extension-MedicationTradeFamily
+  filename: UKCore-Extension-MedicationTradeFamily-Example.page.md
+- name: Example UKCore-Extension-NHSNumberUnavailableReason
+  filename: UKCore-Extension-NHSNumberUnavailableReason-Example.page.md
+- name: Example UKCore-Extension-NHSNumberVerificationStatus
+  filename: UKCore-Extension-NHSNumberVerificationStatus-Example.page.md
+- name: Example UKCore-Extension-Note
+  filename: UKCore-Extension-Note-Example.page.md
+- name: Example UKCore-Extension-OrganizationPeriod
+  filename: UKCore-Extension-OrganizationPeriod-Example.page.md
+- name: Example UKCore-Extension-OtherContactSystem
+  filename: UKCore-Extension-OtherContactSystem-Example.page.md
+- name: Example UKCore-Extension-OutcomeOfAttendance
+  filename: UKCore-Extension-OutcomeOfAttendance-Example.page.md
+- name: Example UKCore-Extension-ParentPresent
+  filename: UKCore-Extension-ParentPresent-Example.page.md
+- name: Example UKCore-Extension-Participant
+  filename: UKCore-Extension-Participant-Example.page.md
+- name: Example UKCore-Extension-PharmacistVerifiedIndicator
+  filename: UKCore-Extension-PharmacistVerifiedIndicator-Example.page.md
+- name: Example UKCore-Extension-PriorityReason
+  filename: UKCore-Extension-PriorityReason-Example.page.md
+- name: Example UKCore-Extension-PriorityReason-SendingAsText
+  filename: UKCore-Extension-PriorityReason-SendingAsText-Example.page.md
+- name: Example UKCore-Extension-RecordingSetting
+  filename: UKCore-Extension-RecordingSetting-Example.page.md
+- name: Example UKCore-Extension-RepeatInformation
+  filename: UKCore-Extension-RepeatInformation-Example.page.md
+- name: Example UKCore-Extension-ResidentialStatus
+  filename: UKCore-Extension-ResidentialStatus-Example.page.md
+- name: Example UKCore-Extension-SampleCategory
+  filename: UKCore-Extension-SampleCategory-Example.page.md
+- name: Example UKCore-Extension-SampleCategory-PheobeSmitham
+  filename: UKCore-Extension-SampleCategory-PheobeSmitham-Example.page.md
+- name: Example UKCore-Extension-SourceOfServiceRequest
+  filename: UKCore-Extension-SourceOfServiceRequest-Example.page.md
+- name: Example UKCore-Extension-SpecialHandling
+  filename: UKCore-Extension-SpecialHandling-Example.page.md
+- name: Example UKCore-Extension-SpecimenCollectionCollector
+  filename: UKCore-Extension-SpecimenCollectionCollector-Example.page.md
+- name: Example UKCore-Extension-TriggeredBy
+  filename: UKCore-Extension-TriggeredBy-Example.page.md
+- name: Example UKCore-Extension-VaccinationProcedure
+  filename: UKCore-Extension-VaccinationProcedure-Example.page.md
+- name: Example UKCore-Extension-VaccinationProcedure-COVID
+  filename: UKCore-Extension-VaccinationProcedure-COVID-Example.page.md

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/Index.page.md
@@ -1,0 +1,15 @@
+---
+topic: Library-Examples-Profiles
+---
+
+## Examples
+
+---
+
+## Profile Examples
+
+<div markdown="span" class="alert alert-warning" role="alert"><h4><i class="fa fa-info-circle"></i> Examples Usage</h4>
+Whilst every effort has been made to ensure that the examples are correct and useful, they are not a normative part of the specification.
+</div>
+
+---

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-AllergyIntolerance-Amoxicillin.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-AllergyIntolerance-Amoxicillin.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-AllergyIntolerance-Amoxicillin-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-AllergyIntolerance-EnteredInError.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-AllergyIntolerance-EnteredInError.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-AllergyIntolerance-EnteredInError-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Appointment-OrthopaedicSurgery.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Appointment-OrthopaedicSurgery.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Appointment-OrthopaedicSurgery-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Bundle-AllergyList.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Bundle-AllergyList.page.md-Example.md
@@ -1,0 +1,7 @@
+---
+subject: UKCore-Bundle-AllergyList-Example
+---
+
+### An example to illustrate a bundled allergy list 
+
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Bundle-NEWS2Observations.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Bundle-NEWS2Observations.page.md-Example.md
@@ -1,0 +1,6 @@
+---
+subject: UKCore-Bundle-NEWS2Observations-Example
+---
+### An example to illustrate a bundle of NEWS2 observations and a Total Score observation
+
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Composition-Discharge.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Composition-Discharge.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Composition-Discharge-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Condition-BleedingFromEar.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Condition-BleedingFromEar.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Condition-BleedingFromEar-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Condition-HipReplacement.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Condition-HipReplacement.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Condition-HipReplacement-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Consent-ForInformationAccess.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Consent-ForInformationAccess.page.md-Example.md
@@ -1,0 +1,6 @@
+---
+subject: UKCore-Consent-ForInformationAccess-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}
+
+

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Device-SoftwareAsAMedicalDevice.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Device-SoftwareAsAMedicalDevice.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Device-SoftwareAsAMedicalDevice-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Device-Sphygmomanometer.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Device-Sphygmomanometer.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Device-Sphygmomanometer-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-CTChestScan.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-CTChestScan.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-DiagnosticReport-CTChestScan-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-DiagnosticStudiesReport.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-DiagnosticStudiesReport.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-DiagnosticReport-Lab-DiagnosticStudiesReport-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-ECG.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-ECG.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-DiagnosticReport-ECG-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-Lab-DiagnosticStudiesReport.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DiagnosticReport-Lab-DiagnosticStudiesReport.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-DiagnosticReport-Lab-DiagnosticStudiesReport-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DocumentReference-ECG.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-DocumentReference-ECG.page.md-Example.md
@@ -1,0 +1,5 @@
+---
+subject: UKCore-DocumentReference-ECG-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}
+

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Encounter-InpatientEncounter.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Encounter-InpatientEncounter.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Encounter-InpatientEncounter-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-FamilyMemberHistory-FatherDiabetes.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-FamilyMemberHistory-FatherDiabetes.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-FamilyMemberHistory-FatherDiabetes-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-HealthcareService-OrthopaedicService.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-HealthcareService-OrthopaedicService.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-HealthcareService-OrthopaedicService-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ImagingStudy-CTChestScan.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ImagingStudy-CTChestScan.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-ImagingStudy-CTChestScan-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Immunization-InfluenzaVaccine.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Immunization-InfluenzaVaccine.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Immunization-InfluenzaVaccine-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-List-EmptyList.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-List-EmptyList.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-List-EmptyList-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Location-CardiologySJUH.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Location-CardiologySJUH.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Location-CardiologySJUH-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Location-GeneralPracticeNurseClinic.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Location-GeneralPracticeNurseClinic.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Location-GeneralPracticeNurseClinic-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Location-HospitalSJUH.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Location-HospitalSJUH.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Location-HospitalSJUH-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Medication-COVID-Vaccine.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Medication-COVID-Vaccine.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Medication-COVID-Vaccine-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Medication-TimololVTM.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Medication-TimololVTM.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Medication-TimololVTM-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Medication-TimoptolEyeDrops.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Medication-TimoptolEyeDrops.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Medication-TimoptolEyeDrops-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationAdministration-TimoptolEyeDrops.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationAdministration-TimoptolEyeDrops.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-MedicationAdministration-TimoptolEyeDrops-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationDispense-EyeDrops.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationDispense-EyeDrops.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-MedicationDispense-EyeDrops-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationRequest-EyeDrops.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationRequest-EyeDrops.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-MedicationRequest-EyeDrops-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationStatement-Amoxicillin.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-MedicationStatement-Amoxicillin.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-MedicationStatement-Amoxicillin-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-24HourBloodPressure.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-24HourBloodPressure.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-24HourBloodPressure-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-AwarenessOfDiagnosis.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-AwarenessOfDiagnosis.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-AwarenessOfDiagnosis-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-BreathingNormally.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-BreathingNormally.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-BreathingNormally-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-DrugUse.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-DrugUse.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-DrugUse-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-FastingTest.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-FastingTest.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-FastingTest-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-FingerJointInflamed.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-FingerJointInflamed.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-FingerJointInflamed-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-Group-FullBloodCount.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-Group-FullBloodCount.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-Group-FullBloodCount-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-HeavyDrinker.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-HeavyDrinker.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-HeavyDrinker-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-Lab-RedCellCount.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-Lab-RedCellCount.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-Lab-RedCellCount-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-Lab-WhiteCellCount.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-Lab-WhiteCellCount.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-Lab-WhiteCellCount-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-NPEWSTotal.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-NPEWSTotal.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-NPEWSTotal-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-OxygenTherapy.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-OxygenTherapy.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-OxygenTherapy-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-PatientConsciousness.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-PatientConsciousness.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-PatientConsciousness-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-PipeSmoker.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-PipeSmoker.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-PipeSmoker-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BMI.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BMI.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-BMI-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BloodPressure.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BloodPressure.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-BloodPressure-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BodyHeight.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BodyHeight.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-BodyHeight-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BodyTemperature.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BodyTemperature.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-BodyTemperature-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BodyWeight.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-BodyWeight.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-BodyWeight-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-HeadCircumference.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-HeadCircumference.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-HeadCircumference-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-HeartRate.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-HeartRate.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-HeartRate-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-OxygenSaturation.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-OxygenSaturation.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-OxygenSaturation-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-RespiratoryRate.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Observation-VitalSigns-RespiratoryRate.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Observation-VitalSigns-RespiratoryRate-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Organization-LeedsTeachingHospital.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Organization-LeedsTeachingHospital.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Organization-LeedsTeachingHospital-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Organization-WhiteRoseMedicalCentre.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Organization-WhiteRoseMedicalCentre.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Organization-WhiteRoseMedicalCentre-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Patient-BabyPatient.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Patient-BabyPatient.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Patient-BabyPatient-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Patient-RichardSmith.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Patient-RichardSmith.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Patient-RichardSmith-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Practitioner-ConsultantSandraGose.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Practitioner-ConsultantSandraGose.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Practitioner-ConsultantSandraGose-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Practitioner-DoctorPaulRastall.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Practitioner-DoctorPaulRastall.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Practitioner-DoctorPaulRastall-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Practitioner-PharmacistJimmyChuck.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Practitioner-PharmacistJimmyChuck.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Practitioner-PharmacistJimmyChuck-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-PractitionerRole-GP.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-PractitionerRole-GP.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-PractitionerRole-GeneralPractitioner-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Procedure-ExaminationOfSkin.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Procedure-ExaminationOfSkin.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Procedure-ExaminationOfSkin-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-RelatedPerson-JoySmith.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-RelatedPerson-JoySmith.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-RelatedPerson-JoySmith-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Schedule-Immunization.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Schedule-Immunization.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Schedule-Immunization-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-CTChestScan.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-CTChestScan.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-ServiceRequest-CTChestScan-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-ColonoscopyRequest.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-ColonoscopyRequest.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-ServiceRequest-ColonoscopyRequest-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-ECG.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-ECG.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-ServiceRequest-ECG-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-Lab-CReactiveProtein.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-ServiceRequest-Lab-CReactiveProtein.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-ServiceRequest-Lab-CReactiveProtein-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Slot-AvailableWalkInVisit.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Slot-AvailableWalkInVisit.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Slot-AvailableWalkInVisit-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Specimen-BloodSpecimen.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Specimen-BloodSpecimen.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Specimen-BloodSpecimen-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Specimen-UrineSpecimen.page.md-Example.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-Specimen-UrineSpecimen.page.md-Example.md
@@ -1,0 +1,4 @@
+---
+subject: UKCore-Specimen-UrineSpecimen-Example
+---
+{{page:Home/Examples/ExampleTemplate.page.md}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/toc.yaml
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/toc.yaml
@@ -1,0 +1,148 @@
+- name: Index
+  filename: Index.page.md
+- name: Example UKCore-AllergyIntolerance-Amoxicillin
+  filename: UKCore-AllergyIntolerance-Amoxicillin-Example.page.md
+- name: Example UKCore-AllergyIntolerance-EnteredInError
+  filename: UKCore-AllergyIntolerance-EnteredInError-Example.page.md
+- name: Example UKCore-Appointment-OrthopaedicSurgery
+  filename: UKCore-Appointment-OrthopaedicSurgery-Example.page.md
+- name: Example UKCore-Bundle-AllergyList
+  filename: UKCore-Bundle-AllergyList-Example.page.md
+- name: Example UKCore-Bundle-NEWS2Observations
+  filename: UKCore-Bundle-NEWS2Observations-Example.page.md
+- name: Example UKCore-Composition-Discharge
+  filename: UKCore-Composition-Discharge-Example.page.md
+- name: Example UKCore-Condition-BleedingFromEar
+  filename: UKCore-Condition-BleedingFromEar-Example.page.md
+- name: Example UKCore-Condition-HipReplacement
+  filename: UKCore-Condition-HipReplacement-Example.page.md
+- name: Example UKCore-Consent-ForInformationAccess
+  filename: UKCore-Consent-ForInformationAccess-Example.page.md
+- name: Example UKCore-DiagnosticReport-CTChestScan
+  filename: UKCore-DiagnosticReport-CTChestScan-Example.page.md
+- name: Example UKCore-DiagnosticReport-DiagnosticStudiesReport
+  filename: UKCore-DiagnosticReport-DiagnosticStudiesReport-Example.page.md
+- name: Example UKCore-DiagnosticReport-ECG
+  filename: UKCore-DiagnosticReport-ECG-Example.page.md
+- name: Example UKCore-DiagnosticReport-Lab-DiagnosticStudiesReport
+  filename: UKCore-DiagnosticReport-Lab-DiagnosticStudiesReport-Example.page.md
+- name: Example UKCore-Device-SoftwareAsAMedicalDevice
+  filename: UKCore-Device-SoftwareAsAMedicalDevice-Example.page.md
+- name: Example UKCore-Device-Sphygmomanometer
+  filename: UKCore-Device-Sphygmomanometer-Example.page.md
+- name: Example UKCore-DocumentReference-ECG
+  filename: UKCore-DocumentReference-ECG-Example.page.md
+- name: Example UKCore-Encounter-InpatientEncounter
+  filename: UKCore-Encounter-InpatientEncounter-Example.page.md
+- name: Example UKCore-FamilyMemberHistory-FatherDiabetes
+  filename: UKCore-FamilyMemberHistory-FatherDiabetes-Example.page.md
+- name: Example UKCore-HealthcareService-OrthopaedicService
+  filename: UKCore-HealthcareService-OrthopaedicService-Example.page.md
+- name: Example UKCore-ImagingStudy-CTChestScan
+  filename: UKCore-ImagingStudy-CTChestScan-Example.page.md
+- name: Example UKCore-Immunization-InfluenzaVaccine
+  filename: UKCore-Immunization-InfluenzaVaccine-Example.page.md
+- name: Example UKCore-List-EmptyList
+  filename: UKCore-List-EmptyList-Example.page.md
+- name: Example UKCore-Location-GeneralPracticeNurseClinic
+  filename: UKCore-Location-GeneralPracticeNurseClinic-Example.page.md
+- name: Example UKCore-Location-CardiologySJUH
+  filename: UKCore-Location-CardiologySJUH-Example.page.md
+- name: Example UKCore-Location-HospitalSJUH
+  filename: UKCore-Location-HospitalSJUH-Example.page.md
+- name: Example UKCore-Medication-COVID-Vaccine
+  filename: UKCore-Medication-COVID-Vaccine-Example.page.md
+- name: Example UKCore-Medication-TimololVTM
+  filename: UKCore-Medication-TimololVTM-Example.page.md
+- name: Example UKCore-Medication-TimoptolEyeDrops
+  filename: UKCore-Medication-TimoptolEyeDrops-Example.page.md
+- name: Example UKCore-MedicationAdministration-TimoptolEyeDrops
+  filename: UKCore-MedicationAdministration-TimoptolEyeDrops-Example.page.md
+- name: Example UKCore-MedicationDispense-EyeDrops
+  filename: UKCore-MedicationDispense-EyeDrops-Example.page.md
+- name: Example UKCore-MedicationRequest-EyeDrops
+  filename: UKCore-MedicationRequest-EyeDrops-Example.page.md
+- name: Example UKCore-MedicationStatement-Amoxicillin
+  filename: UKCore-MedicationStatement-Amoxicillin-Example.page.md
+- name: Example UKCore-Observation-24HourBloodPressure
+  filename: UKCore-Observation-24HourBloodPressure-Example.page.md
+- name: Example UKCore-Observation-AwarenessOfDiagnosis
+  filename: UKCore-Observation-AwarenessOfDiagnosis-Example.page.md
+- name: Example UKCore-Observation-BreathingNormally
+  filename: UKCore-Observation-BreathingNormally-Example.page.md
+- name: Example UKCore-Observation-DrugUse
+  filename: UKCore-Observation-DrugUse-Example.page.md
+- name: Example UKCore-Observation-FastingTest
+  filename: UKCore-Observation-FastingTest-Example.page.md
+- name: Example UKCore-Observation-FingerJointInflamed
+  filename: UKCore-Observation-FingerJointInflamed-Example.page.md
+- name: Example UKCore-Observation-Group-FullBloodCount
+  filename: UKCore-Observation-Group-FullBloodCount-Example.page.md
+- name: Example UKCore-Observation-HeavyDrinker
+  filename: UKCore-Observation-HeavyDrinker-Example.page.md
+- name: Example UKCore-Observation-Lab-RedCellCount
+  filename: UKCore-Observation-Lab-RedCellCount-Example.page.md
+- name: Example UKCore-Observation-Lab-WhiteCellCount
+  filename: UKCore-Observation-Lab-WhiteCellCount-Example.page.md
+- name: Example UKCore-Observation-NPEWSTotal
+  filename: UKCore-Observation-NPEWSTotal-Example.page.md
+- name: Example UKCore-Observation-OxygenTherapy
+  filename: UKCore-Observation-OxygenTherapy-Example.page.md
+- name: Example UKCore-Observation-PatientConsciousness
+  filename: UKCore-Observation-PatientConsciousness-Example.page.md
+- name: Example UKCore-Observation-PipeSmoker
+  filename: UKCore-Observation-PipeSmoker-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-BloodPressure
+  filename: UKCore-Observation-VitalSigns-BloodPressure-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-BMI
+  filename: UKCore-Observation-VitalSigns-BMI-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-BodyHeight
+  filename: UKCore-Observation-VitalSigns-BodyHeight-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-BodyTemperature
+  filename: UKCore-Observation-VitalSigns-BodyTemperature-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-BodyWeight
+  filename: UKCore-Observation-VitalSigns-BodyWeight-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-HeadCircumference
+  filename: UKCore-Observation-VitalSigns-HeadCircumference-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-HeartRate
+  filename: UKCore-Observation-VitalSigns-HeartRate-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-OxygenSaturation
+  filename: UKCore-Observation-VitalSigns-OxygenSaturation-Example.page.md
+- name: Example UKCore-Observation-VitalSigns-RespiratoryRate
+  filename: UKCore-Observation-VitalSigns-RespiratoryRate-Example.page.md
+- name: Example UKCore-Organization-WhiteRoseMedicalCentre
+  filename: UKCore-Organization-WhiteRoseMedicalCentre-Example.page.md
+- name: Example UKCore-Organization-LeedsTeachingHospital
+  filename: UKCore-Organization-LeedsTeachingHospital-Example.page.md
+- name: Example UKCore-Patient-BabyPatient
+  filename: UKCore-Patient-BabyPatient-Example.page.md
+- name: Example UKCore-Patient-RichardSmith
+  filename: UKCore-Patient-RichardSmith-Example.page.md
+- name: Example UKCore-Practitioner-ConsultantSandraGose
+  filename: UKCore-Practitioner-ConsultantSandraGose-Example.page.md
+- name: Example UKCore-Practitioner-DoctorPaulRastall
+  filename: UKCore-Practitioner-DoctorPaulRastall-Example.page.md
+- name: Example UKCore-Practitioner-PharmacistJimmyChuck
+  filename: UKCore-Practitioner-PharmacistJimmyChuck-Example.page.md
+- name: Example UKCore-PractitionerRole-GP
+  filename: UKCore-PractitionerRole-GP-Example.page.md
+- name: Example UKCore-Procedure-ExaminationOfSkin
+  filename: UKCore-Procedure-ExaminationOfSkin-Example.page.md
+- name: Example UKCore-RelatedPerson-JoySmith
+  filename: UKCore-RelatedPerson-JoySmith-Example.page.md
+- name: Example UKCore-Schedule-Immunization
+  filename: UKCore-Schedule-Immunization-Example.page.md
+- name: Example UKCore-ServiceRequest-ColonoscopyRequest
+  filename: UKCore-ServiceRequest-ColonoscopyRequest-Example.page.md
+- name: Example UKCore-ServiceRequest-CTChestScan
+  filename: UKCore-ServiceRequest-CTChestScan-Example.page.md
+- name: Example UKCore-ServiceRequest-ECG
+  filename: UKCore-ServiceRequest-ECG-Example.page.md
+- name: Example UKCore-ServiceRequest-Lab-CReactiveProtein
+  filename: UKCore-ServiceRequest-Lab-CReactiveProtein-Example.page.md
+- name: Example UKCore-Slot-AvailableWalkInVisit
+  filename: UKCore-Slot-AvailableWalkInVisit-Example.page.md
+- name: Example UKCore-Specimen-BloodSpecimen
+  filename: UKCore-Specimen-BloodSpecimen-Example.page.md
+- name: Example UKCore-Specimen-UrineSpecimen
+  filename: UKCore-Specimen-UrineSpecimen-Example.page.md


### PR DESCRIPTION
Used to following code to make mass changes to replace Example-<name> with <name>-Example :

`sed -i -E 's/filename: Example-([^ ]+)\.page\.md/filename: \1-Example.page.md/' toc.yaml` in toc  
`for f in Example-*.md; do mv "$f" "${f#Example-}-Example.md"; done` for .md files