### PR TITLE
Fix/blood pressure slicing error

### DIFF
--- a/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BMI" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BMI" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsBMI" />
   <title value="UK Core Observation Vital Signs BMI" />
-  <status value="active" />
-  <date value="2024-07-11" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,10 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BMI" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
@@ -27,30 +27,16 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="39156-5" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BMI" />
       </binding>
     </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
+    <element id="Observation.code.coding:snomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -27,19 +27,11 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
+    <element id="Observation.code.coding">
       <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="85354-9" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
       <binding>
         <strength value="preferred" />
+        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
       </binding>
     </element>
@@ -132,32 +124,6 @@
     </element>
     <element id="Observation.component:SystolicBP.code.coding">
       <path value="Observation.component.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.component:SystolicBP.code.coding:loinc">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="loinc" />
-      <min value="1" />
-      <max value="1" />
-    </element>
-    <element id="Observation.component:SystolicBP.code.coding:loinc.code">
-      <path value="Observation.component.code.coding.code" />
-      <fixedCode value="8480-6" />
-    </element>
-    <element id="Observation.component:SystolicBP.code.coding:loinc.display">
-      <path value="Observation.component.code.coding.display" />
-      <fixedString value="Systolic blood pressure" />
-    </element>
-    <element id="Observation.component:SystolicBP.code.coding:snomedCT">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="snomedCT" />
-      <min value="1" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Systolic" />
@@ -193,32 +159,6 @@
     </element>
     <element id="Observation.component:DiastolicBP.code.coding">
       <path value="Observation.component.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:loinc">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="loinc" />
-      <min value="1" />
-      <max value="1" />
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:loinc.code">
-      <path value="Observation.component.code.coding.code" />
-      <fixedCode value="8462-4" />
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:loinc.display">
-      <path value="Observation.component.code.coding.display" />
-      <fixedString value="Diastolic blood pressure" />
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:snomedCT">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="snomedCT" />
-      <min value="1" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Diastolic" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BloodPressure" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BloodPressure" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsBloodPressure" />
   <title value="UK Core Observation Vital Signs Blood Pressure" />
-  <status value="active" />
-  <date value="2023-09-12" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -70,14 +70,6 @@
       <min value="1" />
       <max value="2" />
     </element>
-    <element id="Observation.component.code">
-      <path value="Observation.component.code" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of vital sign." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
-      </binding>
-    </element>
     <element id="Observation.component:SystolicBP">
       <path value="Observation.component" />
       <sliceName value="SystolicBP" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -27,11 +27,10 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
       </binding>
     </element>
@@ -76,16 +75,12 @@
       <min value="1" />
       <max value="1" />
     </element>
-    <element id="Observation.component:SystolicBP.code.coding">
-      <path value="Observation.component.code.coding" />
+    <element id="Observation.component:SystolicBP.code">
+      <path value="Observation.component.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Systolic" />
       </binding>
-    </element>
-    <element id="Observation.component:SystolicBP.code.text">
-      <path value="Observation.component.code.text" />
-      <fixedString value="Systolic blood pressure" />
     </element>
     <element id="Observation.component:SystolicBP.value[x]">
       <path value="Observation.component.value[x]" />
@@ -111,16 +106,12 @@
       <sliceName value="DiastolicBP" />
       <max value="1" />
     </element>
-    <element id="Observation.component:DiastolicBP.code.coding">
-      <path value="Observation.component.code.coding" />
+    <element id="Observation.component:DiastolicBP.code">
+      <path value="Observation.component.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Diastolic" />
       </binding>
-    </element>
-    <element id="Observation.component:DiastolicBP.code.text">
-      <path value="Observation.component.code.text" />
-      <fixedString value="Diastolic blood pressure" />
     </element>
     <element id="Observation.component:DiastolicBP.value[x]">
       <path value="Observation.component.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -78,44 +78,6 @@
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
       </binding>
     </element>
-    <element id="Observation.component.code.coding">
-      <path value="Observation.component.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.component.code.coding:loinc">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="loinc" />
-      <min value="1" />
-      <max value="1" />
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult" />
-      </binding>
-    </element>
-    <element id="Observation.component.code.coding:loinc.system">
-      <path value="Observation.component.code.coding.system" />
-      <fixedUri value="http://loinc.org" />
-    </element>
-    <element id="Observation.component.code.coding:snomedCT">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="snomedCT" />
-      <min value="1" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation for vital-signs" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
-      </binding>
-    </element>
-    <element id="Observation.component.code.coding:snomedCT.system">
-      <path value="Observation.component.code.coding.system" />
-      <fixedUri value="http://snomed.info/sct" />
-    </element>
     <element id="Observation.component:SystolicBP">
       <path value="Observation.component" />
       <sliceName value="SystolicBP" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyHeight" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyHeight" />
-  <version value="1.1.1" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsBodyHeight" />
   <title value="UK Core Observation Vital Signs Body Height" />
-  <status value="active" />
-  <date value="2025-03-11" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
@@ -27,20 +27,10 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="8302-2" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED CT UK coding system for length measurements." />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements" />
       </binding>
     </element>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
@@ -27,30 +27,16 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="8310-5" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyTemperature" />
       </binding>
     </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
+    <element id="Observation.code.coding:snomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyTemperature" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyTemperature" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsBodyTemperature" />
   <title value="UK Core Observation Vital Signs Body Temperature" />
-  <status value="active" />
-  <date value="2023-09-12" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,10 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyTemperature" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyWeight" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyWeight" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsBodyWeight" />
   <title value="UK Core Observation Vital Signs Body Weight" />
-  <status value="active" />
-  <date value="2023-09-12" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,10 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightMeasurements" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
@@ -27,22 +27,16 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightMeasurements" />
+      </binding>
+    </element>
     <element id="Observation.code.coding:loinc">
       <path value="Observation.code.coding" />
       <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="29463-7" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED CT UK coding system for weight measurements." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightMeasurements" />
-      </binding>
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
@@ -27,22 +27,16 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements" />
+      </binding>
+    </element>
     <element id="Observation.code.coding:loinc">
       <path value="Observation.code.coding" />
       <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="9843-4" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <binding>
-        <strength value="preferred" />
-        <description value="A code from the SNOMED CT UK coding system for length measurements." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements" />
-      </binding>
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-HeadCircumference" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-HeadCircumference" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsHeadCircumference" />
   <title value="UK Core Observation Vital Signs Head Circumference" />
-  <status value="active" />
-  <date value="2023-09-12" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,10 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-HeartRate" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-HeartRate" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsHeartRate" />
   <title value="UK Core Observation Vital Signs Heart Rate" />
-  <status value="active" />
-  <date value="2024-07-11" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,11 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeartRate" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
@@ -27,30 +27,17 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="8867-4" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeartRate" />
       </binding>
     </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
+    <element id="Observation.code.coding:snomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedCT" />
+      <max value="1" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-OxygenSaturation" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-OxygenSaturation" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsOxygenSaturation" />
   <title value="UK Core Observation Vital Signs Oxygen Saturation" />
-  <status value="active" />
-  <date value="2024-07-11" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,10 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
@@ -27,30 +27,16 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="2708-6" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <max value="1" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
       </binding>
     </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
+    <element id="Observation.code.coding:snomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-RespirationRate" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-RespirationRate" />
-  <version value="1.0.0" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSignsRespirationRate" />
   <title value="UK Core Observation Vital Signs Respiration Rate" />
-  <status value="active" />
-  <date value="2024-07-11" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -33,10 +33,6 @@
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-RespirationRate" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
@@ -27,29 +27,16 @@
   <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-    </element>
-    <element id="Observation.code.coding:loinc.code">
-      <path value="Observation.code.coding.code" />
-      <fixedCode value="9279-1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
+    <element id="Observation.code">
+      <path value="Observation.code" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-RespirationRate" />
       </binding>
     </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <min value="1" />
-    </element>
-    <element id="Observation.code.coding:snomedCT.code">
-      <path value="Observation.code.coding.code" />
-      <min value="1" />
+    <element id="Observation.code.coding:snomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="snomedCT" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -43,7 +43,6 @@
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/StructureDefinition/observation-bodyPosition" />
       </type>
-      <isModifier value="false" />
     </element>
     <element id="Observation.extension:bodyPosition.value[x]">
       <path value="Observation.extension.value[x]" />
@@ -60,7 +59,6 @@
         <code value="Extension" />
         <profile value="https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-RecordingSetting" />
       </type>
-      <isModifier value="false" />
     </element>
     <element id="Observation.status">
       <path value="Observation.status" />
@@ -87,43 +85,10 @@
     </element>
     <element id="Observation.code.coding">
       <path value="Observation.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Observation.code.coding:loinc">
-      <path value="Observation.code.coding" />
-      <sliceName value="loinc" />
-      <short value="A LOINC &quot;magic code&quot; describing the type of observation SHALL be present." />
-      <min value="1" />
-      <max value="1" />
-      <binding>
-        <strength value="extensible" />
-        <valueSet value="http://hl7.org/fhir/ValueSet/observation-vitalsignresult" />
-      </binding>
-    </element>
-    <element id="Observation.code.coding:loinc.system">
-      <path value="Observation.code.coding.system" />
-      <fixedUri value="http://loinc.org" />
-    </element>
-    <element id="Observation.code.coding:snomedCT">
-      <path value="Observation.code.coding" />
-      <sliceName value="snomedCT" />
-      <short value="A SNOMED CT concept describing the type of observation SHALL be present." />
-      <min value="1" />
       <binding>
         <strength value="preferred" />
-        <description value="A code from the SNOMED Clinical Terminology UK coding system describing a type of observation" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
       </binding>
-    </element>
-    <element id="Observation.code.coding:snomedCT.system">
-      <path value="Observation.code.coding.system" />
-      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.subject">
       <path value="Observation.subject" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -1,11 +1,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
-  <version value="1.1.1" />
+  <version value="0.1.1" />
   <name value="UKCoreObservationVitalSigns" />
   <title value="UK Core Observation Vital Signs" />
-  <status value="active" />
-  <date value="2024-07-23" />
+  <status value="draft" />
+  <date value="2025-11-06" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -82,9 +82,6 @@
     <element id="Observation.code">
       <path value="Observation.code" />
       <short value="The type of vital signs observation (code / type)." />
-    </element>
-    <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />


### PR DESCRIPTION
The `component.code` slicing was causing validation errors on `ObserationVitalSigns-BloodPressure`. This is due to slicing names being the same across 3 slices (loinc & snomedCT).

The fix could either be to rename each to ensure uniqueness, but loinc was added on the assumption that it had to be present due to other vitalsigns profiles within international FHIR. This profile is based off UK Core Observation and makes no such claims it conforms to HL7 International profiles. With LOINC not being used in UK, this is adding necessary complexity to the profiles with no benefit.

I propose we remove the LOINC constraints across all vitalsigns profiles. With a customer struggling with validation with this profile I'll do this first. 

Changes made
- remove LOINC slicing from `Observation-VitalSigns.code.coding` SNOMED CT slice removed and valueset moved to the element
- remove LOINC slicing from `Observation-VitalSigns.component.code.coding` SNOMED CT slice removed valueset moved to the relevant systolic and diastolic slices. Open slice reverted to base profile