### PR TITLE
[IOPS-3026] create SCT parameters

### DIFF
--- a/parameters/UKCore-Parameters-SnomedCTSettings.json
+++ b/parameters/UKCore-Parameters-SnomedCTSettings.json
@@ -1,0 +1,8 @@
+{
+  "resourceType" : "Parameters",
+  "id" : "UKCore-Parameters-SnomedCTSettings",
+  "parameter" : [{
+    "name" : "system-version",
+    "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/83821000000107"
+  }]
+}


### PR DESCRIPTION
Allows control of which SNOMED edition to use for $expand or $validate-code operations. Set  specifically to use the UK + Intl version of SCT.


`name = system-version`: tells the terminology server which version of the code system to use. This is defined as a parameter in https://build.fhir.org/valueset-operation-expand.html
`valueUri`: a URI identifying that version. States if the first uri is found, use the second uri (in this case UK +Intl)

More info from https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/SNOMED.20edition.20expectations including

SCT Edition taken from https://digital.nhs.uk/services/terminology-server/training-guides/use-the-terminology-server-in-a-community/content-release-process/appendix-g

Guidance needed in the IG to state if SCT edition differs from the above, we need to explicitly state this in the ValueSet