### PR TITLE
removed issue: and replaced with topic:

### DIFF
--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/ExampleTemplate.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/ExampleTemplate.page.md
@@ -7,6 +7,8 @@
  <button class="tablinks" onclick="openTab(event, 'tree-view')">Tree View</button>
   <button class="tablinks" onclick="openTab(event, 'xml-view')">XML View</button>
   <button class="tablinks" onclick="openTab(event, 'json-view')">JSON View</button>
+  <button class="tablinks feedback" onclick="openTab(event, 'Feedback')">Feedback</button>
+
 </div>
 
 <div id="table-view" class="tabcontent" style="display:block">
@@ -27,6 +29,10 @@
 <div id="json-view" class="tabcontent">
   <h3>JSON View</h3>
 {{json}}
+</div>
+<div id="Feedback" class="tabcontent">
+  <h3>Feedback</h3>
+Click here to: {{page:FeedbackLink}}</a>
 </div>
 
 ---

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-AllergyIntolerance-Amoxicillin-Example.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Examples/Profile-Examples/UKCore-AllergyIntolerance-Amoxicillin-Example.page.md
@@ -1,4 +1,5 @@
 ---
 subject: UKCore-AllergyIntolerance-Amoxicillin-Example
 ---
+
 {{page:ExampleTemplate}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AdditionalContact.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AdditionalContact.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact
-issue: Extension-UKCore-AdditionalContact
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AddressKey.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AddressKey.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey
-issue: Extension-UKCore-AddressKey
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AdmissionMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AdmissionMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdmissionMethod
-issue: Extension-UKCore-AdmissionMethod
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AllergyIntoleranceEnd.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AllergyIntoleranceEnd.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AllergyIntoleranceEnd
-issue: Extension-UKCore-AllergyIntoleranceEnd
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AssociatedEncounter.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-AssociatedEncounter.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AssociatedEncounter
-issue: Extension-UKCore-AssociatedEncounter
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-BirthSex.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-BirthSex.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BirthSex
-issue: Extension-UKCore-BirthSex
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-BodySiteReference.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-BodySiteReference.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference
-issue: Extension-UKCore-BodySiteReference
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-BookingOrganization.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-BookingOrganization.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BookingOrganization
-issue: Extension-UKCore-BookingOrganization
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CareSettingType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CareSettingType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CareSettingType
-issue: Extension-UKCore-CareSettingType
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CodingSCTDescDisplay.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CodingSCTDescDisplay.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CodingSCTDescDisplay
-issue: Extension-UKCore-CodingSCTDescDisplay
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ConditionBodyStructure.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ConditionBodyStructure.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/6.0/StructureDefinition/extension-Condition.bodyStructure
-issue: Extension-UKCore-ConditionBodyStructure
 ---
 
 ## StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ConditionEpisode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ConditionEpisode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ConditionEpisode
-issue: Extension-UKCore-ConditionEpisode
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ContactPreference.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ContactPreference.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference
-issue: Extension-UKCore-ContactPreference
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ContactRank.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ContactRank.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactRank
-issue: Extension-UKCore-ContactRank
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CopyCorrespondenceIndicator.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CopyCorrespondenceIndicator.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CopyCorrespondenceIndicator
-issue: Extension-UKCore-CopyCorrespondenceIndicator
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-Coverage.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-Coverage.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage
-issue: Extension-UKCore-Coverage
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CuffSize.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-CuffSize.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-CuffSize
-issue: Extension-UKCore-CuffSize
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DeathNotificationStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DeathNotificationStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeathNotificationStatus
-issue: Extension-UKCore-DeathNotificationStatus
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DeliveryChannel.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DeliveryChannel.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeliveryChannel
-issue: Extension-UKCore-DeliveryChannel
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DeviceReference.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DeviceReference.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeviceReference
-issue: Extension-UKCore-DeviceReference
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportComposition.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportComposition.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition
-issue: Extension-UKCore-DiagnosticReportComposition
 ---
 
 ## StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportMediaLink.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportMediaLink.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.media.link
-issue: Extension-UKCore-DiagnosticReportMediaLink
 ---
 
 <table id="addToTranspose">

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportNote.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportNote.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.note
-issue: Extension-UKCore-DiagnosticReportNote
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportSupportingInfo.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DiagnosticReportSupportingInfo.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.supportingInfo
-issue: Extension-UKCore-DiagnosticReportSupportingInfo
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DischargeMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-DischargeMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DischargeMethod
-issue: Extension-UKCore-DischargeMethod
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-EmergencyCareDischargeStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-EmergencyCareDischargeStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EmergencyCareDischargeStatus
-issue: Extension-UKCore-EmergencyCareDischargeStatus
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-EthnicCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-EthnicCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-EthnicCategory
-issue: Extension-UKCore-EthnicCategory
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-Evidence.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-Evidence.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Evidence
-issue: Extension-UKCore-Evidence
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-FamilyMemberHistoryParticipant.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-FamilyMemberHistoryParticipant.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-FamilyMemberHistory.participant
-issue: Extension-UKCore-FamilyMemberHistoryParticipant
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-LegalStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-LegalStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-LegalStatus
-issue: Extension-UKCore-LegalStatus
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ListWarningCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ListWarningCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ListWarningCode
-issue: Extension-UKCore-ListWarningCode
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MainLocation.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MainLocation.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MainLocation
-issue: Extension-UKCore-MainLocation
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationPrescribingOrganizationType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationPrescribingOrganizationType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationPrescribingOrganizationType
-issue: Extension-UKCore-MedicationPrescribingOrganizationType
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationRepeatInformation.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationRepeatInformation.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation
-issue: Extension-UKCore-MedicationRepeatInformation
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationStatementLastIssueDate.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationStatementLastIssueDate.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationStatementLastIssueDate
-issue: Extension-UKCore-MedicationStatementLastIssueDate
 ---
 ## StructureDefinition Extension-UKCore-MedicationStatementLastIssueDate
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationTradeFamily.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-MedicationTradeFamily.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationTradeFamily
-issue: Extension-UKCore-MedicationTradeFamily
 ---
 ## StructureDefinition Extension-UKCore-MedicationTradeFamily
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-NHSNumberUnavailableReason.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-NHSNumberUnavailableReason.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberUnavailableReason
-issue: Extension-UKCore-NHSNumberUnavailableReason
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-NHSNumberVerificationStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-NHSNumberVerificationStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus
-issue: Extension-UKCore-NHSNumberVerificationStatus
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ObservationBodyStructure.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ObservationBodyStructure.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.bodyStructure
-issue: Extension-UKCore-ObservationBodyStructure
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ObservationTriggeredBy.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ObservationTriggeredBy.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy
-issue: Extension-UKCore-ObservationTriggeredBy
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-OtherContactSystem.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-OtherContactSystem.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem
-issue: Extension-UKCore-OtherContactSystem
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-OutcomeOfAttendance.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-OutcomeOfAttendance.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OutcomeOfAttendance
-issue: Extension-UKCore-OutcomeOfAttendance
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ParentPresent.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ParentPresent.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ParentPresent
-issue: Extension-UKCore-ParentPresent
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-PatientFetalStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-PatientFetalStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/6.0/StructureDefinition/extension-Patient.fetalStatus
-issue: Extension-UKCore-PatientFetalStatus
 ---
 
 <table id="addToTranspose">

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-PharmacistVerifiedIndicator.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-PharmacistVerifiedIndicator.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PharmacistVerifiedIndicator
-issue: Extension-UKCore-PharmacistVerifiedIndicator
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-PriorityReason.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-PriorityReason.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PriorityReason
-issue: Extension-UKCore-PriorityReason
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-RecordingSetting.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-RecordingSetting.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting
-issue: Extension-UKCore-RecordingSetting
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ResidentialStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-ResidentialStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ResidentialStatus
-issue: Extension-UKCore-ResidentialStatus
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SampleCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SampleCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SampleCategory
-issue: Extension-UKCore-SampleCategory
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SourceOfServiceRequest.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SourceOfServiceRequest.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SourceOfServiceRequest
-issue: Extension-UKCore-SourceOfServiceRequest
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SpecimenCollectionCollector.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SpecimenCollectionCollector.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.collector
-issue: Extension-UKCore-SpecimenCollectionCollector
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SpecimenContainerDevice.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SpecimenContainerDevice.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.container.device
-issue: UKCore-SpecimenContainerDevice
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SpecimenContainerLocation.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SpecimenContainerLocation.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.container.location
-issue: Extension-UKCore-SpecimenContainerLocation
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SubscriptionContent.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SubscriptionContent.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.content
-issue: Extension-UKCore-SubscriptionContent
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SubscriptionParameter.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-SubscriptionParameter.page.md
@@ -1,6 +1,5 @@
 ---
 subject: http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.parameter
-issue: Extension-UKCore-SubscriptionParameter
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-TreatmentCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-TreatmentCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-TreatmentCategory
-issue: Extension-UKCore-TreatmentCategory
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-TypedDateTime.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-TypedDateTime.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-TypedDateTime
-issue: Extension-UKCore-TypedDateTime
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-TypedPeriod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-TypedPeriod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-TypedPeriod
-issue: Extension-UKCore-TypedPeriod
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-VaccinationProcedure.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ExtensionLibrary/Extension-UKCore-VaccinationProcedure.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-VaccinationProcedure
-issue: Extension-UKCore-VaccinationProcedure
 ---
 ## StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/FeedbackLink.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/FeedbackLink.page.md
@@ -1,8 +1,8 @@
 <fql output="inline" delimiter=" ">
 select
     Link: {
-        text: 'Report issue for ' + %issue,
-        href: 'https://simplifier.net/HL7FHIRUKCoreR4/' + %issue + '/~issues?level=File'
+        text: 'Report issue for ' + %topic,
+        href: 'https://simplifier.net/HL7FHIRUKCoreR4/' + %topic + '/~issues?level=File'
     }
 group by Link
 </fql>

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ProfileTest.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/ProfileTest.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-AllergyIntolerance
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance
 usage: http://hl7.org/fhir/StructureDefinition/AllergyIntolerance
-issue: UKCore-AllergyIntolerance
 examples: AllergyIntolerance
 ---
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-AllergyIntolerance/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-AllergyIntolerance/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-AllergyIntolerance
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-AllergyIntolerance
 usage: http://hl7.org/fhir/StructureDefinition/AllergyIntolerance
-issue: UKCore-AllergyIntolerance
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Appointment/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Appointment/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Appointment
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Appointment
 usage: http://hl7.org/fhir/StructureDefinition/Appointment
-issue: UKCore-Appointment
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Composition/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Composition/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Composition
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Composition
 usage: http://hl7.org/fhir/StructureDefinition/Composition
-issue: UKCore-Composition
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Condition/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Condition/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Condition
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Condition
 usage: http://hl7.org/fhir/StructureDefinition/Condition
-issue: UKCore-Condition
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Device-BloodPressure/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Device-BloodPressure/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Device-BloodPressure
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device-BloodPressure
 usage: http://hl7.org/fhir/StructureDefinition/Device
-issue: UKCore-Device-BloodPressure
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-DiagnosticReport-Lab/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-DiagnosticReport-Lab/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-DiagnosticReport-Lab
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport-Lab
 usage: http://hl7.org/fhir/StructureDefinition/DiagnosticReport
-issue: UKCore-DiagnosticReport-Lab
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-DiagnosticReport/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-DiagnosticReport/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-DiagnosticReport
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-DiagnosticReport
 usage: http://hl7.org/fhir/StructureDefinition/DiagnosticReport
-issue: UKCore-DiagnosticReport
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Encounter/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Encounter/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Encounter
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Encounter
 usage: http://hl7.org/fhir/StructureDefinition/Encounter
-issue: UKCore-Encounter
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-FamilyMemberHistory/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-FamilyMemberHistory/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-FamilyMemberHistory
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-FamilyMemberHistory
 usage: http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory
-issue: UKCore-FamilyMemberHistory
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-HealthcareService/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-HealthcareService/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-HealthcareService
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-HealthcareService
 usage: http://hl7.org/fhir/StructureDefinition/HealthcareService
-issue: UKCore-HealthcareService
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Immunization/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Immunization/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Immunization
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Immunization
 usage: http://hl7.org/fhir/StructureDefinition/Immunization
-issue: UKCore-Immunization
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-List/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-List/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-List
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-List
 usage: http://hl7.org/fhir/StructureDefinition/List
-issue: UKCore-List
 ---
 # StructureDefinition-UKCore-List
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Location/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Location/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Location
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Location
 usage: http://hl7.org/fhir/StructureDefinition/Location
-issue: UKCore-Location
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Medication/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Medication/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Medication
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Medication
 usage: http://hl7.org/fhir/StructureDefinition/Medication
-issue: UKCore-Medication
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationAdministration/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationAdministration/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-MedicationAdministration
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationAdministration
 usage: http://hl7.org/fhir/StructureDefinition/MedicationAdministration
-issue: UKCore-MedicationAdministration
 ---
 # StructureDefinition-UKCore-MedicationAdministration
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationDispense/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationDispense/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-MedicationDispense
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationDispense
 usage: http://hl7.org/fhir/StructureDefinition/MedicationDispense
-issue: UKCore-MedicationDispense
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationRequest/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationRequest/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-MedicationRequest
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationRequest
 usage: http://hl7.org/fhir/StructureDefinition/MedicationRequest
-issue: UKCore-MedicationRequest
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationStatement/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-MedicationStatement/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-MedicationStatement
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-MedicationStatement
 usage: http://hl7.org/fhir/StructureDefinition/MedicationStatement
-issue: UKCore-MedicationStatement
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-ACVPU/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-ACVPU/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-ACVPU
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-ACVPU
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-ACVPU
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-AlcoholConsumption/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-AlcoholConsumption/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-AlcoholConsumption
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-AlcoholConsumption
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-AlcoholConsumption
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-AverageBloodPressure/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-AverageBloodPressure/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-AverageBloodPressure
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-AverageBloodPressure
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-AverageBloodPressure
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-BloodGlucose/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-BloodGlucose/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-BloodGlucose
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-BloodGlucose
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-BloodGlucose
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-EarlyWarningTotalScore/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-EarlyWarningTotalScore/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-EarlyWarningTotalScore
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-EarlyWarningTotalScore
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-EarlyWarningTotalScore
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-Group-Lab/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-Group-Lab/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-Group-Lab
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Group-Lab
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-Group-Lab
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-InspiredOxygen/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-InspiredOxygen/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-InspiredOxygen
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-InspiredOxygen
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-InspiredOxygen
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-Lab/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-Lab/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-Lab
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-Lab
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-Lab
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-TobaccoConsumption/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-TobaccoConsumption/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-TobaccoConsumption
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-TobaccoConsumption
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-TobaccoConsumption
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BMI/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BMI/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-BMI
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BMI
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: 
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BloodPressure/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BloodPressure/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-BloodPressure
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BloodPressure
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-BloodPressure
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BodyHeight/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BodyHeight/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-BodyHeight
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyHeight
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-BodyHeight
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BodyTemperature/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BodyTemperature/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-BodyTemperature
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyTemperature
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-BodyTemperature
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BodyWeight/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-BodyWeight/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-BodyWeight
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyWeight
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: 
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-HeadCircumference/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-HeadCircumference/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-HeadCircumference
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-HeadCircumference
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-HeadCircumference
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-HeartRate/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-HeartRate/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-HeartRate
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-HeartRate
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-HeartRate
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-OxygenSaturation/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-OxygenSaturation/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-OxygenSaturation
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-OxygenSaturation
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-OxygenSaturation
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-RespirationRate/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns-RespirationRate/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns-RespirationRate
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-RespirationRate
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns-RespirationRate
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation-VitalSigns/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation-VitalSigns
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation-VitalSigns
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Observation/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Observation
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation
 usage: http://hl7.org/fhir/StructureDefinition/Observation
-issue: UKCore-Observation
 ---
 
 # StructureDefinition {{variable:issue}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Organization/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Organization/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Organization
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Organization
 usage: http://hl7.org/fhir/StructureDefinition/Organization
-issue: UKCore-Organization
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Patient/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Patient/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Patient
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient
 usage: http://hl7.org/fhir/StructureDefinition/Patient
-issue: UKCore-Patient
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Practitioner/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Practitioner/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Practitioner
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Practitioner
 usage: http://hl7.org/fhir/StructureDefinition/Practitioner
-issue: UKCore-Practitioner
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-PractitionerRole/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-PractitionerRole/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-PractitionerRole
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-PractitionerRole
 usage: http://hl7.org/fhir/StructureDefinition/PractitionerRole
-issue: UKCore-PractitionerRole
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Procedure/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Procedure/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Procedure
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Procedure
 usage: http://hl7.org/fhir/StructureDefinition/Procedure
-issue: UKCore-Procedure
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-RelatedPerson/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-RelatedPerson/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-RelatedPerson
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-RelatedPerson
 usage: http://hl7.org/fhir/StructureDefinition/RelatedPerson
-issue: UKCore-RelatedPerson
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Schedule/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Schedule/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Schedule
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Schedule
 usage: http://hl7.org/fhir/StructureDefinition/Schedule
-issue: UKCore-Schedule
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-ServiceRequest-Lab/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-ServiceRequest-Lab/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-ServiceRequest-Lab
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest-Lab
 usage: http://hl7.org/fhir/StructureDefinition/ServiceRequest
-issue: UKCore-ServiceRequest-Lab
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-ServiceRequest/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-ServiceRequest/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-ServiceRequest
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest
 usage: http://hl7.org/fhir/StructureDefinition/ServiceRequest
-issue: UKCore-ServiceRequest
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Slot/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Slot/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Slot
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Slot
 usage: http://hl7.org/fhir/StructureDefinition/Slot
-issue: UKCore-Slot
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Specimen/Index.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-Specimen/Index.page.md
@@ -2,7 +2,6 @@
 topic: UKCore-Specimen
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-Specimen
 usage: http://hl7.org/fhir/StructureDefinition/Specimen
-issue: UKCore-Specimen
 ---
 # StructureDefinition {{variable:issue}}
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystem-table.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystem-table.page.md
@@ -1,0 +1,18 @@
+<fql>
+from
+	CodeSystem
+where
+    status !='retired'
+select
+	CodeSystem: id, Status: status
+order by
+	id
+distinct
+</fql>
+
+<style>
+ [class*=override] {
+ 	background-color:#f2f2f2;
+	 }
+</style>
+

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AdditionalPersonRelationshipRole.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AdditionalPersonRelationshipRole.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-AdditionalPersonRelationshipRole
-issue: CodeSystem-UKCore-AdditionalPersonRelationshipRole
 ---
 ## UK Core Additional Person Relationship Role
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AddressKeyType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AddressKeyType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType
-issue: CodeSystem-UKCore-AddressKeyType
 ---
 ## UK Core Address Key Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AdmissionMethodEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AdmissionMethodEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-AdmissionMethodEngland
-issue: CodeSystem-UKCore-AdmissionMethodEngland
 ---
 ## UK Core Admission Method England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AdmissionMethodWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AdmissionMethodWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-AdmissionMethodWales
-issue: CodeSystem-UKCore-AdmissionMethodWales
 ---
 ## UK Core Admission Method Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AppointmentReasonCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-AppointmentReasonCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-AppointmentReasonCode
-issue: CodeSystem-UKCore-AppointmentReasonCode
 ---
 ## UK Core Appointment Reason Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ConditionCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ConditionCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionCategory
-issue: CodeSystem-UKCore-ConditionCategory
 ---
 ## UK Core Condition Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ConditionEpisodicity.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ConditionEpisodicity.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-ConditionEpisodicity
-issue: CodeSystem-UKCore-ConditionEpisodicity
 ---
 ## UK Core Condition Episodicity
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DeathNotificationStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DeathNotificationStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-DeathNotificationStatus
-issue: CodeSystem-UKCore-DeathNotificationStatus
 ---
 ## UK Core Death Notification Status
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DeliveryChannel.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DeliveryChannel.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-DeliveryChannel
-issue: CodeSystem-UKCore-DeliveryChannel
 ---
 ## UK Core Delivery Channel
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeDestinationEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeDestinationEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-DischargeDestinationEngland
-issue: CodeSystem-UKCore-DischargeDestinationEngland
 ---
 ## UK Core Discharge Destination England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeDestinationWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeDestinationWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-DischargeDestinationWales
-issue: CodeSystem-UKCore-DischargeDestinationWales
 ---
 ## UK Core Discharge Destination Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeMethodEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeMethodEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-DischargeMethodEngland
-issue: CodeSystem-UKCore-DischargeMethodEngland
 ---
 ## UK Core Discharge Method England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeMethodWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-DischargeMethodWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-DischargeMethodWales
-issue: CodeSystem-UKCore-DischargeMethodWales
 ---
 ## UK Core Discharge Method Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EmergencyCareOutcomeOfAttendanceWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EmergencyCareOutcomeOfAttendanceWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-EmergencyCareOutcomeOfAttendanceWales
-issue: CodeSystem-UKCore-EmergencyCareOutcomeOfAttendanceWales
 ---
 ## UK Core Emergency Care Outcome Of Attendance Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EncounterLocationTypeEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EncounterLocationTypeEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-EncounterLocationTypeEngland
-issue: CodeSystem-UKCore-EncounterLocationTypeEngland
 ---
 ## UK Core Encounter Location Type England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EncounterLocationTypeWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EncounterLocationTypeWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-EncounterLocationTypeWales
-issue: CodeSystem-UKCore-EncounterLocationTypeWales
 ---
 ## UK Core Encounter Location Type Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EthnicCategoryEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EthnicCategoryEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-EthnicCategoryEngland
-issue: CodeSystem-UKCore-EthnicCategoryEngland
 ---
 ## UK Core Ethnic Category England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EthnicCategoryWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-EthnicCategoryWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-EthnicCategoryWales
-issue: CodeSystem-UKCore-EthnicCategoryWales
 ---
 ## UK Core Ethnic Category Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-FundingCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-FundingCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory
-issue: CodeSystem-UKCore-FundingCategory
 ---
 ## UK Core Funding Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-GenomeSequencingCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-GenomeSequencingCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-GenomeSequencingCategory
-issue: CodeSystem-UKCore-GenomeSequencingCategory
 ---
 ## UK Core Genome Sequencing Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-LegalStatusClassificationEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-LegalStatusClassificationEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-LegalStatusClassificationEngland
-issue: CodeSystem-UKCore-LegalStatusClassificationEngland
 ---
 ## UK Core Legal Status Classification England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-LegalStatusClassificationWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-LegalStatusClassificationWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-LegalStatusClassificationWales
-issue: CodeSystem-UKCore-LegalStatusClassificationWales
 ---
 ## UK Core Legal Status Classification Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-LegalStatusContext.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-LegalStatusContext.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-LegalStatusContext
-issue: CodeSystem-UKCore-LegalStatusContext
 ---
 ## UK Core UK Core Legal Status Context
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ListEmptyReasonCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ListEmptyReasonCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-ListEmptyReasonCode
-issue: CodeSystem-UKCore-ListEmptyReasonCode
 ---
 ## UK Core List Empty Reason Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ListWarningCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ListWarningCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-ListWarningCode
-issue: CodeSystem-UKCore-ListWarningCode
 ---
 ## UK Core List Warning Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationAdministrationCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationAdministrationCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationAdministrationCategory
-issue: CodeSystem-UKCore-MedicationAdministrationCategory
 ---
 ## UK Core Medication Administration Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationPrescribingOrganization.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationPrescribingOrganization.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationPrescribingOrganizationType
-issue: CodeSystem-UKCore-MedicationPrescribingOrganizationType
 ---
 ## UK Core Medication Prescribing Organization Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationPrescribingOrganizationType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationPrescribingOrganizationType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationPrescribingOrganizationType
-issue: CodeSystem-UKCore-MedicationPrescribingOrganizationType
 ---
 ## UK Core Medication Prescribing Organization Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationRequestCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationRequestCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCategory
-issue: CodeSystem-UKCore-MedicationRequestCategory
 ---
 ## UK Core Medication Request Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationRequestCourseOfTherapy.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationRequestCourseOfTherapy.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationRequestCourseOfTherapy
-issue: CodeSystem-UKCore-MedicationRequestCourseOfTherapy
 ---
 ## UK Core Medication Request Course Of Therapy
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationStatementCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationStatementCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationStatementCategory
-issue: CodeSystem-UKCore-MedicationStatementCategory
 ---
 ## UK Core Medication Statement Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationSupplyType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-MedicationSupplyType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-MedicationSupplyType
-issue: CodeSystem-UKCore-MedicationSupplyType
 ---
 ## UK Core Medication Supply Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-NHSNumberUnavailableReason.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-NHSNumberUnavailableReason.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberUnavailableReason
-issue: CodeSystem-UKCore-NHSNumberUnavailableReason
 ---
 ## UK Core NHS Number Unavailable Reason
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-NHSNumberVerificationStatusEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusEngland
-issue: CodeSystem-UKCore-NHSNumberVerificationStatusEngland
 ---
 ## UK Core NHS Number Verification Status England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-NHSNumberVerificationStatusWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-NHSNumberVerificationStatusWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatusWales
-issue: CodeSystem-UKCore-NHSNumberVerificationStatusWales
 ---
 ## UK Core NHS Number Verification Status Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OrganizationTypeGenomics.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OrganizationTypeGenomics.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-OrganizationTypeGenomics
-issue: CodeSystem-UKCore-OrganizationTypeGenomics
 ---
 ##  UK Core Organization Type Genomics
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OtherContactSystem.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OtherContactSystem.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-OtherContactSystem
-issue: CodeSystem-UKCore-OtherContactSystem
 ---
 ##  UK Core Other Contact System
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OutcomeOfAttendanceEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OutcomeOfAttendanceEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-OutcomeOfAttendanceEngland
-issue: CodeSystem-UKCore-OutcomeOfAttendanceEngland
 ---
 ## UK Core Outcome Of Attendance England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OutcomeOfAttendanceWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-OutcomeOfAttendanceWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-OutcomeOfAttendanceWales
-issue: CodeSystem-UKCore-OutcomeOfAttendanceWales
 ---
 ## UK Core Outcome Of Attendance Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PeriodType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PeriodType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PeriodType
-issue: CodeSystem-UKCore-PeriodType
 ---
 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PersonMaritalStatusEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PersonMaritalStatusEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusEngland
-issue: CodeSystem-UKCore-PersonMaritalStatusEngland
 ---
 ## UK Core Person Marital Status England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PersonMaritalStatusWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PersonMaritalStatusWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PersonMaritalStatusWales
-issue: CodeSystem-UKCore-PersonMaritalStatusWales
 ---
 ## UK Core Person Marital Status Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PracticeSettingCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PracticeSettingCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PracticeSettingCode
-issue: CodeSystem-UKCore-PracticeSettingCode
 ---
 ##  UK Core Practice Setting Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PreferredContactMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PreferredContactMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PreferredContactMethod
-issue: CodeSystem-UKCore-PreferredContactMethod
 ---
 ## UK Core Preferred Contact Method
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PreferredWrittenCommunicationFormat.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PreferredWrittenCommunicationFormat.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PreferredWrittenCommunicationFormat
-issue: CodeSystem-UKCore-PreferredWrittenCommunicationFormat
 ---
 ## UK Core Preferred Written Communication Format
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PrimarySampleState.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-PrimarySampleState.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-PrimarySampleState
-issue: CodeSystem-UKCore-PrimarySampleState
 ---
 ## UK Core Primary Sample State
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-RecordStandardHeadings.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-RecordStandardHeadings.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordStandardHeadings
-issue: CodeSystem-UKCore-RecordStandardHeadings
 ---
 ## UK Core Record Standard Headings
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-RecordingSetting.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-RecordingSetting.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-RecordingSetting
-issue: CodeSystem-UKCore-RecordingSetting
 ---
 ## UK Core Recording Setting
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ResidentialStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-ResidentialStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-ResidentialStatus
-issue: CodeSystem-UKCore-ResidentialStatus
 ---
 ## UK Core Residential Status
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-SampleCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-SampleCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-SampleCategory
-issue: CodeSystem-UKCore-SampleCategory
 ---
 ## UK Core Sample Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-SourceOfAdmissionEngland.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-SourceOfAdmissionEngland.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-SourceOfAdmissionEngland
-issue: CodeSystem-UKCore-SourceOfAdmissionEngland
 ---
 ## UK Core Source Of Admission England
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-SourceOfAdmissionWales.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-SourceOfAdmissionWales.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-SourceOfAdmissionWales
-issue: CodeSystem-UKCore-SourceOfAdmissionWales
 ---
 ## UK Core Source Of Admission Wales
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-WithheldIdentityReason.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/CodeSystems/CodeSystem-UKCore-WithheldIdentityReason.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/CodeSystem/UKCore-WithheldIdentityReason
-issue: CodeSystem-UKCore-WithheldIdentityReason
 ---
 
 {{page:CodeSystemTemplate_new}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/UKCore-ServiceRequest.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/UKCore-ServiceRequest.page.md
@@ -1,7 +1,6 @@
 
 ---
 subject: https://fhir.hl7.org.uk/StructureDefinition/UKCore-ServiceRequest
-issue: UKCore-ServiceRequest
 ---
 ## ServiceRequest
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ACVPU.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ACVPU.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ACVPU
-issue: ValueSet-UKCore-ACVPU
 ---
 ## UK Core ACVPU
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AddressKeyType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AddressKeyType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AddressKeyType
-issue: ValueSet-UKCore-AddressKeyType
 ---
 ## UK Core Address Key Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AdmissionMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AdmissionMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AdmissionMethod
-issue: ValueSet-UKCore-AdmissionMethod
 ---
 ## UK Core Admission Method
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AlcoholConsumption.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AlcoholConsumption.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AlcoholConsumption
-issue: ValueSet-UKCore-AlcoholConsumption
 ---
 ## UK Core Alcohol Consumption
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AllergyCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AllergyCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AllergyCode
-issue: ValueSet-UKCore-AllergyCode
 ---
 ## UK Core Allergy Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AllergyManifestation.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AllergyManifestation.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AllergyManifestation
-issue: ValueSet-UKCore-AllergyManifestation
 ---
 ## UK Core Allergy Manifestation
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AllergySubstance.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AllergySubstance.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AllergySubstance
-issue: ValueSet-UKCore-AllergySubstance
 ---
 ## UK Core Allergy Substance
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AppointmentReasonCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-AppointmentReasonCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-AppointmentReasonCode
-issue: ValueSet-UKCore-AppointmentReasonCode
 ---
 ## UK Core Appointment Reason Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BMI.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BMI.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BMI
-issue: ValueSet-UKCore-BMI
 ---
 ## UK Core BMI
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BirthSex.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BirthSex.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BirthSex
-issue: ValueSet-UKCore-BirthSex
 ---
 ## UK Core Birth Sex
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodGlucose.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodGlucose.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodGlucose
-issue: ValueSet-UKCore-BloodGlucose
 ---
 ## UK Core Blood Glucose
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-Average.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-Average.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Average
-issue: ValueSet-UKCore-BloodPressure-Average
 ---
 ## UK Core Blood Pressure: Average
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-AverageDiastolic.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-AverageDiastolic.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-AverageDiastolic
-issue: ValueSet-UKCore-BloodPressure-AverageDiastolic
 ---
 ## UK Core Blood Pressure: Average Diastolic
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-AverageSystolic.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-AverageSystolic.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-AverageSystolic
-issue: ValueSet-UKCore-BloodPressure-AverageSystolic
 ---
 ## UK Core Blood Pressure: Average Systolic
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-CuffSize.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-CuffSize.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-CuffSize
-issue: ValueSet-UKCore-BloodPressure-CuffSize
 ---
 ## UK Core Blood Pressure: Cuff Size
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-DeviceType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-DeviceType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-DeviceType
-issue: ValueSet-UKCore-BloodPressure-DeviceType
 ---
 ## UK Core Blood Pressure: Device Type 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-Diastolic.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-Diastolic.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Diastolic
-issue: ValueSet-UKCore-BloodPressure-Diastolic
 ---
 ## UK Core Blood Pressure: Diastolic
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-MeasurementMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-MeasurementMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-MeasurementMethod
-issue: ValueSet-UKCore-BloodPressure-MeasurementMethod
 ---
 ## UK Core Blood Pressure: Measurement Method
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-Systolic.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure-Systolic.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Systolic
-issue: ValueSet-UKCore-BloodPressure-Systolic
 ---
 ## UK Core Blood Pressure: Systolic
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BloodPressure.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure
-issue: ValueSet-UKCore-BloodPressure
 ---
 ## UK Core Blood Pressure
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyHeightMeasurements.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyHeightMeasurements.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements
-issue: ValueSet-UKCore-BodyHeightMeasurements
 ---
 ## UK Core Body Height Measurements
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyPosition.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyPosition.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BodyPosition
-issue: ValueSet-UKCore-BodyPosition
 ---
 ## UK Core Body Position
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodySite.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodySite.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BodySite
-issue: ValueSet-UKCore-BodySite
 ---
 ## UK Core Body Site
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyTemperature.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyTemperature.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BodyTemperature
-issue: ValueSet-UKCore-BodyTemperature
 ---
 ## UK Core Body Temperature
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyWeightMeasurements.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-BodyWeightMeasurements.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightMeasurements
-issue: ValueSet-UKCore-BodyWeightMeasurements
 ---
 ## UK Core Body Weight Measurement
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-CareSettingType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-CareSettingType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-CareSettingType
-issue: ValueSet-UKCore-CareSettingType
 ---
 ## UK Core Care Setting Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-CompositionCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-CompositionCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-CompositionCategory
-issue: ValueSet-UKCore-CompositionCategory
 ---
 ## UK Core Composition Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-CompositionSectionCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-CompositionSectionCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-CompositionSectionCode
-issue: ValueSet-UKCore-CompositionSectionCode
 ---
 ## UK Core Composition Section Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConditionCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConditionCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ConditionCategory
-issue: ValueSet-UKCore-ConditionCategory
 ---
 ## UK Core Condition Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConditionCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConditionCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ConditionCode
-issue: ValueSet-UKCore-ConditionCode
 ---
 ## UK Core Condition Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConditionEpisodicity.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConditionEpisodicity.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ConditionEpisodicity
-issue: ValueSet-UKCore-ConditionEpisodicity
 ---
 ## UK Core Condition Episodicity
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConsentException.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ConsentException.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ConsentException
-issue: ValueSet-UKCore-ConsentException
 ---
 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DeathNotificationStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DeathNotificationStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-DeathNotificationStatus
-issue: ValueSet-UKCore-DeathNotificationStatus
 ---
 ## UK Core Death Notification Status
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DeliveryChannel.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DeliveryChannel.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-DeliveryChannel
-issue: ValueSet-UKCore-DeliveryChannel
 ---
 ## UK Core Delivery Channel
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DischargeDestination.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DischargeDestination.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-DischargeDestination
-issue: ValueSet-UKCore-DischargeDestination
 ---
 ## UK Core Discharge Destination
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DischargeMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DischargeMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-DischargeMethod
-issue: ValueSet-UKCore-DischargeMethod
 ---
 ## UK Core Discharge Method
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DocumentType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-DocumentType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-DocumentType
-issue: ValueSet-UKCore-DocumentType
 ---
 ## UK Core Document Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EarlyWarningSubScore.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EarlyWarningSubScore.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-EarlyWarningSubScore
-issue: ValueSet-UKCore-EarlyWarningSubScore
 ---
 ## UK Core Early Warning Sub Score
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EarlyWarningTotalScore.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EarlyWarningTotalScore.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-EarlyWarningTotalScore
-issue: ValueSet-UKCore-EarlyWarningTotalScore
 ---
 ## UK Core Early Warning Total Score
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EmergencyCareDischargeStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EmergencyCareDischargeStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-EmergencyCareDischargeStatus
-issue: ValueSet-UKCore-EmergencyCareDischargeStatus
 ---
 ## UK Core Emergency Care Discharge Status
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EncounterLocationType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EncounterLocationType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-EncounterLocationType
-issue: ValueSet-UKCore-EncounterLocationType
 ---
 ## UK Core Encounter Location Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EncounterType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EncounterType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-EncounterType
-issue: ValueSet-UKCore-EncounterType
 ---
 ## UK Core Encounter Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EthnicCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-EthnicCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-EthnicCategory
-issue: ValueSet-UKCore-EthnicCategory
 ---
 ## UK Core Ethnic Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-FundingCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-FundingCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-FundingCategory
-issue: ValueSet-UKCore-FundingCategory
 ---
 ## UK Core Funding Category 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-GenomeSequencingCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-GenomeSequencingCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-GenomeSequencingCategory
-issue: ValueSet-UKCore-GenomeSequencingCategory
 ---
 ## UK Core Genome Sequencing Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-HeadCircumferenceMeasurements.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-HeadCircumferenceMeasurements.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements
-issue: ValueSet-UKCore-HeadCircumferenceMeasurements
 ---
 ## UK Core Head Circumference
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-HeartRate.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-HeartRate.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-HeartRate
-issue: ValueSet-UKCore-HeartRate
 ---
 ## UK Core Heart Rate
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ImmunizationAdministrationBodySite.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ImmunizationAdministrationBodySite.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ImmunizationAdministrationBodySite
-issue: ValueSet-UKCore-ImmunizationAdministrationBodySite
 ---
 ## UK Core Immunization Administration Body Site
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ImmunizationExplanationReason.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ImmunizationExplanationReason.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ImmunizationExplanationReason
-issue: ValueSet-UKCore-ImmunizationExplanationReason
 ---
 ## UK Core Immunization Explanation Reason
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-InspiredOxygen.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-InspiredOxygen.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-InspiredOxygen
-issue: ValueSet-UKCore-InspiredOxygen
 ---
 ## UK Core Inspired Oxygen
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-LegalStatusClassification.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-LegalStatusClassification.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-LegalStatusClassification
-issue: ValueSet-UKCore-LegalStatusClassification
 ---
 ## UK Core Legal Status Classification
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-LegalStatusContext.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-LegalStatusContext.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-LegalStatusContext
-issue: ValueSet-UKCore-LegalStatusContext
 ---
 ## UK Core Legal Status Context
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ListCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ListCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ListCode
-issue: ValueSet-UKCore-ListCode
 ---
 ## UK Core List Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ListEmptyReasonCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ListEmptyReasonCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ListEmptyReasonCode
-issue: ValueSet-UKCore-ListEmptyReasonCode
 ---
 ## UK Core List Empty Reason Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ListWarningCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ListWarningCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ListWarningCode
-issue: ValueSet-UKCore-ListWarningCode
 ---
 ## UK Core List Warning Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationAdministrationCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationAdministrationCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationAdministrationCategory
-issue: ValueSet-UKCore-MedicationAdministrationCategory
 ---
 ## UK Core Medication Administration Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationCode
-issue: ValueSet-UKCore-MedicationCode
 ---
 ## UK Core Medication Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationDosageMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationDosageMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationDosageMethod
-issue: ValueSet-UKCore-MedicationDosageMethod
 ---
 ## UK Core Medication Dosage Method
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationForm.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationForm.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationForm
-issue: ValueSet-UKCore-MedicationForm
 ---
 ## UK Core Medication Form
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationPrescribingOrganizationType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationPrescribingOrganizationType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationPrescribingOrganizationType
-issue: ValueSet-UKCore-MedicationPrescribingOrganizationType
 ---
 ## UK Core Medication Prescribing Organization Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationRequestCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationRequestCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationRequestCategory
-issue: ValueSet-UKCore-MedicationRequestCategory
 ---
 ## UK Core Medication Request Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationRequestCourseOfTherapy.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationRequestCourseOfTherapy.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationRequestCourseOfTherapy
-issue: ValueSet-UKCore-MedicationRequestCourseOfTherapy
 ---
 ## UK Core Medication Request Course Of Therapy
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationStatementCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationStatementCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationStatementCategory
-issue: ValueSet-UKCore-MedicationStatementCategory
 ---
 ## UK Core Medication Statement Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationSupplyType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationSupplyType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationSupplyType
-issue: ValueSet-UKCore-MedicationSupplyType
 ---
 ## UK Core Medication Supply Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationTradeFamily.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-MedicationTradeFamily.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-MedicationTradeFamily
-issue: ValueSet-UKCore-MedicationTradeFamily
 ---
 ## UK Core Medication Trade Family
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-NHSNumberUnavailableReason.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-NHSNumberUnavailableReason.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-NHSNumberUnavailableReason
-issue: ValueSet-UKCore-NHSNumberUnavailableReason
 ---
 ## UK Core NHS Number Unavailable Reason
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-NHSNumberVerificationStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-NHSNumberVerificationStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-NHSNumberVerificationStatus
-issue: ValueSet-UKCore-NHSNumberVerificationStatus
 ---
 ## UK Core NHS Number Verification Status
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ObservationType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ObservationType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationType
-issue: ValueSet-UKCore-ObservationType
 ---
 ## UK Core Observation Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ObservationVitalSignsType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ObservationVitalSignsType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType
-issue: ValueSet-UKCore-ObservationVitalSignsType
 ---
 ## UK Core Observation Vital Signs Type 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OrganizationType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OrganizationType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-OrganizationType
-issue: ValueSet-UKCore-OrganizationType
 ---
 ## UK Core Organization Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OtherContactSystem.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OtherContactSystem.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-OtherContactSystem
-issue: ValueSet-UKCore-OtherContactSystem
 ---
 ## UK Core Other Contact System
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OutcomeOfAttendance.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OutcomeOfAttendance.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-OutcomeOfAttendance
-issue: ValueSet-UKCore-OutcomeOfAttendance
 ---
 ## UK Core Outcome Of Attendance
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OxygenSaturation.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-OxygenSaturation.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation
-issue: ValueSet-UKCore-OxygenSaturation
 ---
 ## UK Core Oxygen Saturation
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineObservables
-issue: ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables
 ---
 ## UK Core Pathology And Laboratory Medicine Observables
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures
-issue: ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures
 ---
 ## UK Core Pathology And Laboratory Medicine Procedures
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PeriodType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PeriodType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PeriodType
-issue: ValueSet-UKCore-PeriodType
 ---
 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PersonMaritalStatusCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PersonMaritalStatusCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PersonMaritalStatusCode
-issue: ValueSet-UKCore-PersonMaritalStatusCode
 ---
 ## UK Core Person Marital Status Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PersonRelationshipType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PersonRelationshipType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PersonRelationshipType
-issue: ValueSet-UKCore-PersonRelationshipType
 ---
 ## UK Core Person Relationship Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PracticeSettingCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PracticeSettingCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PracticeSettingCode
-issue: ValueSet-UKCore-PracticeSettingCode
 ---
 ## UK Core Practice Setting Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PreferredContactMethod.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PreferredContactMethod.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PreferredContactMethod
-issue: ValueSet-UKCore-PreferredContactMethod
 ---
 ## UK Core Preferred Contact Method
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PreferredWrittenCommunicationFormat.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PreferredWrittenCommunicationFormat.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PreferredWrittenCommunicationFormat
-issue: ValueSet-UKCore-PreferredWrittenCommunicationFormat
 ---
 ## UK Core Preferred Written Communication Format
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ProcedureCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ProcedureCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode
-issue: ValueSet-UKCore-ProcedureCode
 ---
 ## UK Core Procedure Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ReasonImmunizationNotAdministered.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ReasonImmunizationNotAdministered.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ReasonImmunizationNotAdministered
-issue: ValueSet-UKCore-ReasonImmunizationNotAdministered
 ---
 ## UK Core Reason Immunization Not Administered
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-RecordingSetting.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-RecordingSetting.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-RecordingSetting
-issue: ValueSet-UKCore-RecordingSetting
 ---
 ## UK Core Recording Setting
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ReportCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ReportCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ReportCode
-issue: ValueSet-UKCore-ReportCode
 ---
 ## UK Core Report Code 
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ResidentialStatus.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ResidentialStatus.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ResidentialStatus
-issue: ValueSet-UKCore-ResidentialStatus
 ---
 ## UK Core Residential Status
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-RespirationRate.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-RespirationRate.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-RespirationRate
-issue: ValueSet-UKCore-RespirationRate
 ---
 ## UK Core Respiration Rate
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SampleCategory.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SampleCategory.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SampleCategory
-issue: ValueSet-UKCore-SampleCategory
 ---
 ## UK Core Sample Category
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SampleState.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SampleState.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SampleState
-issue: ValueSet-UKCore-SampleState
 ---
 ## UK Core Sample State
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ServiceRequestReasonCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-ServiceRequestReasonCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-ServiceRequestReasonCode
-issue: ValueSet-UKCore-ServiceRequestReasonCode
 ---
 ## UK Core Service Request Reason Code
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SourceOfAdmission.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SourceOfAdmission.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SourceOfAdmission
-issue: ValueSet-UKCore-SourceOfAdmission
 ---
 ## UK Core Source of Admission
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SourceOfServiceRequest.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SourceOfServiceRequest.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SourceOfServiceRequest
-issue: ValueSet-UKCore-SourceOfServiceRequest
 ---
 ## UK Core Source Of Service Request
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SpecimenBodySite.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SpecimenBodySite.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenBodySite
-issue: ValueSet-UKCore-SpecimenBodySite
 ---
 ## UK Core Specimen Body Site
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SpecimenType.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SpecimenType.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SpecimenType
-issue: ValueSet-UKCore-SpecimenType
 ---
 ## UK Core Specimen Type
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SubstanceOrProductAdministrationRoute.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-SubstanceOrProductAdministrationRoute.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-SubstanceOrProductAdministrationRoute
-issue: ValueSet-UKCore-SubstanceOrProductAdministrationRoute
 ---
 ## UK Core  Substance Or Product Administration Route
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-TobaccoConsumption.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-TobaccoConsumption.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-TobaccoConsumption
-issue: ValueSet-UKCore-TobaccoConsumption
 ---
 ## UK Core Tobacco Consumption
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-VaccinationProcedure.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-VaccinationProcedure.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-VaccinationProcedure
-issue: ValueSet-UKCore-VaccinationProcedure
 ---
 ## UK Core Vaccination Procedure
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-VaccinationProcedureSupplementary.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-VaccinationProcedureSupplementary.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-VaccinationProcedureSupplementary
-issue: ValueSet-UKCore-VaccinationProcedureSupplementary
 ---
 ## UK Core Vaccination Procedure Supplementary
 

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-VaccineCode.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-VaccineCode.page.md
@@ -1,6 +1,5 @@
 ---
 subject: https://fhir.hl7.org.uk/ValueSet/UKCore-VaccineCode
-issue: ValueSet-UKCore-VaccineCode
 ---
 ## UK Core Vaccine Code
 


### PR DESCRIPTION
this is a tidy up of the code where the topic and issue where both the asset id. Changing to topic will automatically pick up the relevant id for feedback link without the need to create a separate tag.  Feedback also added to examples pages
---
topic:
issue:
---