### PR TITLE
added profiles to align to EU Lab

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
     "hl7.fhir.r5.core": "5.0.0",
-    "hl7.fhir.eu.laboratory": "0.1.1"
+    "hl7.fhir.eu.laboratory": "0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "hl7.fhir.r5.core": "5.0.0"
+    "hl7.fhir.r5.core": "5.0.0",
+    "hl7.fhir.eu.laboratory": "0.1.1"
   }
 }

--- a/structuredefinitions/UKCore-Composition-Lab.xml
+++ b/structuredefinitions/UKCore-Composition-Lab.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-Composition-Lab" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Composition-Lab" />
+  <version value="2.4.0" />
+  <name value="UKCoreCompositionLab" />
+  <title value="UK Core Composition Lab" />
+  <status value="draft" />
+  <date value="2025-05-13" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Composition](https://hl7.org/fhir/R4/Composition.html)." />
+  <purpose value="This profile allows a record of a set of healthcare-related information that is assembled together into a single logical package that provides a single coherent statement of meaning, establishes its own context and that has clinical attestation with regard to who is making the statement. &#xD;&#xA;&#xD;&#xA;A Composition defines the structure and narrative content necessary for a document. However, a Composition alone does not constitute a document. Rather, the Composition SHALL be the first entry in a Bundle where `Bundle.type=document`, and any other resources referenced from Composition SHALL be included as subsequent entries in the Bundle, for example Patient, Practitioner, Encounter, etc." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Composition" />
+  <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/Composition-eu-lab" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Composition">
+      <path value="Composition" />
+      <definition value="A set of healthcare-related information that is assembled together into a single logical package that provides a single coherent statement of meaning, establishes its own context and that has clinical attestation with regard to who is making the statement. A Composition defines the structure and narrative content necessary for a document. However, a Composition alone does not constitute a document. Rather, the Composition SHALL be the first entry in a Bundle where Bundle.type=document, and any other resources referenced from Composition SHALL be included as subsequent entries in the Bundle, for example Patient, Practitioner, Encounter, etc." />
+    </element>
+    <element id="Composition.extension:careSettingType">
+      <path value="Composition.extension" />
+      <sliceName value="careSettingType" />
+      <short value="Used to support the type of care setting associated with a composition or a list." />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CareSettingType" />
+      </type>
+    </element>
+    <element id="Composition.status">
+      <path value="Composition.status" />
+      <short value="The workflow / clinical status of this composition." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Composition.type">
+      <path value="Composition.type" />
+      <short value="Specifies the particular kind of composition." />
+      <mustSupport value="true" />
+      <binding>
+        <strength value="preferred" />
+        <description value="SNOMED CT Document Type" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-DocumentType" />
+      </binding>
+    </element>
+    <element id="Composition.category">
+      <path value="Composition.category" />
+      <binding>
+        <strength value="preferred" />
+        <description value="A ValueSet to identify the category of a composition." />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-CompositionCategory" />
+      </binding>
+    </element>
+    <element id="Composition.subject">
+      <path value="Composition.subject" />
+      <short value="Who and / or what the composition is about." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Composition.author">
+      <path value="Composition.author" />
+      <short value="Identifies who is responsible for the information in the composition." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Composition.confidentiality">
+      <path value="Composition.confidentiality" />
+      <short value="The code specifying the level of confidentiality of the Composition." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Composition.custodian">
+      <path value="Composition.custodian" />
+      <short value="Identifies the organization or group who is responsible for ongoing maintenance of and access to the composition/document information." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Composition.section.code">
+      <path value="Composition.section.code" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-CompositionSectionCode" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -88,10 +88,10 @@
             <path value="DiagnosticReport.category" />
                   <slicing>
         <discriminator>
-          <type value="value"/>
-          <path value="$this"/>
+          <type value="value" />
+          <path value="$this" />
         </discriminator>
-        <rules value="open"/>
+        <rules value="open" />
       </slicing>
             <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
             <min value="1" />

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -84,19 +84,6 @@
             <short value="The status of the diagnostic report." />
             <mustSupport value="true" />
         </element>
-        <element id="DiagnosticReport.category">
-            <path value="DiagnosticReport.category" />
-                  <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="$this" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-            <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
-            <min value="1" />
-            <mustSupport value="true" />
-        </element>
         <element id="DiagnosticReport.category:laboratory">
             <path value="DiagnosticReport.category" />
             <sliceName value="laboratory" />

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -86,13 +86,13 @@
         </element>
         <element id="DiagnosticReport.category">
             <path value="DiagnosticReport.category" />
-            <slicing>
-                <discriminator>
-                    <type value="value" />
-                    <path value="coding.code" />
-                </discriminator>
-                <rules value="open" />
-            </slicing>
+                  <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="$this"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
             <short value="A code that classifies the clinical discipline, department or diagnostic service that created the report." />
             <min value="1" />
             <mustSupport value="true" />
@@ -121,16 +121,6 @@
                 <strength value="preferred" />
                 <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode" />
             </binding>
-        </element>
-        <element id="DiagnosticReport.subject">
-            <path value="DiagnosticReport.subject" />
-            <short value="The patient that is the subject of the report." />
-            <min value="1" />
-            <type>
-                <code value="Reference" />
-                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-            </type>
-            <mustSupport value="true" />
         </element>
         <element id="DiagnosticReport.issued">
             <path value="DiagnosticReport.issued" />

--- a/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
+++ b/structuredefinitions/UKCore-DiagnosticReport-Lab.xml
@@ -5,7 +5,7 @@
     <name value="UKCoreDiagnosticReportLab" />
     <title value="UK Core Diagnostic Report Lab" />
     <status value="active" />
-    <date value="2024-07-23" />
+    <date value="2025-05-13" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />
@@ -23,7 +23,7 @@
     <kind value="resource" />
     <abstract value="false" />
     <type value="DiagnosticReport" />
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" />
+    <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/DiagnosticReport-eu-lab" />
     <derivation value="constraint" />
     <differential>
         <element id="DiagnosticReport">

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -5,7 +5,7 @@
     <name value="UKCoreObservationLab" />
     <title value="UK Core Observation Lab" />
     <status value="active" />
-    <date value="2024-07-23" />
+    <date value="2025-05-13" />
     <publisher value="HL7 UK" />
     <contact>
         <name value="HL7 UK" />
@@ -23,7 +23,7 @@
     <kind value="resource" />
     <abstract value="false" />
     <type value="Observation" />
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
+    <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/Observation-resultslab-eu-lab" />
     <derivation value="constraint" />
     <differential>
         <element id="Observation">

--- a/structuredefinitions/UKCore-Observation-Lab.xml
+++ b/structuredefinitions/UKCore-Observation-Lab.xml
@@ -85,19 +85,6 @@
             <short value="The status of the result value." />
             <mustSupport value="true" />
         </element>
-        <element id="Observation.category">
-            <path value="Observation.category" />
-            <slicing>
-                <discriminator>
-                    <type value="value" />
-                    <path value="coding.code" />
-                </discriminator>
-                <rules value="open" />
-            </slicing>
-            <short value="A code that classifies the general type of observation being made." />
-            <min value="1" />
-            <mustSupport value="true" />
-        </element>
         <element id="Observation.category:laboratory">
             <path value="Observation.category" />
             <sliceName value="laboratory" />
@@ -122,25 +109,6 @@
                 <strength value="preferred" />
                 <description value="A code from the SNOMED Clinical Terminology UK coding system regarding laboratory medicine test results" />
                 <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables" />
-            </binding>
-        </element>
-        <element id="Observation.subject">
-            <path value="Observation.subject" />
-            <type>
-                <code value="Reference" />
-                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-            </type>
-        </element>
-        <element id="Observation.bodySite">
-            <path value="Observation.bodySite" />
-            <binding>
-                <strength value="preferred" />
-            </binding>
-        </element>
-        <element id="Observation.method">
-            <path value="Observation.method" />
-            <binding>
-                <strength value="preferred" />
             </binding>
         </element>
     </differential>

--- a/structuredefinitions/UKCore-Patient-Lab.xml
+++ b/structuredefinitions/UKCore-Patient-Lab.xml
@@ -1,0 +1,323 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-Patient-Lab" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient-Lab" />
+  <version value="2.6.1" />
+  <name value="UKCorePatientLab" />
+  <title value="UK Core Patient Lab" />
+  <status value="draft" />
+  <date value="2025-05-13" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Patient](https://hl7.org/fhir/R4/Patient.html)." />
+  <purpose value="This profile allows exchange of demographics and other administrative information about an individual receiving care or other health-related services." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Patient" />
+  <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/Patient-eu-lab" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Patient.extension:birthPlace">
+      <path value="Patient.extension" />
+      <sliceName value="birthPlace" />
+      <short value="The registered place of birth of the patient." />
+      <definition value="The registered place of birth of the patient." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthPlace" />
+      </type>
+    </element>
+    <element id="Patient.extension:birthPlace.value[x]">
+      <path value="Patient.extension.value[x]" />
+      <short value="The registered place of birth of the patient." />
+    </element>
+    <element id="Patient.extension:birthSex">
+      <path value="Patient.extension" />
+      <sliceName value="birthSex" />
+      <short value="The patient's phenotypic sex at birth." />
+      <definition value="The patient's phenotypic sex at birth." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex" />
+      </type>
+    </element>
+    <element id="Patient.extension:cadavericDonor">
+      <path value="Patient.extension" />
+      <sliceName value="cadavericDonor" />
+      <short value="Post-mortem donor status." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/patient-cadavericDonor" />
+      </type>
+    </element>
+    <element id="Patient.extension:cadavericDonor.value[x]">
+      <path value="Patient.extension.value[x]" />
+      <short value="Post-mortem donor status." />
+      <definition value="Flag indicating whether the patient authorized the donation of body parts after death." />
+    </element>
+    <element id="Patient.extension:contactPreference">
+      <path value="Patient.extension" />
+      <sliceName value="contactPreference" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference" />
+      </type>
+    </element>
+    <element id="Patient.extension:deathNotificationStatus">
+      <path value="Patient.extension" />
+      <sliceName value="deathNotificationStatus" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeathNotificationStatus" />
+      </type>
+    </element>
+    <element id="Patient.extension:ethnicCategory">
+      <path value="Patient.extension" />
+      <sliceName value="ethnicCategory" />
+      <short value="The ethnicity of the subject." />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory" />
+      </type>
+    </element>
+    <element id="Patient.extension:fetalStatus">
+      <path value="Patient.extension" />
+      <sliceName value="fetalStatus" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/6.0/StructureDefinition/extension-Patient.fetalStatus" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Patient.extension:residentialStatus">
+      <path value="Patient.extension" />
+      <sliceName value="residentialStatus" />
+      <short value="The residential status of the patient." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ResidentialStatus" />
+      </type>
+    </element>
+    <element id="Patient.extension:patientInterpreterRequired">
+      <path value="Patient.extension" />
+      <sliceName value="patientInterpreterRequired" />
+      <short value="Indicator showing whether the patient needs an interpreter." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired" />
+      </type>
+    </element>
+    <element id="Patient.extension:patientInterpreterRequired.value[x]">
+      <path value="Patient.extension.value[x]" />
+      <short value="Indicator showing whether the patient needs an interpreter" />
+      <definition value="Indicator showing if this Patient requires an interpreter to communicate healthcare information to the practitioner." />
+    </element>
+    <element id="Patient.extension:nhsNumberUnavailableReason">
+      <path value="Patient.extension" />
+      <sliceName value="nhsNumberUnavailableReason" />
+      <short value="Reason why this Patient does not include an NHS Number identifier." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberUnavailableReason" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Patient.identifier">
+      <path value="Patient.identifier" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <ordered value="false" />
+        <rules value="open" />
+      </slicing>
+      <short value="An identifier for this patient." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.identifier:nhsNumber">
+      <path value="Patient.identifier" />
+      <sliceName value="nhsNumber" />
+      <short value="The patient's NHS number." />
+      <max value="1" />
+      <mustSupport value="false" />
+    </element>
+    <element id="Patient.identifier:nhsNumber.extension:nhsNumberVerificationStatus">
+      <path value="Patient.identifier.extension" />
+      <sliceName value="nhsNumberVerificationStatus" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus" />
+      </type>
+      <mustSupport value="false" />
+    </element>
+    <element id="Patient.identifier:nhsNumber.system">
+      <path value="Patient.identifier.system" />
+      <min value="1" />
+      <fixedUri value="https://fhir.nhs.uk/Id/nhs-number" />
+    </element>
+    <element id="Patient.identifier:nhsNumber.value">
+      <path value="Patient.identifier.value" />
+      <min value="1" />
+    </element>
+    <element id="Patient.active">
+      <path value="Patient.active" />
+      <short value="Whether this patient's record is in active use." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.name">
+      <path value="Patient.name" />
+      <short value="A name associated with the patient." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.telecom">
+      <path value="Patient.telecom" />
+      <short value="A contact detail for the individual." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.telecom.system.extension:otherContactSystem">
+      <path value="Patient.telecom.system.extension" />
+      <sliceName value="otherContactSystem" />
+      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
+      </type>
+    </element>
+    <element id="Patient.gender">
+      <path value="Patient.gender" />
+      <short value="The gender that the patient is considered to have for administration and record keeping purposes." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.birthDate">
+      <path value="Patient.birthDate" />
+      <short value="The date of birth for the individual." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.birthDate.extension:birthTime">
+      <path value="Patient.birthDate.extension" />
+      <sliceName value="birthTime" />
+      <short value="The time of day that the patient was born. This SHOULD be included when the birth time is relevant." />
+      <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/patient-birthTime" />
+      </type>
+    </element>
+    <element id="Patient.birthDate.extension:birthTime.value[x]">
+      <path value="Patient.birthDate.extension.value[x]" />
+      <short value="Time of day of birth." />
+      <definition value="The time of day that the patient was born. This includes the date to ensure that the timezone information can be communicated effectively." />
+    </element>
+    <element id="Patient.address">
+      <path value="Patient.address" />
+      <mustSupport value="true" />
+    </element>
+    <element id="Patient.address.extension:addressKey">
+      <path value="Patient.address.extension" />
+      <sliceName value="addressKey" />
+      <short value="A patient's address key and type" />
+      <definition value="A patient's address key and type." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey" />
+      </type>
+      <mustSupport value="false" />
+    </element>
+    <element id="Patient.maritalStatus">
+      <path value="Patient.maritalStatus" />
+      <binding>
+        <strength value="extensible" />
+        <description value="An indicator to identify the legal marital status of a person" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonMaritalStatusCode" />
+      </binding>
+    </element>
+    <element id="Patient.contact.extension:contactRank">
+      <path value="Patient.contact.extension" />
+      <sliceName value="contactRank" />
+      <short value="The preferred ranking or order of contact applied to a contact on a Patient's contact list." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactRank" />
+      </type>
+    </element>
+    <element id="Patient.contact.extension:copyCorrespondenceIndicator">
+      <path value="Patient.contact.extension" />
+      <sliceName value="copyCorrespondenceIndicator" />
+      <short value="Indicates that a must be copied in to all related correspondence." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CopyCorrespondenceIndicator" />
+      </type>
+    </element>
+    <element id="Patient.contact.relationship">
+      <path value="Patient.contact.relationship" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PersonRelationshipType" />
+      </binding>
+    </element>
+    <element id="Patient.contact.telecom.system.extension:otherContactSystem">
+      <path value="Patient.contact.telecom.system.extension" />
+      <sliceName value="otherContactSystem" />
+      <short value="Information about other contact methods which could be used in addition to those listed in `ContactPoint.system`." />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem" />
+      </type>
+    </element>
+    <element id="Patient.communication.extension:proficiency">
+      <path value="Patient.communication.extension" />
+      <sliceName value="proficiency" />
+      <short value="The patient's proficiency level of the communication method." />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/patient-proficiency" />
+      </type>
+    </element>
+    <element id="Patient.communication.extension:proficiency.extension:level">
+      <path value="Patient.communication.extension.extension" />
+      <sliceName value="level" />
+    </element>
+    <element id="Patient.communication.extension:proficiency.extension:level.value[x]">
+      <path value="Patient.communication.extension.extension.value[x]" />
+      <short value="The proficiency level for the communication" />
+      <definition value="The proficiency level for the communication." />
+    </element>
+    <element id="Patient.communication.extension:proficiency.extension:type">
+      <path value="Patient.communication.extension.extension" />
+      <sliceName value="type" />
+    </element>
+    <element id="Patient.communication.extension:proficiency.extension:type.value[x]">
+      <path value="Patient.communication.extension.extension.value[x]" />
+      <short value="The proficiency type for the communication" />
+      <definition value="The proficiency type for the communication." />
+    </element>
+    <element id="Patient.communication.language">
+      <path value="Patient.communication.language" />
+      <short value="A ValueSet that identifies the language used by a person." />
+      <definition value="A ValueSet that identifies the language used by a person." />
+      <binding>
+        <strength value="required" />
+        <description value="A ValueSet that identifies the language used by a person." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/all-languages" />
+      </binding>
+    </element>
+    <element id="Patient.managingOrganization">
+      <path value="Patient.managingOrganization" />
+      <mustSupport value="true" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/UKCore-Practitioner-Lab.xml
+++ b/structuredefinitions/UKCore-Practitioner-Lab.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-Practitioner-Lab" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner-Lab" />
+  <version value="2.4.0" />
+  <name value="UKCorePractitionerLab" />
+  <title value="UK Core Practitioner Lab" />
+  <status value="draft" />
+  <date value="2025-05-13" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Practitioner](https://hl7.org/fhir/R4/Practitioner.html)." />
+  <purpose value="This profile allows exchange of information about all individuals who are engaged in the healthcare process and healthcare-related services as part of their formal responsibilities, is used for attribution of activities and responsibilities to these individuals." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Practitioner" />
+  <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/Practitioner-eu-lab" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Practitioner.identifier">
+      <path value="Practitioner.identifier" />
+      <short value="An identifier that applies to this person in this role." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Practitioner.name">
+      <path value="Practitioner.name" />
+      <short value="The name(s) associated with the practitioner." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Practitioner.telecom">
+      <path value="Practitioner.telecom" />
+      <short value="A contact detail for the practitioner (that apply to all roles)." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Practitioner.communication">
+      <path value="Practitioner.communication" />
+      <binding>
+        <strength value="required" />
+        <description value="A ValueSet that identifies the language used by a person." />
+        <valueSet value="http://hl7.org/fhir/ValueSet/all-languages" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/UKCore-PractitionerRole-IPS.xml
+++ b/structuredefinitions/UKCore-PractitionerRole-IPS.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-PractitionerRole-IPS" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole-IPS" />
+  <version value="2.4.0" />
+  <name value="UKCorePractitionerRoleIPS" />
+  <title value="UK Core Practitioner Role IPS" />
+  <status value="draft" />
+  <date value="2025-05-13" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [PractitionerRole](https://hl7.org/fhir/R4/PractitionerRole.html)." />
+  <purpose value="This profile allows exchange of a specific set of roles, specialties and services that a practitioner may perform at an organisation for a period of time." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="PractitionerRole" />
+  <baseDefinition value="http://hl7.org/fhir/uv/ips/StructureDefinition/PractitionerRole-uv-ips" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="PractitionerRole.active">
+      <path value="PractitionerRole.active" />
+      <short value="Whether this practitioner role record is in active use." />
+      <mustSupport value="true" />
+    </element>
+    <element id="PractitionerRole.period">
+      <path value="PractitionerRole.period" />
+      <short value="The period during which the practitioner is authorized to perform in these role(s)." />
+      <mustSupport value="true" />
+    </element>
+    <element id="PractitionerRole.practitioner">
+      <path value="PractitionerRole.practitioner" />
+      <short value="Practitioner that is able to provide the defined services for the organization." />
+      <mustSupport value="true" />
+    </element>
+    <element id="PractitionerRole.organization">
+      <path value="PractitionerRole.organization" />
+      <short value="Organization where the roles are available." />
+      <mustSupport value="true" />
+    </element>
+    <element id="PractitionerRole.specialty">
+      <path value="PractitionerRole.specialty" />
+      <short value="Specific specialty of the practitioner." />
+      <mustSupport value="true" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PracticeSettingCode" />
+      </binding>
+    </element>
+    <element id="PractitionerRole.location">
+      <path value="PractitionerRole.location" />
+      <short value="The location(s) at which this practitioner provides care." />
+      <mustSupport value="true" />
+    </element>
+    <element id="PractitionerRole.telecom">
+      <path value="PractitionerRole.telecom" />
+      <short value="Contact details that are specific to the role/location/service." />
+      <mustSupport value="true" />
+    </element>
+  </differential>
+</StructureDefinition>

--- a/structuredefinitions/UKCore-ServiceRequest-Lab.xml
+++ b/structuredefinitions/UKCore-ServiceRequest-Lab.xml
@@ -6,7 +6,7 @@
   <name value="UKCoreServiceRequestLab" />
   <title value="UK Core Service Request Lab" />
   <status value="active" />
-  <date value="2024-07-11" />
+  <date value="2025-05-13" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,7 +24,7 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="ServiceRequest" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ServiceRequest" />
+  <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/ServiceRequest-eu-lab" />
   <derivation value="constraint" />
   <differential>
     <element id="ServiceRequest.extension:sourceOfServiceRequest">

--- a/structuredefinitions/UKCore-Specimen-Lab.xml
+++ b/structuredefinitions/UKCore-Specimen-Lab.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="UKCore-Specimen-Lab" />
+  <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen-Lab" />
+  <version value="3.1.0" />
+  <name value="UKCoreSpecimenLab" />
+  <title value="UK Core Specimen Lab" />
+  <status value="draft" />
+  <date value="2025-05-13" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="This profile defines the UK constraints and extensions on the International FHIR resource [Specimen](https://hl7.org/fhir/R4/Specimen.html)." />
+  <purpose value="This profile allows the exchange of information about a sample to be used for analysis." />
+  <copyright value="Copyright © 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Specimen" />
+  <baseDefinition value="http://hl7.eu/fhir/laboratory/StructureDefinition/Specimen-eu-lab" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Specimen.extension:sampleCategory">
+      <path value="Specimen.extension" />
+      <sliceName value="sampleCategory" />
+      <short value="An extension to record the category of a sample." />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SampleCategory" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Specimen.status">
+      <path value="Specimen.status" />
+      <short value="The availability of the specimen sample." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Specimen.type">
+      <path value="Specimen.type" />
+      <short value="The kind of material that forms the specimen." />
+      <mustSupport value="true" />
+      <binding>
+        <strength value="preferred" />
+        <description value="A code from the SNOMED CT UK Clinical Terminology coding system" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenType" />
+      </binding>
+    </element>
+    <element id="Specimen.subject">
+      <path value="Specimen.subject" />
+      <short value="Where the specimen came from." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Specimen.receivedTime">
+      <path value="Specimen.receivedTime" />
+      <short value="The time when specimen was received for processing." />
+      <mustSupport value="true" />
+    </element>
+    <element id="Specimen.collection">
+      <path value="Specimen.collection" />
+      <constraint>
+        <key value="ukcore-spec-001" />
+        <severity value="error" />
+        <human value="Only one of Specimen.collection.collector or Specimen.collection.extension:collectorR5 can be populated at a time." />
+        <expression value="collector.reference.empty() or collector.extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.collector').empty()" />
+      </constraint>
+    </element>
+    <element id="Specimen.collection.extension:specialHandling">
+      <path value="Specimen.collection.extension" />
+      <sliceName value="specialHandling" />
+      <short value="This SHOULD be included if there is a high contamination risk reason for a sample / biopsy." />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/StructureDefinition/specimen-specialHandling" />
+      </type>
+    </element>
+    <element id="Specimen.collection.extension:CollectorR5">
+      <path value="Specimen.collection.extension" />
+      <sliceName value="collectorR5" />
+      <comment value="If this extension is used then Specimen.collection.collector SHALL NOT have a value to keep the cardinality restraint 0..1" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.collector" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Specimen.collection.bodySite">
+      <path value="Specimen.collection.bodySite" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite" />
+      </binding>
+    </element>
+    <element id="Specimen.collection.bodySite.extension:bodySiteReference">
+      <path value="Specimen.collection.bodySite.extension" />
+      <sliceName value="bodySiteReference" />
+      <short value="An extension to allow referencing to a BodyStructure." />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Specimen.collection.bodySite.extension:bodySiteReference.value[x]">
+      <path value="Specimen.collection.bodySite.extension.value[x]" />
+      <short value="A reference to a BodyStructure" />
+    </element>
+    <element id="Specimen.container.extension:deviceR5">
+      <path value="Specimen.container.extension" />
+      <sliceName value="deviceR5" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.container.device" />
+      </type>
+    </element>
+    <element id="Specimen.container.extension:locationR5">
+      <path value="Specimen.container.extension" />
+      <sliceName value="locationR5" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.container.location" />
+      </type>
+    </element>
+    <element id="Specimen.container.type">
+      <path value="Specimen.container.type" />
+      <binding>
+        <strength value="preferred" />
+      </binding>
+    </element>
+    <element id="Specimen.condition">
+      <path value="Specimen.condition" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-SampleState" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
This is a PR for discussion to see if it is possible to align with the [EU-Lab](https://hl7.eu/fhir/laboratory/artifacts.html) to the UK-Core)

EU Profiles not included as there is no UK Core equivalent 
- Substance
- Patient:Animal
- Bundle
- BodyStructure

### Differences (EU v UK - does not include extensions nor mustsupports)
- `Observation.category` slicing aligned with EU. UK Core adds `slice=laboratory` with fixed `code=laboratory`. Is this slice still needed?
- `Observation.code`  from [Results Laboratory Observation - IPS](https://build.fhir.org/ig/HL7/fhir-ips/ValueSet-results-laboratory-observations-uv-ips.html) to https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables
- Patient Extension uses http://hl7.org/fhir/extensions/5.2.0/StructureDefinition-patient-sexParameterForClinicalUse.html but also has https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex. What is the difference? Probably need to decide on one or another
- `Practitioner.communication` binding changed to align with R5
- `PractitionerRole.specialty` - set to https://fhir.hl7.org.uk/ValueSet/UKCore-PracticeSettingCode
- `Specimen.type` set from https://hl7.eu/fhir/laboratory/ValueSet-lab-specimenType-eu-lab.html (LOINC) to https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenType (SNOMED CT)
- `Specimen.bodySite` set from http://hl7.org/fhir/R4/valueset-body-site.html (SNOMED CT) to https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite (SNOMED CT)
- `Specimen.condition` from http://terminology.hl7.org/5.3.0/ValueSet-v2-0493.html to https://fhir.hl7.org.uk/ValueSet/UKCore-SampleState
- `DiagnosticReport.category` slicing changed to align to EU-Lab and `slice=laboratory` add with `code=LAB`. Is this slice still needed?
- `DiagnosticReport.code` binding changed from https://hl7.eu/fhir/laboratory/ValueSet-lab-reportType-eu-lab.html to https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode 
- `Composition.category` changed from http://hl7.org/fhir/R4/valueset-document-classcodes.html (LOINC) to https://fhir.hl7.org.uk/ValueSet/UKCore-CompositionCategory (SNOMED CT). Do we need to also change the EU slices to SNOMED CT?
- `Composition.selection.code` changed from http://hl7.org/fhir/R4/valueset-doc-section-codes.html (LOINC) to https://fhir.hl7.org.uk/ValueSet/UKCore-CompositionSectionCode (SNOMED CT)

https://simplifier.net/snippet can be used to render these if easier to read