### PR TITLE
Fix/iops 3916 slicing

### DIFF
--- a/fhirpkg.lock.json
+++ b/fhirpkg.lock.json
@@ -1,8 +1,10 @@
 {
-  "updated": "2025-08-14T14:55:55.4607406+01:00",
+  "updated": "2026-04-07T13:17:09.3887142+01:00",
   "dependencies": {
     "hl7.fhir.r4.core": "4.0.1",
-    "hl7.fhir.r5.core": "5.0.0"
+    "hl7.fhir.uv.tools.r4": "1.1.2",
+    "hl7.terminology.r4": "7.1.0",
+    "hl7.fhir.uv.extensions.r4": "5.2.0"
   },
   "missing": {}
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "2.0.0",
   "description": "UK Core FHIR profiles and Assets",
   "author": "NHS Digital",
+  "dependencies": {
+    "hl7.fhir.r4.core": "4.0.1",
+    "hl7.fhir.uv.tools.r4": "1.1.2"
+  },
   "fhirVersions": [
     "4.0.1"
-  ],
-  "dependencies": {
-    "hl7.fhir.r4.core": "4.0.1"
-  }
+  ]
 }

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
@@ -37,14 +37,12 @@
     </element>
     <element id="Observation.code.coding:BMICodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
-      <fixedUri value="http://snomedct.info/sct" />
-    </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
+    <element id="Observation.code.coding:BMICodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
+      <min value="1" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BMI.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BMI" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BMI" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsBMI" />
   <title value="UK Core Observation Vital Signs BMI" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,15 +24,20 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bmi" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:BMICodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="BMICodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BMI" />
       </binding>
+    </element>
+    <element id="Observation.code.coding:BMICodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomedct.info/sct" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
@@ -40,20 +45,6 @@
       <type>
         <code value="Quantity" />
       </type>
-    </element>
-    <element id="Observation.value[x].value">
-      <path value="Observation.value[x].value" />
-      <min value="1" />
-    </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <min value="1" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
-      <path value="Observation.value[x].code" />
-      <min value="1" />
-      <fixedCode value="kg/m2" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -27,16 +27,6 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bp" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding">
-      <path value="Observation.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
     <element id="Observation.code.coding:BPCodeSnomedct">
       <path value="Observation.code.coding" />
       <sliceName value="BPCodeSnomedct" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -27,7 +27,7 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bp" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:BPCodeSnomedct">
+    <element id="Observation.code.coding:BPCodeSnomedCT">
       <path value="Observation.code.coding" />
       <sliceName value="BPCodeSnomedct" />
     </element>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BloodPressure" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BloodPressure" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsBloodPressure" />
   <title value="UK Core Observation Vital Signs Blood Pressure" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,19 +24,30 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bp" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding">
+      <path value="Observation.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.code.coding:BPCodeSnomedct">
+      <path value="Observation.code.coding" />
+      <sliceName value="BPCodeSnomedct" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
       </binding>
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
-      <max value="0" />
+    <element id="Observation.code.coding:BPCodeSnomedct.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.method">
       <path value="Observation.method" />
@@ -61,26 +72,38 @@
       <path value="Observation.component" />
       <slicing>
         <discriminator>
-          <type value="value" />
-          <path value="code.text" />
+          <type value="pattern" />
+          <path value="$this" />
         </discriminator>
         <rules value="closed" />
       </slicing>
-      <min value="1" />
       <max value="2" />
     </element>
     <element id="Observation.component:SystolicBP">
       <path value="Observation.component" />
       <sliceName value="SystolicBP" />
-      <min value="1" />
-      <max value="1" />
     </element>
-    <element id="Observation.component:SystolicBP.code">
-      <path value="Observation.component.code" />
+    <element id="Observation.component:SystolicBP.code.coding">
+      <path value="Observation.component.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.component:SystolicBP.code.coding:SBPCodeSnomedCT">
+      <path value="Observation.component.code.coding" />
+      <sliceName value="SBPCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Systolic" />
       </binding>
+    </element>
+    <element id="Observation.component:SystolicBP.code.coding:SBPCodeSnomedCT.system">
+      <path value="Observation.component.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.component:SystolicBP.value[x]">
       <path value="Observation.component.value[x]" />
@@ -104,14 +127,30 @@
     <element id="Observation.component:DiastolicBP">
       <path value="Observation.component" />
       <sliceName value="DiastolicBP" />
-      <max value="1" />
     </element>
-    <element id="Observation.component:DiastolicBP.code">
-      <path value="Observation.component.code" />
+    <element id="Observation.component:DiastolicBP.code.coding:diastolicbp-code-loinc">
+      <path value="Observation.component.code.coding" />
+      <sliceName value="diastolicbp-code-loinc" />
+    </element>
+    <element id="Observation.component:DiastolicBP.code.coding:diastolicbp-code-loinc.system">
+      <path value="Observation.component.code.coding.system" />
+      <fixedUri value="http://loinc.org" />
+    </element>
+    <element id="Observation.component:DiastolicBP.code.coding:diastolicbp-code-loinc.code">
+      <path value="Observation.component.code.coding.code" />
+      <fixedCode value="8462-4" />
+    </element>
+    <element id="Observation.component:DiastolicBP.code.coding:diastolic-code-snomedct">
+      <path value="Observation.component.code.coding" />
+      <sliceName value="diastolic-code-snomedct" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Diastolic" />
       </binding>
+    </element>
+    <element id="Observation.component:DiastolicBP.code.coding:diastolic-code-snomedct.system">
+      <path value="Observation.component.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.component:DiastolicBP.value[x]">
       <path value="Observation.component.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -29,13 +29,13 @@
   <differential>
     <element id="Observation.code.coding:BPCodeSnomedCT">
       <path value="Observation.code.coding" />
-      <sliceName value="BPCodeSnomedct" />
+      <sliceName value="BPCodeSnomedCT" />
     </element>
-    <element id="Observation.code.coding:BPCodeSnomedct.system">
+    <element id="Observation.code.coding:BPCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.code.coding:BPCodeSnomedct.code">
+    <element id="Observation.code.coding:BPCodeSnomedCT.code">
       <path value="Observation.code.coding.code" />
       <binding>
         <strength value="preferred" />
@@ -75,65 +75,47 @@
     </element>
     <element id="Observation.component:SystolicBP.code.coding:SBPCodeSnomedCT.system">
       <path value="Observation.component.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.component:SystolicBP.value[x]">
-      <path value="Observation.component.value[x]" />
+    <element id="Observation.component:SystolicBP.code.coding:SBPCodeSnomedCT.code">
+      <path value="Observation.component.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
     </element>
-    <element id="Observation.component:SystolicBP.value[x].unit">
+    <element id="Observation.component:SystolicBP.value[x]:valueQuantity">
+      <path value="Observation.component.value[x]" />
+      <sliceName value="valueQuantity" />
+      <min value="1" />
+    </element>
+    <element id="Observation.component:SystolicBP.value[x]:valueQuantity.unit">
       <path value="Observation.component.value[x].unit" />
       <fixedString value="millimeter of mercury" />
-    </element>
-    <element id="Observation.component:SystolicBP.value[x].system">
-      <path value="Observation.component.value[x].system" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.component:SystolicBP.value[x].code">
-      <path value="Observation.component.value[x].code" />
-      <fixedCode value="mm[Hg]" />
     </element>
     <element id="Observation.component:DiastolicBP">
       <path value="Observation.component" />
       <sliceName value="DiastolicBP" />
     </element>
-    <element id="Observation.component:DiastolicBP.code.coding:diastolicbp-code-loinc">
+    <element id="Observation.component:DiastolicBP.code.coding:DBPCodeSnomedCT">
       <path value="Observation.component.code.coding" />
-      <sliceName value="diastolicbp-code-loinc" />
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:diastolicbp-code-loinc.system">
-      <path value="Observation.component.code.coding.system" />
-      <fixedUri value="http://loinc.org" />
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:diastolicbp-code-loinc.code">
-      <path value="Observation.component.code.coding.code" />
-      <fixedCode value="8462-4" />
-    </element>
-    <element id="Observation.component:DiastolicBP.code.coding:diastolic-code-snomedct">
-      <path value="Observation.component.code.coding" />
-      <sliceName value="diastolic-code-snomedct" />
+      <sliceName value="DBPCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure-Diastolic" />
       </binding>
     </element>
-    <element id="Observation.component:DiastolicBP.code.coding:diastolic-code-snomedct.system">
+    <element id="Observation.component:DiastolicBP.code.coding:DBPCodeSnomedCT.system">
       <path value="Observation.component.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.component:DiastolicBP.value[x]">
-      <path value="Observation.component.value[x]" />
+    <element id="Observation.component:DiastolicBP.code.coding:DBPCodeSnomedCT.code">
+      <path value="Observation.component.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
     </element>
     <element id="Observation.component:DiastolicBP.value[x]:valueQuantity">
       <path value="Observation.component.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.component:DiastolicBP.value[x]:valueQuantity.unit">
       <path value="Observation.component.value[x].unit" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -82,6 +82,12 @@
       <path value="Observation.component.code.coding.code" />
       <min value="1" />
     </element>
+    <element id="Observation.component:SystolicBP.value[x]">
+      <path value="Observation.component.value[x]" />
+      <type>
+        <code value="Quantity" />
+      </type>
+    </element>
     <element id="Observation.component:SystolicBP.value[x]:valueQuantity">
       <path value="Observation.component.value[x]" />
       <sliceName value="valueQuantity" />
@@ -112,10 +118,15 @@
       <path value="Observation.component.code.coding.code" />
       <min value="1" />
     </element>
+    <element id="Observation.component:DiastolicBP.value[x]">
+      <path value="Observation.component.value[x]" />
+      <type>
+        <code value="Quantity" />
+      </type>
+    </element>
     <element id="Observation.component:DiastolicBP.value[x]:valueQuantity">
       <path value="Observation.component.value[x]" />
       <sliceName value="valueQuantity" />
-      <min value="1" />
     </element>
     <element id="Observation.component:DiastolicBP.value[x]:valueQuantity.unit">
       <path value="Observation.component.value[x].unit" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -61,30 +61,9 @@
         <targetProfile value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Device-BloodPressure" />
       </type>
     </element>
-    <element id="Observation.component">
-      <path value="Observation.component" />
-      <slicing>
-        <discriminator>
-          <type value="pattern" />
-          <path value="$this" />
-        </discriminator>
-        <rules value="closed" />
-      </slicing>
-      <max value="2" />
-    </element>
     <element id="Observation.component:SystolicBP">
       <path value="Observation.component" />
       <sliceName value="SystolicBP" />
-    </element>
-    <element id="Observation.component:SystolicBP.code.coding">
-      <path value="Observation.component.code.coding" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="system" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
     </element>
     <element id="Observation.component:SystolicBP.code.coding:SBPCodeSnomedCT">
       <path value="Observation.component.code.coding" />
@@ -152,17 +131,13 @@
         <code value="Quantity" />
       </type>
     </element>
-    <element id="Observation.component:DiastolicBP.value[x].unit">
+    <element id="Observation.component:DiastolicBP.value[x]:valueQuantity">
+      <path value="Observation.component.value[x]" />
+      <sliceName value="valueQuantity" />
+    </element>
+    <element id="Observation.component:DiastolicBP.value[x]:valueQuantity.unit">
       <path value="Observation.component.value[x].unit" />
       <fixedString value="millimeter of mercury" />
-    </element>
-    <element id="Observation.component:DiastolicBP.value[x].system">
-      <path value="Observation.component.value[x].system" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.component:DiastolicBP.value[x].code">
-      <path value="Observation.component.value[x].code" />
-      <fixedCode value="mm[Hg]" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BloodPressure.xml
@@ -40,14 +40,17 @@
     <element id="Observation.code.coding:BPCodeSnomedct">
       <path value="Observation.code.coding" />
       <sliceName value="BPCodeSnomedct" />
-      <binding>
-        <strength value="preferred" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
-      </binding>
     </element>
     <element id="Observation.code.coding:BPCodeSnomedct.system">
       <path value="Observation.code.coding.system" />
       <fixedUri value="http://snomed.info/sct" />
+    </element>
+    <element id="Observation.code.coding:BPCodeSnomedct.code">
+      <path value="Observation.code.coding.code" />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
+      </binding>
     </element>
     <element id="Observation.method">
       <path value="Observation.method" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyHeight" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyHeight" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsBodyHeight" />
   <title value="UK Core Observation Vital Signs Body Height" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,14 +24,15 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bodyheight" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:BodyHeightSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="BodyHeightSnomedCT" />
       <binding>
         <strength value="preferred" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements" />
+        <description value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements" />
       </binding>
     </element>
     <element id="Observation.value[x]">
@@ -40,11 +41,14 @@
       <type>
         <code value="Quantity" />
       </type>
-      <binding>
-        <strength value="required" />
-        <description value="Include codes from http://unitsofmeasure.org where canonical = m" />
-        <valueSet value="http://hl7.org/fhir/ValueSet/all-distance-units" />
-      </binding>
+    </element>
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+    </element>
+    <element id="Observation.value[x]:valueQuantity.code">
+      <path value="Observation.value[x].code" />
+      <fixedCode value="cm" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyHeight.xml
@@ -27,24 +27,27 @@
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bodyheight" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code.coding:BodyHeightSnomedCT">
+    <element id="Observation.code.coding:BodyHeightCodeSnomedCT">
       <path value="Observation.code.coding" />
-      <sliceName value="BodyHeightSnomedCT" />
+      <sliceName value="BodyHeightCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
-        <description value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyHeightMeasurements" />
       </binding>
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:BodyHeightCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
+    <element id="Observation.code.coding:BodyHeightCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyTemperature" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyTemperature" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsBodyTemperature" />
   <title value="UK Core Observation Vital Signs Body Temperature" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,15 +24,20 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bodytemp" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:BodyTempCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="BodyTempCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyTemperature" />
       </binding>
+    </element>
+    <element id="Observation.code.coding:BodyTempCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
@@ -41,16 +46,15 @@
         <code value="Quantity" />
       </type>
     </element>
-    <element id="Observation.value[x].unit">
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+    </element>
+    <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />
-      <min value="1" />
       <fixedString value="degree Celsius" />
     </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
+    <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />
       <fixedCode value="Cel" />
     </element>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyTemperature.xml
@@ -37,18 +37,17 @@
     </element>
     <element id="Observation.code.coding:BodyTempCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:BodyTempCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
     </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-BodyWeight" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-BodyWeight" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsBodyWeight" />
   <title value="UK Core Observation Vital Signs Body Weight" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,15 +24,20 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/bodyweight" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:BodyWeightCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="BodyWeightCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightMeasurements" />
       </binding>
+    </element>
+    <element id="Observation.code.coding:BodyWeightCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
@@ -37,30 +37,17 @@
     </element>
     <element id="Observation.code.coding:BodyWeightCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:BodyWeightCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
-    </element>
-    <element id="Observation.value[x].unit">
-      <path value="Observation.value[x].unit" />
-      <fixedString value="kilogram" />
-    </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
-      <path value="Observation.value[x].code" />
-      <fixedCode value="kg" />
     </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-BodyWeight.xml
@@ -58,5 +58,16 @@
       <path value="Observation.value[x].code" />
       <fixedCode value="kg" />
     </element>
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+    </element>
+    <element id="Observation.value[x]:valueQuantity.code">
+      <path value="Observation.value[x].code" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightUCUM" />
+      </binding>
+    </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
@@ -35,16 +35,18 @@
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements" />
       </binding>
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:HeadCircumCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
+    </element>
+    <element id="Observation.code.coding:HeadCircumCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeadCircumference.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-HeadCircumference" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-HeadCircumference" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsHeadCircumference" />
   <title value="UK Core Observation Vital Signs Head Circumference" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,11 +24,12 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/headcircum" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:HeadCircumCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="HeadCircumCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeadCircumferenceMeasurements" />
@@ -41,15 +42,15 @@
         <code value="Quantity" />
       </type>
     </element>
-    <element id="Observation.value[x].unit">
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+    </element>
+    <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />
       <fixedString value="centimeter" />
     </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
+    <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />
       <fixedCode value="cm" />
     </element>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-HeartRate" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-HeartRate" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsHeartRate" />
   <title value="UK Core Observation Vital Signs Heart Rate" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,15 +24,20 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/heartrate" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:HeartRateCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="HeartRateCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-HeartRate" />
       </binding>
+    </element>
+    <element id="Observation.code.coding:HeartRateCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
@@ -41,20 +46,13 @@
         <code value="Quantity" />
       </type>
     </element>
-    <element id="Observation.value[x].unit">
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+    </element>
+    <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />
-      <min value="1" />
       <fixedString value="per minute" />
-    </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <min value="1" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
-      <path value="Observation.value[x].code" />
-      <min value="1" />
-      <fixedCode value="/min" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-HeartRate.xml
@@ -37,18 +37,17 @@
     </element>
     <element id="Observation.code.coding:HeartRateCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:HeartRateCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
     </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-OxygenSaturation" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-OxygenSaturation" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsOxygenSaturation" />
   <title value="UK Core Observation Vital Signs Oxygen Saturation" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,15 +24,20 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/oxygensat" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:OxygenSatCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="OxygenSatCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
-        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
+        <description value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
       </binding>
+    </element>
+    <element id="Observation.code.coding:OxygenSatCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
@@ -41,24 +46,13 @@
         <code value="Quantity" />
       </type>
     </element>
-    <element id="Observation.value[x].value">
-      <path value="Observation.value[x].value" />
-      <min value="1" />
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
     </element>
-    <element id="Observation.value[x].unit">
+    <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />
-      <min value="1" />
       <fixedString value="percent" />
-    </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <min value="1" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
-      <path value="Observation.value[x].code" />
-      <min value="1" />
-      <fixedCode value="%" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-OxygenSaturation.xml
@@ -32,23 +32,22 @@
       <sliceName value="OxygenSatCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
-        <description value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
+        <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-OxygenSaturation" />
       </binding>
     </element>
     <element id="Observation.code.coding:OxygenSatCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:OxygenSatCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
     </element>
     <element id="Observation.value[x]:valueQuantity">
       <path value="Observation.value[x]" />
       <sliceName value="valueQuantity" />
+      <min value="1" />
     </element>
     <element id="Observation.value[x]:valueQuantity.unit">
       <path value="Observation.value[x].unit" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
@@ -37,14 +37,21 @@
     </element>
     <element id="Observation.code.coding:RespRateCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.value[x]">
-      <path value="Observation.value[x]" />
+    <element id="Observation.code.coding:RespRateCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
       <min value="1" />
-      <type>
-        <code value="Quantity" />
-      </type>
+    </element>
+    <element id="Observation.value[x]:valueQuantity">
+      <path value="Observation.value[x]" />
+      <sliceName value="valueQuantity" />
+      <min value="1" />
+    </element>
+    <element id="Observation.value[x]:valueQuantity.unit">
+      <path value="Observation.value[x].unit" />
+      <fixedString value="per minute" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns-RespirationRate.xml
@@ -2,11 +2,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns-RespirationRate" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns-RespirationRate" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSignsRespirationRate" />
   <title value="UK Core Observation Vital Signs Respiration Rate" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -24,15 +24,20 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/resprate" />
   <derivation value="constraint" />
   <differential>
-    <element id="Observation.code">
-      <path value="Observation.code" />
+    <element id="Observation.code.coding:RespRateCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="RespRateCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-RespirationRate" />
       </binding>
+    </element>
+    <element id="Observation.code.coding:RespRateCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
     </element>
     <element id="Observation.value[x]">
       <path value="Observation.value[x]" />
@@ -40,25 +45,6 @@
       <type>
         <code value="Quantity" />
       </type>
-    </element>
-    <element id="Observation.value[x].value">
-      <path value="Observation.value[x].value" />
-      <min value="1" />
-    </element>
-    <element id="Observation.value[x].unit">
-      <path value="Observation.value[x].unit" />
-      <min value="1" />
-      <fixedString value="per minute" />
-    </element>
-    <element id="Observation.value[x].system">
-      <path value="Observation.value[x].system" />
-      <min value="1" />
-      <fixedUri value="http://unitsofmeasure.org" />
-    </element>
-    <element id="Observation.value[x].code">
-      <path value="Observation.value[x].code" />
-      <min value="1" />
-      <fixedCode value="/min" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -82,6 +82,7 @@
         </discriminator>
         <rules value="open" />
       </slicing>
+      <short value="Code defined by a terminology system." />
     </element>
     <element id="Observation.code.coding:VSCodeSnomedCT">
       <path value="Observation.code.coding" />

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -78,7 +78,7 @@
       <slicing>
         <discriminator>
           <type value="value" />
-          <path value="pattern[x]" />
+          <path value="system" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -67,20 +67,11 @@
     </element>
     <element id="Observation.category">
       <path value="Observation.category" />
-      <short value="A category of `vital-signs` SHALL be present." />
       <max value="1" />
     </element>
     <element id="Observation.category.coding.system">
       <path value="Observation.category.coding.system" />
       <fixedUri value="http://terminology.hl7.org/CodeSystem/observation-category" />
-    </element>
-    <element id="Observation.category.coding.code">
-      <path value="Observation.category.coding.code" />
-      <fixedCode value="vital-signs" />
-    </element>
-    <element id="Observation.code">
-      <path value="Observation.code" />
-      <short value="The type of vital signs observation (code / type)." />
     </element>
     <element id="Observation.code.coding">
       <path value="Observation.code.coding" />
@@ -102,15 +93,12 @@
     </element>
     <element id="Observation.code.coding:VSCodeSnomedCT.system">
       <path value="Observation.code.coding.system" />
+      <min value="1" />
       <fixedUri value="http://snomed.info/sct" />
     </element>
-    <element id="Observation.subject">
-      <path value="Observation.subject" />
-      <short value="Who or what the observation relates to SHALL be present." />
-    </element>
-    <element id="Observation.effective[x]">
-      <path value="Observation.effective[x]" />
-      <short value="A clinically relevant time / time-period for observation SHALL be present." />
+    <element id="Observation.code.coding:VSCodeSnomedCT.code">
+      <path value="Observation.code.coding.code" />
+      <min value="1" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -1,11 +1,11 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="UKCore-Observation-VitalSigns" />
   <url value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation-VitalSigns" />
-  <version value="0.1.1" />
+  <version value="0.2.0" />
   <name value="UKCoreObservationVitalSigns" />
   <title value="UK Core Observation Vital Signs" />
   <status value="draft" />
-  <date value="2025-11-06" />
+  <date value="2026-04-07" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />
@@ -23,7 +23,7 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Observation" />
-  <baseDefinition value="https://fhir.hl7.org.uk/StructureDefinition/UKCore-Observation" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/vitalsigns" />
   <derivation value="constraint" />
   <differential>
     <element id="Observation">
@@ -68,7 +68,6 @@
     <element id="Observation.category">
       <path value="Observation.category" />
       <short value="A category of `vital-signs` SHALL be present." />
-      <min value="1" />
       <max value="1" />
     </element>
     <element id="Observation.category.coding.system">
@@ -82,20 +81,36 @@
     <element id="Observation.code">
       <path value="Observation.code" />
       <short value="The type of vital signs observation (code / type)." />
+    </element>
+    <element id="Observation.code.coding">
+      <path value="Observation.code.coding" />
+      <slicing>
+        <discriminator>
+          <type value="pattern" />
+          <path value="$this" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.code.coding:VSCodeSnomedCT">
+      <path value="Observation.code.coding" />
+      <sliceName value="VSCodeSnomedCT" />
       <binding>
         <strength value="preferred" />
         <valueSet value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
       </binding>
     </element>
+    <element id="Observation.code.coding:VSCodeSnomedCT.system">
+      <path value="Observation.code.coding.system" />
+      <fixedUri value="http://snomed.info/sct" />
+    </element>
     <element id="Observation.subject">
       <path value="Observation.subject" />
       <short value="Who or what the observation relates to SHALL be present." />
-      <min value="1" />
     </element>
     <element id="Observation.effective[x]">
       <path value="Observation.effective[x]" />
       <short value="A clinically relevant time / time-period for observation SHALL be present." />
-      <min value="1" />
     </element>
   </differential>
 </StructureDefinition>

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -77,8 +77,8 @@
       <path value="Observation.code.coding" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
-          <path value="$this" />
+          <type value="value" />
+          <path value="pattern[x]" />
         </discriminator>
         <rules value="open" />
       </slicing>

--- a/structuredefinitions/UKCore-Observation-VitalSigns.xml
+++ b/structuredefinitions/UKCore-Observation-VitalSigns.xml
@@ -82,7 +82,6 @@
         </discriminator>
         <rules value="open" />
       </slicing>
-      <short value="Code defined by a terminology system." />
     </element>
     <element id="Observation.code.coding:VSCodeSnomedCT">
       <path value="Observation.code.coding" />

--- a/valuesets/ValueSet-UKCore-BodyWeightMeasurements - Copy.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightMeasurements - Copy.xml
@@ -20,12 +20,12 @@
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>
-      <system value="http://unitsofmeasure.org"/>
+      <system value="http://unitsofmeasure.org" />
       <concept>
-        <code value="kg"/>
+        <code value="kg" />
       </concept>
       <concept>
-        <code value="g"/>
+        <code value="g" />
       </concept>
     </include>
   </compose>

--- a/valuesets/ValueSet-UKCore-BodyWeightMeasurements - Copy.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightMeasurements - Copy.xml
@@ -1,0 +1,32 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="UKCore-BodyWeightMeasurements" />
+  <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightUCUM" />
+  <version value="0.1.0" />
+  <name value="UKCoreBodyWeightUCUM" />
+  <title value="UK Core UCUM" />
+  <status value="draft" />
+  <date value="2026-04-07" />
+  <publisher value="HL7 UK" />
+  <contact>
+    <name value="HL7 UK" />
+    <telecom>
+      <system value="email" />
+      <value value="ukcore@hl7.org.uk" />
+      <use value="work" />
+      <rank value="1" />
+    </telecom>
+  </contact>
+  <description value="UCUM metric units for recording Body Weight. This is based on https://hl7.org/fhir/R4/valueset-ucum-bodyweight.html" />
+  <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
+  <compose>
+    <include>
+      <system value="http://unitsofmeasure.org"/>
+      <concept>
+        <code value="kg"/>
+      </concept>
+      <concept>
+        <code value="g"/>
+      </concept>
+    </include>
+  </compose>
+</ValueSet>

--- a/valuesets/ValueSet-UKCore-BodyWeightUCUM.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightUCUM.xml
@@ -3,7 +3,7 @@
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightUCUM" />
   <version value="0.1.0" />
   <name value="UKCoreBodyWeightUCUM" />
-  <title value="UK Core UCUM" />
+  <title value="UK Core Body Weight UCUM" />
   <status value="draft" />
   <date value="2026-04-07" />
   <publisher value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-BodyWeightUCUM.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightUCUM.xml
@@ -20,12 +20,12 @@
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>
-      <system value="http://unitsofmeasure.org"/>
+      <system value="http://unitsofmeasure.org" />
       <concept>
-        <code value="kg"/>
+        <code value="kg" />
       </concept>
       <concept>
-        <code value="g"/>
+        <code value="g" />
       </concept>
     </include>
   </compose>

--- a/valuesets/ValueSet-UKCore-BodyWeightUCUM.xml
+++ b/valuesets/ValueSet-UKCore-BodyWeightUCUM.xml
@@ -1,5 +1,5 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-  <id value="UKCore-BodyWeightMeasurements" />
+  <id value="UKCore-BodyWeightUCUM" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BodyWeightUCUM" />
   <version value="0.1.0" />
   <name value="UKCoreBodyWeightUCUM" />
@@ -20,12 +20,12 @@
   <copyright value="Copyright &#169; 2021+ HL7 UK Licensed under the Apache License, Version 2.0 (the &quot;License&quot;); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7&#174; FHIR&#174; standard Copyright &#169; 2011+ HL7 The HL7&#174; FHIR&#174; standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html." />
   <compose>
     <include>
-      <system value="http://unitsofmeasure.org" />
+      <system value="http://unitsofmeasure.org"/>
       <concept>
-        <code value="kg" />
+        <code value="kg"/>
       </concept>
       <concept>
-        <code value="g" />
+        <code value="g"/>
       </concept>
     </include>
   </compose>


### PR DESCRIPTION
re-added loinc codes by setting basedefiniton to relevant hl7 profiles. This ensures all vitalsigns profiles align and conform to HL7 international. Ensure SNOMED CT ValueSets sliced correctly. Ensured only metric values allowed in valueQuantity where neccesary