### PR TITLE
Fix/iops 2946 remove refs to invasive blood pressure

### DIFF
--- a/valuesets/ValueSet-UKCore-BloodPressure.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure.xml
@@ -21,7 +21,6 @@
 &#13; - 75367002 | Blood pressure (observable entity) |
 &#13; - 386534000 | Arterial blood pressure (observable entity) |
 &#13; - 87179004 | Arterial pulse pressure (observable entity) |
-&#13; - 386533006 | Invasive blood pressure (observable entity) |
 &#13; - 386532001 | Invasive arterial pressure (observable entity) |
 &#13; - 723237002 | Non-invasive blood pressure (observable entity) |
 &#13; - 251076008 | Non-invasive arterial pressure (observable entity) |
@@ -104,11 +103,6 @@
       <system value="http://snomed.info/sct" />
       <code value="386532001" />
       <display value="Invasive arterial pressure" />
-    </contains>
-    <contains>
-      <system value="http://snomed.info/sct" />
-      <code value="386533006" />
-      <display value="Invasive blood pressure" />
     </contains>
     <contains>
       <system value="http://snomed.info/sct" />

--- a/valuesets/ValueSet-UKCore-BloodPressure.xml
+++ b/valuesets/ValueSet-UKCore-BloodPressure.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-BloodPressure" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-BloodPressure" />
-  <version value="0.2.0" />
+  <version value="0.2.1" />
   <name value="UKCoreBloodPressure" />
   <title value="UK Core Blood Pressure" />
   <status value="draft" />
-  <date value="2025-03-31" />
+  <date value="2026-04-29" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-ObservationVitalSignsType.xml
+++ b/valuesets/ValueSet-UKCore-ObservationVitalSignsType.xml
@@ -1,11 +1,11 @@
 <ValueSet xmlns="http://hl7.org/fhir">
   <id value="UKCore-ObservationVitalSignsType" />
   <url value="https://fhir.hl7.org.uk/ValueSet/UKCore-ObservationVitalSignsType" />
-  <version value="1.1.0" />
+  <version value="1.1.1" />
   <name value="UKCoreObservationVitalSignsType" />
   <title value="UK Core Observation Vital Signs Type" />
   <status value="active" />
-  <date value="2024-02-11" />
+  <date value="2026-04-29" />
   <publisher value="HL7 UK" />
   <contact>
     <name value="HL7 UK" />

--- a/valuesets/ValueSet-UKCore-ObservationVitalSignsType.xml
+++ b/valuesets/ValueSet-UKCore-ObservationVitalSignsType.xml
@@ -455,11 +455,6 @@
       </contains>
       <contains>
         <system value="http://snomed.info/sct" />
-        <code value="386533006" />
-        <display value="Invasive blood pressure" />
-      </contains>
-      <contains>
-        <system value="http://snomed.info/sct" />
         <code value="37476000" />
         <display value="Jugular venous pressure" />
       </contains>


### PR DESCRIPTION
Remove references to 'Invasive blood pressure'.
Looked at https://github.com/search?q=repo%3ANHSDigital%2FFHIR-R4-UKCORE-STAGING-MAIN+invasive&type=code for instances of this but excluded references from guides and 'Invasive blood pressure monitor'.