### PR TITLE
removed PaLM preocdure reference as no longer used in NHSE

### DIFF
--- a/fhirpkg.lock.json
+++ b/fhirpkg.lock.json
@@ -1,8 +1,7 @@
 {
-  "updated": "2025-08-14T14:55:55.4607406+01:00",
+  "updated": "2026-02-17T11:23:10.0472601+00:00",
   "dependencies": {
-    "hl7.fhir.r4.core": "4.0.1",
-    "hl7.fhir.r5.core": "5.0.0"
+    "hl7.fhir.r4.core": "4.0.1"
   },
   "missing": {}
 }

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-ServiceRequest-Lab/code.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/ProfilesandExtensions/UKCore-ServiceRequest-Lab/code.page.md
@@ -1,5 +1,5 @@
 ## <code>{{page-title}}</code>
 
-This SHOULD be from {{pagelink:Valueset-UKCore-PathologyAndLaboratoryMedicineProcedures}} if possible.
+This SHOULD be from {{pagelink:Valueset-UKCore-ProcedureCode}} where possible.
 
 ---

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.page.md
@@ -1,6 +1,0 @@
----
-subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures
----
-## UK Core Pathology And Laboratory Medicine Procedures
-
-{{page:ValueSetTemplate_new}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyBoundedCodeListObservables.page.md
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/ValueSet-UKCore-PathologyBoundedCodeListObservables.page.md
@@ -1,6 +1,0 @@
----
-subject: https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyBoundedCodeListObservables
----
-## UK Core Pathology Bounded Code List Observables
-
-{{page:ValueSetTemplate_new}}

--- a/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/toc.yaml
+++ b/guides/UK-Core-Implementation-Guide-STU3-Sequence/Home/Terminology/ValueSets/toc.yaml
@@ -146,10 +146,6 @@
   filename: ValueSet-UKCore-OxygenSaturation.page.md
 - name: ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables
   filename: ValueSet-UKCore-PathologyAndLaboratoryMedicineObservables.page.md
-- name: ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures
-  filename: ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.page.md
-- name: ValueSet-UKCore-PathologyBoundedCodeListObservables
-  filename: ValueSet-UKCore-PathologyBoundedCodeListObservables.page.md
 - name: ValueSet-UKCore-PeriodType
   filename: ValueSet-UKCore-PeriodType.page.md
 - name: ValueSet-UKCore-PersonMaritalStatusCode

--- a/structuredefinitions/UKCore-ServiceRequest-Lab.xml
+++ b/structuredefinitions/UKCore-ServiceRequest-Lab.xml
@@ -109,7 +109,7 @@
       <binding>
         <strength value="preferred" />
         <description value="A set of codes that define laboratory medicine test requests. Selected from the SNOMED CT UK coding system." />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ProcedureCode" />
       </binding>
     </element>
     <element id="ServiceRequest.orderDetail">

--- a/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
+++ b/valuesets/ValueSet-UKCore-PathologyAndLaboratoryMedicineProcedures.xml
@@ -1,0 +1,33 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="UKCore-PathologyAndLaboratoryMedicineProcedures" />
+    <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-PathologyAndLaboratoryMedicineProcedures" />
+    <version value="1.0.1" />
+    <name value="UKCorePathologyAndLaboratoryMedicineProcedures" />
+    <title value="UK Core Pathology And Laboratory Medicine Procedures" />
+    <status value="retired" />
+    <date value="2026-02-17" />
+    <publisher value="HL7 UK" />
+    <contact>
+        <name value="HL7 UK" />
+        <telecom>
+            <system value="email" />
+            <value value="ukcore@hl7.org.uk" />
+            <use value="work" />
+            <rank value="1" />
+        </telecom>
+    </contact>
+    <description value="A set of codes regarding laboratory medicine test requests and test group results intended for use by pathology services and their users. Selected from the SNOMED CT UK coding system: &#xD;&#xA;
+  - memberOf 1853561000000109 | Pathology and laboratory medicine procedure simple reference set |" />
+    <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.&lt;br$gt;This value set includes content from SNOMED CT, which is copyright &#169; 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement." />
+    <compose>
+        <include>
+            <system value="http://snomed.info/sct" />
+            <filter>
+                <property value="constraint" />
+                <op value="=" />
+                <value value="memberOf 1853561000000109" />
+            </filter>
+        </include>
+    </compose>
+</ValueSet>
+


### PR DESCRIPTION
Removed PaLM Procedure from ServiceRequest and retired the valueset as these are NHSE only and not UK wide, and NHSE are no longer needing this valueset. Note I accidently deleted this valueset in https://github.com/NHSDigital/FHIR-R4-UKCORE-STAGING-MAIN/pull/706 rather than retired, this PR amends this issue.

If the valueset is needed in the future this will be added to NHSE profiles rather than the UK Core